### PR TITLE
fix(clion): restore cmake.xml so build toolbar works on fresh clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ CTestTestfile.cmake
 compile_commands.json
 
 # IDE / editor
-.idea/
+.idea/*
+!.idea/cmake.xml
 .vscode/
 .vs/
 *.user

--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CMakeSharedSettings">
+    <configurations>
+      <!-- Linux / macOS — uses system clang (set by the preset) -->
+      <configuration PROFILE_NAME="debug"   ENABLED="true"  CONFIG_NAME="debug"   />
+      <configuration PROFILE_NAME="release" ENABLED="false" CONFIG_NAME="release" />
+
+      <!-- Windows — requires a CLion toolchain named exactly "Visual Studio" -->
+      <!-- Create it once in Settings > Build > Toolchains > + Visual Studio  -->
+      <configuration PROFILE_NAME="debug-win"          ENABLED="false" CONFIG_NAME="debug-win"          TOOLCHAIN_NAME="Visual Studio" />
+      <configuration PROFILE_NAME="release-win"        ENABLED="false" CONFIG_NAME="release-win"        TOOLCHAIN_NAME="Visual Studio" />
+      <configuration PROFILE_NAME="relwithdebinfo-win" ENABLED="false" CONFIG_NAME="relwithdebinfo-win" TOOLCHAIN_NAME="Visual Studio" />
+    </configurations>
+  </component>
+</project>


### PR DESCRIPTION
## Problem

After removing `.idea/` entirely, CLion opens the project with no configured CMake profiles. The build toolbar goes blank and there's no "Reload CMake" button because CLion has nothing to activate.

## Fix

Bring back **only** `.idea/cmake.xml` — the one file CLion needs to know which presets to load. Everything else in `.idea/` (workspace.xml, misc.xml, vcs.xml) remains gitignored, so CLion's local UI state never shows up as uncommitted changes.

`cmake.xml` maps each preset from `CMakePresets.json` to a CLion profile:

| Profile | Preset | Platform |
|---|---|---|
| `debug` ✅ enabled | `debug` | Linux / macOS |
| `release` | `release` | Linux / macOS |
| `debug-win` | `debug-win` | Windows (needs "Visual Studio" toolchain) |
| `release-win` | `release-win` | Windows |
| `relwithdebinfo-win` | `relwithdebinfo-win` | Windows |

On first open CLion reads this, enables the `debug` profile, and the build toolbar populates automatically.

## Test plan

- [ ] Fresh clone → open in CLion → build toolbar shows `debug` profile immediately
- [ ] `git status` stays clean after CLion generates its local `workspace.xml` etc.
- [ ] VS Code and Visual Studio unaffected (they don't read `.idea/`)