### PR TITLE
Add automated website deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Deploy via rsync
         run: |
-          rsync -avz --delete \
+          rsync -rltz --delete \
             -e "ssh -i ~/.ssh/deploy_key -p 222 -o StrictHostKeyChecking=yes" \
             website/ \
             dkatulevskiy@cse125.ucsd.edu:/var/www/html/class/cse125/www/2026/cse125g2/


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to deploy the `website/` directory automatically when changes land on `main`.
- Configure SSH-based deployment to the course web server using the `DEPLOY_SSH_KEY` secret and port `222`.
- Use `rsync --delete` to keep the remote site in sync with the repository contents.
- Add a simple `website/index.html` landing page for the deployed site.

## Testing
- Not run (workflow and static HTML changes only).
- Verified the workflow definition includes checkout, SSH key setup, host key scanning, and `rsync` deployment steps.
- Verified the workflow triggers on pushes to `main` that touch files under `website/**`.