### PR TITLE
fix(ci): prevent CMake generator mismatch on Windows release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/${{ matrix.preset }}/_deps
-          key: deps-${{ runner.os }}-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: deps-${{ runner.os }}-${{ matrix.preset }}-
+          key: deps-v2-${{ runner.os }}-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: deps-v2-${{ runner.os }}-${{ matrix.preset }}-
+
+      # Remove stale *-build and *-subbuild dirs after cache restore.
+      # Those dirs contain CMakeCache.txt files that record the generator
+      # used in the run that created the cache — if it differs from the
+      # current run's generator, CMake fails with "generator does not match".
+      # Source dirs (*-src) are left intact so FetchContent doesn't re-download.
+      # sccache handles compilation caching, so re-building from source is fast.
+      - name: Purge stale dep build dirs
+        shell: bash
+        run: |
+          find build/${{ matrix.preset }}/_deps -maxdepth 1 -type d \
+            \( -name '*-build' -o -name '*-subbuild' \) \
+            -exec rm -rf {} + 2>/dev/null || true
 
       - name: Configure
         shell: bash
@@ -151,8 +164,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/debug/_deps
-          key: deps-Linux-debug-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: deps-Linux-debug-
+          key: deps-v2-Linux-debug-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: deps-v2-Linux-debug-
+
+      - name: Purge stale dep build dirs
+        shell: bash
+        run: |
+          find build/debug/_deps -maxdepth 1 -type d \
+            \( -name '*-build' -o -name '*-subbuild' \) \
+            -exec rm -rf {} + 2>/dev/null || true
 
       - name: Configure
         env:
@@ -257,8 +277,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build/${{ matrix.preset }}/_deps
-          key: deps-${{ runner.os }}-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt') }}
-          restore-keys: deps-${{ runner.os }}-${{ matrix.preset }}-
+          key: deps-v2-${{ runner.os }}-${{ matrix.preset }}-${{ hashFiles('CMakeLists.txt') }}
+          restore-keys: deps-v2-${{ runner.os }}-${{ matrix.preset }}-
+
+      # Remove stale *-build and *-subbuild dirs after cache restore.
+      # Those dirs contain CMakeCache.txt files that record the generator
+      # used in the run that created the cache — if it differs from the
+      # current run's generator, CMake fails with "generator does not match".
+      # Source dirs (*-src) are left intact so FetchContent doesn't re-download.
+      # sccache handles compilation caching, so re-building from source is fast.
+      - name: Purge stale dep build dirs
+        shell: bash
+        run: |
+          find build/${{ matrix.preset }}/_deps -maxdepth 1 -type d \
+            \( -name '*-build' -o -name '*-subbuild' \) \
+            -exec rm -rf {} + 2>/dev/null || true
 
       - name: Configure
         shell: bash


### PR DESCRIPTION
## Problem

The Windows `Release Build` CI job was failing with:

```
CMake Error: Error: generator : does not match the generator used previously
```

`FetchContent` dependency build dirs (`*-build`, `*-subbuild`) contain a `CMakeCache.txt` that records which CMake generator compiled them. When those directories are restored from cache in a run that uses a different generator (e.g. Visual Studio on one run, Ninja on another), CMake refuses to continue.

## Fix

Applied consistently to all three jobs that cache `_deps` — `build`, `tidy`, and `release-build`:

1. **Bump cache key prefix** `deps-` → `deps-v2-` — evicts all stale cache entries that contain generator-locked build dirs.
2. **Add a purge step** after cache restore that deletes `*-build` and `*-subbuild` dirs while leaving `*-src` dirs intact. FetchContent skips re-downloading (sources already present), but always regenerates the build dirs fresh for the current runner's generator. sccache absorbs the recompilation cost.

## Test plan

- [x] `Release Build (Windows)` passes on the CI run triggered by this PR being merged to main
- [x] `Build (Windows)` passes on this PR's CI run
- [x] Linux and macOS builds unaffected