### PR TITLE
Add automated deployment for website updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p 222 cse125.ucsd.edu >> ~/.ssh/known_hosts
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Deploy via rsync
+        run: |
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -p 222 -o StrictHostKeyChecking=yes" \
+            website/ \
+            dkatulevskiy@cse125.ucsd.edu:/var/www/html/class/cse125/www/2026/cse125g2/

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Group 2 (yay!) (via automation)</h1>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to deploy `website/**` changes automatically when `main` is updated.
- Configure SSH-based deployment with a stored secret key, host key scanning, and `rsync --delete` to mirror the `website/` directory to the target server.
- Add a simple `website/index.html` update to reflect the automated deployment path.

## Testing
- Not run (workflow/configuration change only).
- Verified the workflow triggers on pushes to `main` that modify files under `website/`.
- Verified the deploy step uses `rsync` over SSH on port `222` with strict host key checking enabled.