### PR TITLE
fix: add .idea/misc.xml so CLion recognizes CMake project on fresh clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ compile_commands.json
 
 # IDE / editor
 .idea/*
+!.idea/misc.xml
+!.idea/vcs.xml
 !.idea/workspace.xml
 *.user
 *.suo

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -75,7 +75,14 @@ git update-index --skip-worktree .idea/workspace.xml
 Write-Host ""
 Write-Host "==> All prerequisites installed." -ForegroundColor Green
 Write-Host ""
-Write-Host "Build commands (run inside 'Developer PowerShell for VS 2022'):" -ForegroundColor Yellow
+Write-Host "IMPORTANT: Close and reopen CLion / your terminal so PATH changes take effect." -ForegroundColor Yellow
+Write-Host ""
+Write-Host "CLion setup:" -ForegroundColor Cyan
+Write-Host "  1. Open CLion and select File > Open > this repo root"
+Write-Host "  2. CMake presets (debug-win, release, relwithdebinfo) appear automatically"
+Write-Host "  3. Select a preset from the dropdown, then press the play button"
+Write-Host ""
+Write-Host "Command-line build (run inside 'Developer PowerShell for VS 2022'):" -ForegroundColor Cyan
 Write-Host "  cmake --preset debug-win && cmake --build --preset debug-win"
 Write-Host "  cmake --preset release   && cmake --build --preset release"
 Write-Host ""


### PR DESCRIPTION
CLion needs misc.xml with a CMakeWorkspace component to initialize CMake preset detection. Without it, workspace.xml's CMakeSettings are ignored and no build profiles appear.

- Add .idea/misc.xml (CMakeWorkspace marker)
- Add .idea/vcs.xml (Git root mapping)
- Track both in .gitignore alongside workspace.xml
- Add CLion setup instructions and PATH restart reminder to setup script