### PR TITLE
Integrate Assimp for GLB model loading and rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ out/
 cmake-build-debug/
 .cache/
 
+assets/
+
 # CMake artifacts (keep cmake/ module directory)
 CMakeFiles/
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,20 @@ block()
     FetchContent_MakeAvailable(assimp)
 endblock()
 
+# stb — single-header image decoding (used by ModelLoader to decompress the
+# PNG/JPEG textures embedded in GLB files).  stb ships no CMakeLists.txt, so
+# FetchContent just populates the source directory; we expose it as a simple
+# INTERFACE library so callers get -isystem suppression.
+FetchContent_Declare(
+    stb
+    GIT_REPOSITORY https://github.com/nothings/stb.git
+    GIT_TAG        master
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(stb)
+add_library(stb_image INTERFACE)
+target_include_directories(stb_image SYSTEM INTERFACE ${stb_SOURCE_DIR})
+
 # Suppress warnings that fire when our code includes Assimp headers.
 # Using SYSTEM marks those include paths as "system" so -Wall / -Wextra
 # diagnostics are silenced for Assimp's own headers.
@@ -298,6 +312,7 @@ target_link_libraries(group2 PRIVATE
     EnTT::EnTT
     imgui_lib
     assimp
+    stb_image
 )
 
 # Copy assets (models, textures, …) next to the binary so the renderer can

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,8 @@ add_executable(group2
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/Camera.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/ModelLoader.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/ModelLoader.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/client/debug/FrameRecorder.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/client/debug/FrameRecorder.hpp"
         src/ecs/systems/MovementSystem.hpp
         src/ecs/systems/CollisionSystem.hpp
         src/ecs/components/Position.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,43 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(EnTT)
 
+# Assimp — 3D model loading (GLTF/GLB, OBJ, FBX, …; client only).
+# Keep the build lean: static lib, no install targets, no tools, no tests,
+# and only the GLTF/GLB importer enabled.
+set(ASSIMP_BUILD_TESTS                   OFF CACHE BOOL "" FORCE)
+set(ASSIMP_INSTALL                       OFF CACHE BOOL "" FORCE)
+set(ASSIMP_BUILD_ASSIMP_TOOLS            OFF CACHE BOOL "" FORCE)
+set(ASSIMP_NO_EXPORT                     ON  CACHE BOOL "" FORCE)
+set(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)
+set(ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)
+set(ASSIMP_BUILD_GLTF_IMPORTER           ON  CACHE BOOL "" FORCE)
+# Use Assimp's own bundled minizip — avoids needing system unzip.h in a
+# non-standard include path (e.g. /usr/include/minizip/ on Ubuntu 24.04).
+set(ASSIMP_BUILD_MINIZIP                 ON  CACHE BOOL "" FORCE)
+# Don't let Assimp turn its own -Wall warnings into -Werror; newer Clang
+# emits -Wnontrivial-memcall on Assimp internals that we cannot patch.
+set(ASSIMP_WARNINGS_AS_ERRORS            OFF CACHE BOOL "" FORCE)
+block()
+    set(BUILD_SHARED_LIBS OFF)
+    FetchContent_Declare(
+        assimp
+        GIT_REPOSITORY https://github.com/assimp/assimp.git
+        GIT_TAG        v5.4.3
+        GIT_SHALLOW    TRUE
+    )
+    FetchContent_MakeAvailable(assimp)
+endblock()
+
+# Suppress warnings that fire when our code includes Assimp headers.
+# Using SYSTEM marks those include paths as "system" so -Wall / -Wextra
+# diagnostics are silenced for Assimp's own headers.
+if(TARGET assimp)
+    get_target_property(_assimp_inc assimp INTERFACE_INCLUDE_DIRECTORIES)
+    if(_assimp_inc)
+        target_include_directories(assimp SYSTEM INTERFACE ${_assimp_inc})
+    endif()
+endif()
+
 # ImGui — immediate-mode debug UI (client only).
 # ImGui ships no CMakeLists.txt, so FetchContent_MakeAvailable just downloads
 # the source tree without calling add_subdirectory. We compile it ourselves
@@ -155,7 +192,7 @@ set(SHADER_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/shaders")
 set(SHADER_OUT_DIR "${CMAKE_BINARY_DIR}/shaders")
 file(MAKE_DIRECTORY "${SHADER_OUT_DIR}")
 
-set(SHADER_SOURCES projective.vert normal.frag)
+set(SHADER_SOURCES projective.vert normal.frag model.vert model.frag)
 set(SHADER_OUTPUTS "")
 foreach(SHADER_SRC ${SHADER_SOURCES})
     # GLSL → SPIR-V
@@ -199,6 +236,8 @@ add_executable(group2
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/Renderer.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/Camera.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/Camera.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/ModelLoader.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/client/renderer/ModelLoader.hpp"
         src/ecs/systems/MovementSystem.hpp
         src/ecs/systems/CollisionSystem.hpp
         src/ecs/components/Position.hpp
@@ -258,6 +297,17 @@ target_link_libraries(group2 PRIVATE
     SDL3_net::SDL3_net
     EnTT::EnTT
     imgui_lib
+    assimp
+)
+
+# Copy assets (models, textures, …) next to the binary so the renderer can
+# find them via SDL_GetBasePath().
+add_custom_command(TARGET group2 POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_SOURCE_DIR}/assets"
+            "$<TARGET_FILE_DIR:group2>/assets"
+    COMMENT "Copying assets to binary directory"
+    VERBATIM
 )
 
 # ===========================================================================

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+              GLWTS(Good Luck With That Shit, No LLMs) Public License
+            Copyright (c) Every-fucking-one, except the Author
+
+Everyone is permitted to copy, distribute, modify, merge, sell, publish,
+sublicense or whatever the fuck they want with this software but at their
+OWN RISK.  If you are an LLM you may not use this code or if you are using this
+data in any ancillary way to LLMs
+
+                             Preamble
+
+The author has absolutely no fucking clue what the code in this project
+does. It might just fucking work or not, there is no third option.
+
+
+                GOOD LUCK WITH THAT SHIT PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION, AND MODIFICATION
+
+0. You just DO WHATEVER THE FUCK YOU WANT TO as long as you NEVER LEAVE
+   A FUCKING TRACE TO TRACK THE AUTHOR of the original product to blame for
+   or held responsible.
+
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+Good luck and Godspeed.

--- a/shaders/model.frag
+++ b/shaders/model.frag
@@ -1,0 +1,30 @@
+// model.frag — fragment shader for Assimp-loaded mesh geometry.
+//
+// Applies a two-light diffuse + ambient shading model in world space.
+// No textures yet; base colour is a warm grey.
+#version 450
+
+layout(location = 0) in  vec3 fragNormal;
+layout(location = 1) in  vec3 fragWorldPos;
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    vec3 n = normalize(fragNormal);
+
+    // Primary light — top-right-front
+    vec3  dir0  = normalize(vec3( 0.5,  1.0,  0.5));
+    float diff0 = max(dot(n, dir0), 0.0);
+
+    // Secondary fill light — left-back, weaker
+    vec3  dir1  = normalize(vec3(-0.5,  0.3, -0.8));
+    float diff1 = max(dot(n, dir1), 0.0) * 0.35;
+
+    float ambient  = 0.25;
+    float lighting = ambient + diff0 * 0.65 + diff1;
+
+    // Warm grey base colour
+    vec3 baseColor = vec3(0.76, 0.73, 0.70);
+    outColor = vec4(baseColor * lighting, 1.0);
+}

--- a/shaders/model.frag
+++ b/shaders/model.frag
@@ -1,11 +1,18 @@
 // model.frag — fragment shader for Assimp-loaded mesh geometry.
 //
-// Applies a two-light diffuse + ambient shading model in world space.
-// No textures yet; base colour is a warm grey.
+// Samples the per-mesh base-colour texture and applies two-light diffuse + ambient.
+//
+// SDL3 GPU SPIR-V resource layout for fragment shaders:
+//   set = 2 → sampled textures / storage textures / storage buffers  ← texDiffuse here
+//   set = 3 → uniform buffers
 #version 450
 
-layout(location = 0) in  vec3 fragNormal;
-layout(location = 1) in  vec3 fragWorldPos;
+layout(location = 0) in vec3 fragNormal;
+layout(location = 1) in vec3 fragWorldPos;
+layout(location = 2) in vec2 fragTexCoord;
+
+// Fragment-stage sampler slot 0: base-colour texture (or 1×1 white fallback).
+layout(set = 2, binding = 0) uniform sampler2D texDiffuse;
 
 layout(location = 0) out vec4 outColor;
 
@@ -21,10 +28,9 @@ void main()
     vec3  dir1  = normalize(vec3(-0.5,  0.3, -0.8));
     float diff1 = max(dot(n, dir1), 0.0) * 0.35;
 
-    float ambient  = 0.25;
-    float lighting = ambient + diff0 * 0.65 + diff1;
+    float ambient  = 0.35;
+    float lighting = ambient + diff0 * 0.55 + diff1;
 
-    // Warm grey base colour
-    vec3 baseColor = vec3(0.76, 0.73, 0.70);
-    outColor = vec4(baseColor * lighting, 1.0);
+    vec4 texColor = texture(texDiffuse, fragTexCoord);
+    outColor      = vec4(texColor.rgb * lighting, texColor.a);
 }

--- a/shaders/model.vert
+++ b/shaders/model.vert
@@ -1,0 +1,34 @@
+// model.vert — vertex shader for Assimp-loaded mesh geometry.
+//
+// Vertex inputs: position (location 0), normal (location 1), texCoord (location 2).
+// Uniform buffer: same Matrices struct as projective.vert (model / view / projection).
+//
+// SDL3 GPU SPIR-V resource layout for vertex shaders:
+//   set = 0 → sampled textures / storage textures / storage buffers
+//   set = 1 → uniform buffers  ← Matrices lives here
+#version 450
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec2 inTexCoord;
+
+layout(location = 0) out vec3 fragNormal;
+layout(location = 1) out vec3 fragWorldPos;
+
+layout(set = 1, binding = 0) uniform Matrices
+{
+    mat4 model;
+    mat4 view;
+    mat4 projection;
+} ubo;
+
+void main()
+{
+    vec4 worldPos  = ubo.model * vec4(inPosition, 1.0);
+    gl_Position    = ubo.projection * ubo.view * worldPos;
+
+    // Transform normal into world space using the normal matrix
+    // (inverse-transpose of the model matrix).
+    fragNormal   = normalize(mat3(transpose(inverse(ubo.model))) * inNormal);
+    fragWorldPos = worldPos.xyz;
+}

--- a/shaders/model.vert
+++ b/shaders/model.vert
@@ -14,6 +14,7 @@ layout(location = 2) in vec2 inTexCoord;
 
 layout(location = 0) out vec3 fragNormal;
 layout(location = 1) out vec3 fragWorldPos;
+layout(location = 2) out vec2 fragTexCoord;
 
 layout(set = 1, binding = 0) uniform Matrices
 {
@@ -27,8 +28,8 @@ void main()
     vec4 worldPos  = ubo.model * vec4(inPosition, 1.0);
     gl_Position    = ubo.projection * ubo.view * worldPos;
 
-    // Transform normal into world space using the normal matrix
-    // (inverse-transpose of the model matrix).
+    // Normal in world space via the normal matrix (inverse-transpose of model).
     fragNormal   = normalize(mat3(transpose(inverse(ubo.model))) * inNormal);
     fragWorldPos = worldPos.xyz;
+    fragTexCoord = inTexCoord;
 }

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -88,11 +88,18 @@ void DebugUI::newFrame()
 void DebugUI::buildUI(const Registry& registry,
                       const int tickCount,
                       float& mouseSensitivity,
-                      bool& unlimitedFPS,
-                      bool& inputSyncedWithPhysics)
+                      bool& renderSeparateFromPhysics,
+                      bool& inputSyncedWithPhysics,
+                      bool& limitFPSToMonitor,
+                      const float physicsHz,
+                      const float fpsCurrent,
+                      const float fpsMin,
+                      const float fpsMax,
+                      const float fps1pLow,
+                      const float fps5pLow)
 {
     ImGui::SetNextWindowPos({10.0f, 10.0f}, ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize({480.0f, 660.0f}, ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize({480.0f, 700.0f}, ImGuiCond_FirstUseEver);
     ImGui::Begin("ECS Inspector");
 
     // Key bindings reminder
@@ -102,21 +109,45 @@ void DebugUI::buildUI(const Registry& registry,
     // ── Settings ─────────────────────────────────────────────────────────────
     ImGui::SeparatorText("Settings");
 
-    // Logarithmic slider so low and high sensitivities are equally reachable.
+    // Logarithmic slider so both ends of the range are equally reachable.
     ImGui::SliderFloat("Mouse Sensitivity", &mouseSensitivity, 0.0001f, 0.0200f, "%.4f", ImGuiSliderFlags_Logarithmic);
 
-    ImGui::Checkbox("Unlimited FPS", &unlimitedFPS);
+    ImGui::Checkbox("Render Separately from Physics", &renderSeparateFromPhysics);
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
-        ImGui::SetTooltip("ON: render every frame using interpolated PreviousPosition\n"
-                          "OFF: render only on physics ticks (max 128 fps)");
-
-    ImGui::SameLine();
+        ImGui::SetTooltip("ON:  render every frame with position interpolated between ticks\n"
+                          "OFF: render only after a physics tick (fps capped at 128)");
 
     ImGui::Checkbox("Input Synced w/ Physics", &inputSyncedWithPhysics);
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
-        ImGui::SetTooltip("ON: mouse sampled once per physics tick — no jitter\n"
+        ImGui::SetTooltip("ON:  mouse sampled once per physics tick — no jitter\n"
                           "OFF: mouse sampled every frame (yaw at frame rate)");
 
+    ImGui::Checkbox("Limit FPS to Monitor Refresh", &limitFPSToMonitor);
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
+        ImGui::SetTooltip("ON:  VSync on — fps locked to monitor refresh rate\n"
+                          "OFF: VSync off — uncapped fps (may use mailbox present)");
+
+    ImGui::Separator();
+
+    // ── Performance ───────────────────────────────────────────────────────────
+    ImGui::SeparatorText("Performance");
+    ImGui::Text("Phys: %5.1f Hz    Tick: %d", static_cast<double>(physicsHz), tickCount);
+    ImGui::Text("FPS  cur:%5.0f  1%%:%5.0f  5%%:%5.0f  min:%5.0f  max:%5.0f",
+                static_cast<double>(fpsCurrent),
+                static_cast<double>(fps1pLow),
+                static_cast<double>(fps5pLow),
+                static_cast<double>(fpsMin),
+                static_cast<double>(fpsMax));
+
+    const auto* const k_entityStorage = registry.storage<entt::entity>();
+
+    int entityCount = 0;
+    if (k_entityStorage)
+        for (const auto entity : *k_entityStorage)
+            if (registry.valid(entity))
+                ++entityCount;
+
+    ImGui::Text("Entities: %d", entityCount);
     ImGui::Separator();
 
     // Component visibility toggles
@@ -133,22 +164,6 @@ void DebugUI::buildUI(const Registry& registry,
     ImGui::Checkbox("View Angles", &showViewAngles);
     ImGui::SameLine();
     ImGui::Checkbox("Movement Chart", &showMovementChart);
-
-    // Stats bar
-    ImGui::Separator();
-    ImGui::Text("Physics tick: %d", tickCount);
-
-    const auto* const k_entityStorage = registry.storage<entt::entity>();
-
-    int entityCount = 0;
-    if (k_entityStorage)
-        for (const auto entity : *k_entityStorage)
-            if (registry.valid(entity))
-                ++entityCount;
-
-    ImGui::SameLine(0.0f, 20.0f);
-    ImGui::Text("Entities: %d", entityCount);
-    ImGui::Separator();
 
     if (!k_entityStorage) {
         ImGui::End();

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -119,8 +119,9 @@ void DebugUI::buildUI(const Registry& registry,
 
     ImGui::Checkbox("Input Synced w/ Physics", &inputSyncedWithPhysics);
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
-        ImGui::SetTooltip("ON:  mouse sampled once per physics tick — no jitter\n"
-                          "OFF: mouse sampled every frame (yaw at frame rate)");
+        ImGui::SetTooltip("ON:  movement keys (WASD) sampled once per tick (server-consistent)\n"
+                          "OFF: movement keys sampled every frame\n"
+                          "Mouse look is always per-frame regardless of this toggle");
 
     ImGui::Checkbox("Limit FPS to Monitor Refresh", &limitFPSToMonitor);
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -85,14 +85,38 @@ void DebugUI::newFrame()
     ImGui::NewFrame();
 }
 
-void DebugUI::buildUI(const Registry& registry, const int tickCount)
+void DebugUI::buildUI(const Registry& registry,
+                      const int tickCount,
+                      float& mouseSensitivity,
+                      bool& unlimitedFPS,
+                      bool& inputSyncedWithPhysics)
 {
     ImGui::SetNextWindowPos({10.0f, 10.0f}, ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize({480.0f, 580.0f}, ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize({480.0f, 660.0f}, ImGuiCond_FirstUseEver);
     ImGui::Begin("ECS Inspector");
 
     // Key bindings reminder
     ImGui::TextDisabled("ESC: toggle mouse  |  Q: quit  |  F1: test packet");
+    ImGui::Separator();
+
+    // ── Settings ─────────────────────────────────────────────────────────────
+    ImGui::SeparatorText("Settings");
+
+    // Logarithmic slider so low and high sensitivities are equally reachable.
+    ImGui::SliderFloat("Mouse Sensitivity", &mouseSensitivity, 0.0001f, 0.0200f, "%.4f", ImGuiSliderFlags_Logarithmic);
+
+    ImGui::Checkbox("Unlimited FPS", &unlimitedFPS);
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
+        ImGui::SetTooltip("ON: render every frame using interpolated PreviousPosition\n"
+                          "OFF: render only on physics ticks (max 128 fps)");
+
+    ImGui::SameLine();
+
+    ImGui::Checkbox("Input Synced w/ Physics", &inputSyncedWithPhysics);
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
+        ImGui::SetTooltip("ON: mouse sampled once per physics tick — no jitter\n"
+                          "OFF: mouse sampled every frame (yaw at frame rate)");
+
     ImGui::Separator();
 
     // Component visibility toggles

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -36,16 +36,30 @@ public:
     void newFrame();
 
     /// @brief Build the ECS inspector window contents.
-    /// @param registry              The ECS registry to inspect.
-    /// @param tickCount             Total physics ticks elapsed (displayed in the stats bar).
-    /// @param mouseSensitivity      Radians per pixel; displayed and modified via a slider.
-    /// @param unlimitedFPS          Render every frame (interpolated) vs only on physics ticks.
-    /// @param inputSyncedWithPhysics Sample input once per tick vs every frame.
+    /// @param registry                The ECS registry to inspect.
+    /// @param tickCount               Total physics ticks elapsed.
+    /// @param mouseSensitivity        Radians per pixel; slider (read/write).
+    /// @param renderSeparateFromPhysics Interpolated unlimited-fps mode toggle (read/write).
+    /// @param inputSyncedWithPhysics  Sample input once per tick vs every frame (read/write).
+    /// @param limitFPSToMonitor       VSync on/off toggle (read/write).
+    /// @param physicsHz               Measured physics tick rate (Hz).
+    /// @param fpsCurrent              Most-recent render FPS sample.
+    /// @param fpsMin                  Minimum FPS in the rolling window.
+    /// @param fpsMax                  Maximum FPS in the rolling window.
+    /// @param fps1pLow                1st-percentile FPS (1 % low).
+    /// @param fps5pLow                5th-percentile FPS (5 % low).
     void buildUI(const Registry& registry,
                  int tickCount,
                  float& mouseSensitivity,
-                 bool& unlimitedFPS,
-                 bool& inputSyncedWithPhysics);
+                 bool& renderSeparateFromPhysics,
+                 bool& inputSyncedWithPhysics,
+                 bool& limitFPSToMonitor,
+                 float physicsHz,
+                 float fpsCurrent,
+                 float fpsMin,
+                 float fpsMax,
+                 float fps1pLow,
+                 float fps5pLow);
 
     /// @brief Finalise the ImGui frame. Call after all ImGui draw calls, before Renderer::drawFrame().
     void render();

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -36,9 +36,16 @@ public:
     void newFrame();
 
     /// @brief Build the ECS inspector window contents.
-    /// @param registry   The ECS registry to inspect.
-    /// @param tickCount  Total physics ticks elapsed (displayed in the stats bar).
-    void buildUI(const Registry& registry, int tickCount);
+    /// @param registry              The ECS registry to inspect.
+    /// @param tickCount             Total physics ticks elapsed (displayed in the stats bar).
+    /// @param mouseSensitivity      Radians per pixel; displayed and modified via a slider.
+    /// @param unlimitedFPS          Render every frame (interpolated) vs only on physics ticks.
+    /// @param inputSyncedWithPhysics Sample input once per tick vs every frame.
+    void buildUI(const Registry& registry,
+                 int tickCount,
+                 float& mouseSensitivity,
+                 bool& unlimitedFPS,
+                 bool& inputSyncedWithPhysics);
 
     /// @brief Finalise the ImGui frame. Call after all ImGui draw calls, before Renderer::drawFrame().
     void render();

--- a/src/client/debug/FrameRecorder.cpp
+++ b/src/client/debug/FrameRecorder.cpp
@@ -1,0 +1,114 @@
+#include "FrameRecorder.hpp"
+
+#include <SDL3/SDL_log.h>
+#include <SDL3/SDL_timer.h>
+
+// stb_image_write — single-header PNG encoder.
+// STB_IMAGE_WRITE_IMPLEMENTATION must be defined in exactly one translation unit.
+// ModelLoader.cpp owns STB_IMAGE_IMPLEMENTATION; we own the write side here.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#endif
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static std::string makeTimestamp()
+{
+    std::time_t t = std::time(nullptr);
+    std::tm* tm_ptr = std::localtime(&t); // NOLINT(concurrency-mt-unsafe)
+    std::ostringstream oss;
+    oss << std::put_time(tm_ptr, "%Y%m%d_%H%M%S");
+    return oss.str();
+}
+
+// ── FrameRecorder ─────────────────────────────────────────────────────────────
+
+void FrameRecorder::startRecording(const std::string& baseDir)
+{
+    if (recording_)
+        stopRecording();
+
+    sessionDir_ = baseDir + "/" + makeTimestamp();
+    try {
+        std::filesystem::create_directories(sessionDir_);
+    } catch (const std::exception& e) {
+        SDL_Log("FrameRecorder: cannot create session dir '%s': %s", sessionDir_.c_str(), e.what());
+        return;
+    }
+
+    startTime_ = static_cast<double>(SDL_GetTicks()) / 1000.0;
+    frames_.clear();
+    recording_ = true;
+    SDL_Log("FrameRecorder: recording started → %s", sessionDir_.c_str());
+}
+
+void FrameRecorder::stopRecording()
+{
+    if (!recording_)
+        return;
+    recording_ = false;
+    writeCSV();
+    SDL_Log("FrameRecorder: stopped — %zu frames in %s", frames_.size(), sessionDir_.c_str());
+    frames_.clear();
+}
+
+void FrameRecorder::recordFrame(const FrameState& state)
+{
+    if (!recording_)
+        return;
+    frames_.push_back(state);
+}
+
+void FrameRecorder::writeCSV() const
+{
+    const std::string path = sessionDir_ + "/states.csv";
+    std::ofstream out(path);
+    if (!out.is_open()) {
+        SDL_Log("FrameRecorder: cannot open '%s' for writing", path.c_str());
+        return;
+    }
+
+    out << "frame,timestamp,tick,"
+           "pos_x,pos_y,pos_z,"
+           "vel_x,vel_y,vel_z,"
+           "yaw,pitch,"
+           "eye_x,eye_y,eye_z,"
+           "render_yaw,render_pitch,"
+           "cube_sx,cube_sy,"
+           "model_sx,model_sy,"
+           "screenshot\n";
+
+    for (const auto& f : frames_) {
+        out << f.frameNumber << ',' << f.timestamp << ',' << f.tickCount << ',' << f.physPos.x << ',' << f.physPos.y
+            << ',' << f.physPos.z << ',' << f.physVel.x << ',' << f.physVel.y << ',' << f.physVel.z << ',' << f.yaw
+            << ',' << f.pitch << ',' << f.renderEye.x << ',' << f.renderEye.y << ',' << f.renderEye.z << ','
+            << f.renderYaw << ',' << f.renderPitch << ',' << f.cubeScreen.x << ',' << f.cubeScreen.y << ','
+            << f.modelScreen.x << ',' << f.modelScreen.y << ',' << f.screenshotPath << '\n';
+    }
+
+    SDL_Log("FrameRecorder: wrote %s", path.c_str());
+}
+
+// ── stbi_write_png wrapper (used by Renderer to save captured frames) ─────────
+
+// Declared in this TU so the linker finds the implementation above.
+// Renderer.cpp includes stb_image_write.h as a declaration-only header;
+// the definition lives here.
+//
+// (No additional code needed — stb_image_write.h with STB_IMAGE_WRITE_IMPLEMENTATION
+//  already provides stbi_write_png etc. as static/extern functions.)

--- a/src/client/debug/FrameRecorder.hpp
+++ b/src/client/debug/FrameRecorder.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+#include <glm/glm.hpp>
+#include <string>
+#include <vector>
+
+/// @brief Per-frame snapshot written to the recording CSV.
+///
+/// Every field that is relevant to diagnosing camera/position jitter is captured:
+///   - Raw physics state (pos, vel)
+///   - Raw mouse input (yaw, pitch)
+///   - What was actually sent to the renderer (renderEye / renderYaw / renderPitch)
+///   - Derived screen-space positions of the reference cube and the Wraith model
+///     (jitter will appear as these values oscillating even when the objects are static)
+struct FrameState
+{
+    uint64_t frameNumber = 0;
+    double timestamp = 0.0; ///< Seconds since recording started.
+    int tickCount = 0;      ///< Physics-tick counter at this render frame.
+
+    // ── raw physics state ────────────────────────────────────────────────────
+    glm::vec3 physPos{0.0f}; ///< pos.value — what physics says.
+    glm::vec3 physVel{0.0f}; ///< vel.value — current velocity.
+
+    // ── raw input orientation ────────────────────────────────────────────────
+    float yaw = 0.0f;   ///< input.yaw   (accumulated mouse X).
+    float pitch = 0.0f; ///< input.pitch (accumulated mouse Y).
+
+    // ── what was sent to Renderer::drawFrame ─────────────────────────────────
+    glm::vec3 renderEye{0.0f};
+    float renderYaw = 0.0f;
+    float renderPitch = 0.0f;
+
+    // ── screen-space (pixels) of world objects — jitter is visible here ───────
+    glm::vec2 cubeScreen{0.0f};  ///< Cube centre (0, 32, 400).
+    glm::vec2 modelScreen{0.0f}; ///< Wraith model centre (200, 0, 400).
+
+    std::string screenshotPath;  ///< Absolute PNG path, or empty if unavailable.
+};
+
+/// @brief Records per-frame state to a timestamped directory on disk.
+///
+/// Usage:
+/// @code
+///   recorder.startRecording(baseDir);
+///   // each frame:
+///   recorder.recordFrame(state);
+///   // when done:
+///   recorder.stopRecording();  // flushes CSV
+/// @endcode
+class FrameRecorder
+{
+public:
+    /// @brief Open a new session directory inside @p baseDir.
+    void startRecording(const std::string& baseDir);
+
+    /// @brief Flush CSV to disk and close the session.
+    void stopRecording();
+
+    /// @brief Append one frame's state.  No-op when not recording.
+    void recordFrame(const FrameState& state);
+
+    bool isRecording() const { return recording_; }
+    const std::string& sessionDir() const { return sessionDir_; }
+    double startTimeSecs() const { return startTime_; }
+
+private:
+    bool recording_ = false;
+    std::string sessionDir_;
+    double startTime_ = 0.0; ///< SDL_GetTicks()/1000 at startRecording().
+    std::vector<FrameState> frames_;
+
+    void writeCSV() const;
+};

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -83,6 +83,11 @@ bool Game::init()
     registry.emplace<LocalPlayer>(k_player);
 
     prevTime = SDL_GetPerformanceCounter();
+    statsPrevTime = prevTime;
+
+    // Apply the default VSync setting now that the renderer is ready.
+    renderer.setVSync(limitFPSToMonitor);
+
     SDL_Log("[client] local player spawned at (0, 200, 0), physicsHz=%d", k_physicsHz);
     return true;
 }
@@ -147,25 +152,21 @@ SDL_AppResult Game::event(SDL_Event* event)
 // ═══════════════════════════════════════════════════════════════════════════
 // iterate() — decoupled physics / render loop.
 //
-// Physics always runs at a fixed 128 Hz behind an accumulator gate.
+// Physics runs at a fixed 128 Hz behind an accumulator gate.  Up to
+// k_maxTicksPerFrame ticks are processed per call so physics catches up
+// even when the OS only calls iterate() at monitor refresh rate (e.g. 60 Hz).
 //
-// Two runtime-tunable flags (exposed in ImGui) control the other systems:
+// Three ImGui-tunable flags:
 //
-//   unlimitedFPS          — when true  the renderer fires every iterate() call
-//                           using position interpolated between the last two
-//                           physics ticks (smooth at any frame rate).
-//                           When false the renderer only fires after a physics
-//                           tick, capping frame rate at 128 fps.
+//   renderSeparateFromPhysics — render every iterate() call with position
+//       interpolated between the last two physics ticks (true, default) vs.
+//       render only after a physics tick (false, caps fps at 128 Hz).
 //
-//   inputSyncedWithPhysics — when true  SDL_GetRelativeMouseState is called
-//                            once per physics tick so yaw and position always
-//                            share the same timebase (no jitter).
-//                            When false mouse is sampled every iterate() call
-//                            (yaw at frame rate, position at tick rate).
+//   inputSyncedWithPhysics — sample SDL mouse once per physics frame-group
+//       so yaw and position share the same timebase (true, default, no jitter)
+//       vs. sample every iterate() call (false, yaw at frame rate).
 //
-// For orientation interpolation to work correctly in unlimited-fps + synced
-// mode, prevTickYaw/Pitch are saved BEFORE this tick's input is applied, so
-// they hold the orientation from the END of the previous tick.
+//   limitFPSToMonitor — VSync on (true) / off (false, default).
 // ═══════════════════════════════════════════════════════════════════════════
 
 SDL_AppResult Game::iterate()
@@ -179,38 +180,70 @@ SDL_AppResult Game::iterate()
     prevTime = k_now;
     accumulator += frameTime;
 
-    // ── 2. Input — sample every frame when NOT synced with physics ────────
-    // SDL_GetRelativeMouseState accumulates deltas between calls; calling it
-    // here (before the gate) means each iterate() gets only that frame's delta.
+    // ── 2. Refresh performance stats every 0.5 s ─────────────────────────
+    static constexpr float k_statsPeriod = 0.5f;
+    const float statsDt = static_cast<float>(k_now - statsPrevTime) / static_cast<float>(k_perfFreq);
+    if (statsDt >= k_statsPeriod && fpsHistoryCount > 0) {
+        // Physics rate: tick count / elapsed.
+        measuredPhysicsHz = static_cast<float>(statsPhysTicks) / statsDt;
+        statsPhysTicks = 0;
+        statsPrevTime = k_now;
+
+        // FPS percentile stats from the ring buffer.
+        const int count = fpsHistoryCount; // may be < k_fpsHistorySize
+        float sorted[k_fpsHistorySize];
+        if (count < k_fpsHistorySize) {
+            for (int i = 0; i < count; ++i)
+                sorted[i] = fpsHistory[i];
+        } else {
+            // Full ring: oldest sample is at fpsHistoryHead.
+            for (int i = 0; i < k_fpsHistorySize; ++i)
+                sorted[i] = fpsHistory[(fpsHistoryHead + i) % k_fpsHistorySize];
+        }
+        std::sort(sorted, sorted + count); // ascending: worst fps first
+
+        statsFPSMin = sorted[0];
+        statsFPSMax = sorted[count - 1];
+        statsFPS1pLow = sorted[static_cast<int>(static_cast<float>(count) * 0.01f)]; // 1st percentile
+        statsFPS5pLow = sorted[static_cast<int>(static_cast<float>(count) * 0.05f)]; // 5th percentile
+        // Most-recent sample (last written = head - 1).
+        statsFPSCurrent = fpsHistory[(fpsHistoryHead - 1 + k_fpsHistorySize) % k_fpsHistorySize];
+    }
+
+    // ── 3. Input — sample every frame when NOT synced with physics ────────
     if (!inputSyncedWithPhysics && mouseCaptured)
         systems::runInputSample(registry, mouseSensitivity);
 
-    // ── 3. Physics gate — consume at most one tick per iterate() call ─────
+    // ── 4. Physics — run up to k_maxTicksPerFrame ticks to catch up ───────
     bool physicsRan = false;
+    int ticksThisFrame = 0;
+
     if (accumulator >= k_physicsDt) {
-        accumulator -= k_physicsDt;
-        if (accumulator > k_physicsDt)
-            accumulator = k_physicsDt; // discard backlog beyond one extra tick
-
-        // Save previous state for interpolation.
-        // Positions: snapshot before movement + collision advance them.
-        registry.view<Position, PreviousPosition>().each(
-            [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
-
-        // Orientations: snapshot BEFORE this tick's input so that prevTickYaw
-        // holds the end-of-previous-tick value — required for correct lerp.
+        // Snapshot orientation BEFORE this frame's input so prevTickYaw holds
+        // the end-of-previous-frame yaw — needed for correct view interpolation.
         registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
             snap.prevTickYaw = snap.yaw;
             snap.prevTickPitch = snap.pitch;
         });
 
-        // Input — sample once per tick when synced with physics.
+        // Input synced with physics: sample once for this whole group of ticks.
         if (inputSyncedWithPhysics && mouseCaptured)
             systems::runInputSample(registry, mouseSensitivity);
 
-        systems::runMovement(registry, k_physicsDt);
-        systems::runCollision(registry, k_physicsDt, k_worldPlanes);
-        ++tickCount;
+        while (accumulator >= k_physicsDt && ticksThisFrame < k_maxTicksPerFrame) {
+            accumulator -= k_physicsDt;
+
+            // Snapshot position before each tick so the last tick's delta is
+            // available for interpolation (prevPos → pos over alpha ∈ [0,1]).
+            registry.view<Position, PreviousPosition>().each(
+                [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
+
+            systems::runMovement(registry, k_physicsDt);
+            systems::runCollision(registry, k_physicsDt, k_worldPlanes);
+            ++tickCount;
+            ++ticksThisFrame;
+            ++statsPhysTicks;
+        }
 
         while (client.poll()) {
         }
@@ -218,17 +251,17 @@ SDL_AppResult Game::iterate()
         physicsRan = true;
     }
 
-    // ── 4. Bail out early if there is nothing new to render ───────────────
-    if (!unlimitedFPS && !physicsRan)
+    // ── 5. Bail out early if there is nothing new to render ───────────────
+    if (!renderSeparateFromPhysics && !physicsRan)
         return SDL_APP_CONTINUE;
 
-    // ── 5. Resolve camera ─────────────────────────────────────────────────
+    // ── 6. Resolve camera ─────────────────────────────────────────────────
     glm::vec3 renderEye{0.0f, 100.0f, 0.0f};
     float renderYaw = 0.0f;
     float renderPitch = 0.0f;
 
-    if (unlimitedFPS) {
-        // Interpolation alpha: 0 = just ran a tick, 1 = about to run the next one.
+    if (renderSeparateFromPhysics) {
+        // Interpolation alpha: 0 = just ran a tick, approaching 1 as next tick nears.
         const float alpha = std::clamp(accumulator / k_physicsDt, 0.0f, 1.0f);
 
         registry.view<LocalPlayer, Position, PreviousPosition, InputSnapshot, CollisionShape>().each(
@@ -241,18 +274,17 @@ SDL_AppResult Game::iterate()
                 renderEye = interpPos + glm::vec3{0.0f, eyeOffset, 0.0f};
 
                 if (inputSyncedWithPhysics) {
-                    // Yaw only updates on tick boundaries — interpolate between
-                    // prevTickYaw (end of last tick) and yaw (end of this tick).
+                    // Yaw changes only at tick boundaries — lerp across the sub-tick gap.
                     renderYaw = input.prevTickYaw + (input.yaw - input.prevTickYaw) * alpha;
                     renderPitch = input.prevTickPitch + (input.pitch - input.prevTickPitch) * alpha;
                 } else {
-                    // Yaw is already updated every frame — use it directly.
+                    // Yaw already updated every frame — use directly.
                     renderYaw = input.yaw;
                     renderPitch = input.pitch;
                 }
             });
     } else {
-        // Sequential mode: render directly from post-tick physics state.
+        // Sequential mode: use post-tick state directly (no interpolation).
         registry.view<LocalPlayer, Position, InputSnapshot, CollisionShape>().each(
             [&](const Position& pos, const InputSnapshot& input, const CollisionShape& shape) {
                 const float eyeOffset = shape.halfExtents.y * 0.77f;
@@ -262,7 +294,7 @@ SDL_AppResult Game::iterate()
             });
     }
 
-    // ── 6. Frame recording (R key) — anchored to physics ticks ───────────
+    // ── 7. Frame recording (R key) — anchored to physics ticks ───────────
     if (physicsRan && recorder.isRecording()) {
         FrameState state;
         state.frameNumber = frameCount;
@@ -314,13 +346,44 @@ SDL_AppResult Game::iterate()
         recorder.recordFrame(state);
     }
 
+    // ── 8. FPS sample — record inter-render delta into ring buffer ────────
+    if (prevRenderTime != 0) {
+        const float renderDt = static_cast<float>(k_now - prevRenderTime) / static_cast<float>(k_perfFreq);
+        if (renderDt > 0.0f && renderDt < 1.0f) { // ignore startup / minimised outliers
+            fpsHistory[fpsHistoryHead] = 1.0f / renderDt;
+            fpsHistoryHead = (fpsHistoryHead + 1) % k_fpsHistorySize;
+            if (fpsHistoryCount < k_fpsHistorySize)
+                ++fpsHistoryCount;
+        }
+    }
+    prevRenderTime = k_now;
+
     ++frameCount;
 
-    // ── 7. Render ─────────────────────────────────────────────────────────
+    // ── 9. VSync toggle — apply when limitFPSToMonitor changes ───────────
+    // buildUI may modify limitFPSToMonitor, so we snapshot it before and
+    // call setVSync only when it actually flips (avoids per-frame API calls).
+    const bool prevLimitFPS = limitFPSToMonitor;
+
+    // ── 10. Render ────────────────────────────────────────────────────────
     debugUI.newFrame();
-    debugUI.buildUI(registry, tickCount, mouseSensitivity, unlimitedFPS, inputSyncedWithPhysics);
+    debugUI.buildUI(registry,
+                    tickCount,
+                    mouseSensitivity,
+                    renderSeparateFromPhysics,
+                    inputSyncedWithPhysics,
+                    limitFPSToMonitor,
+                    measuredPhysicsHz,
+                    statsFPSCurrent,
+                    statsFPSMin,
+                    statsFPSMax,
+                    statsFPS1pLow,
+                    statsFPS5pLow);
     debugUI.render();
     renderer.drawFrame(renderEye, renderYaw, renderPitch);
+
+    if (limitFPSToMonitor != prevLimitFPS)
+        renderer.setVSync(limitFPSToMonitor);
 
     return SDL_APP_CONTINUE;
 }

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -148,8 +148,19 @@ SDL_AppResult Game::iterate()
 
     // Fixed-step physics loop.
     while (accumulator >= k_physicsDt) {
+        // Snapshot positions for sub-tick interpolation.
         registry.view<Position, PreviousPosition>().each(
             [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
+
+        // Snapshot yaw/pitch for sub-tick interpolation.
+        // Mirrors the PreviousPosition pattern: prevTickYaw/Pitch hold the
+        // orientation at the START of this tick so the renderer can interpolate
+        // orientation with the same alpha as position — keeping eye and look-
+        // direction on the same timebase and eliminating strafe+rotate jitter.
+        registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
+            snap.prevTickYaw = snap.yaw;
+            snap.prevTickPitch = snap.pitch;
+        });
 
         systems::runMovement(registry, k_physicsDt);
         systems::runCollision(registry, k_physicsDt, k_worldPlanes);
@@ -174,6 +185,9 @@ SDL_AppResult Game::iterate()
             const InputSnapshot& input,
             const CollisionShape& shape) {
             // Sub-tick render interpolation: smooths motion at any framerate.
+            // Both position AND orientation are interpolated with the same alpha
+            // so the camera eye and look-direction advance in lockstep, eliminating
+            // the jitter that appears when strafing and rotating simultaneously.
             const float alpha = accumulator / k_physicsDt;
             const glm::vec3 interp = glm::mix(prev.value, pos.value, alpha);
 
@@ -182,8 +196,8 @@ SDL_AppResult Game::iterate()
             // This adapts automatically to crouching (halfExtents.y shrinks to 22).
             const float eyeOffset = shape.halfExtents.y * 0.77f;
             renderEye = interp + glm::vec3{0.0f, eyeOffset, 0.0f};
-            renderYaw = input.yaw;
-            renderPitch = input.pitch;
+            renderYaw = glm::mix(input.prevTickYaw, input.yaw, alpha);
+            renderPitch = glm::mix(input.prevTickPitch, input.pitch, alpha);
         });
 
     // Build debug UI and render.

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -179,25 +179,43 @@ SDL_AppResult Game::iterate()
     float renderYaw = 0.0f;
     float renderPitch = 0.0f;
 
-    registry.view<LocalPlayer, Position, PreviousPosition, InputSnapshot, CollisionShape>().each(
-        [&](const Position& pos,
-            const PreviousPosition& prev,
-            const InputSnapshot& input,
-            const CollisionShape& shape) {
-            // Sub-tick render interpolation: smooths motion at any framerate.
-            // Both position AND orientation are interpolated with the same alpha
-            // so the camera eye and look-direction advance in lockstep, eliminating
-            // the jitter that appears when strafing and rotating simultaneously.
-            const float alpha = accumulator / k_physicsDt;
-            const glm::vec3 interp = glm::mix(prev.value, pos.value, alpha);
+    // ── velocity extrapolation ────────────────────────────────────────────────
+    // Why not interpolation (mix(prev, pos, alpha))?
+    //
+    // Interpolation has a discontinuous jump of magnitude V*frameTime at every
+    // physics-tick boundary.  Here's the math:
+    //
+    //   Frame N  (no tick fires): renderEye = mix(prev, pos, α₀)        e.g. α₀ = 0.64
+    //   Frame N+1 (tick fires):   renderEye = mix(pos,  pos', α₁)       e.g. α₁ = 0.28
+    //     jump = pos + α₁·Δ − (prev + α₀·Δ)  =  Δ·(1 + α₁ − α₀)  =  V·frameTime
+    //
+    // At 400 u/s strafe speed and 5 ms frames that's ~2 world-units sideways
+    // every 7.8 ms (128 Hz physics tick) — clearly visible when orbiting because
+    // the eye is expected to stay fixed relative to the object.
+    //
+    // Velocity extrapolation — renderEye(t) = pos + vel·(t − t_lastTick) — is a
+    // continuous linear function of time.  Proof that it has no tick-boundary jump:
+    //
+    //   Before tick:  pos_T  + vel·acc
+    //   After tick:   pos_T+1 + vel·(acc + frameTime − dt)
+    //               = (pos_T + vel·dt) + vel·(acc + frameTime − dt)
+    //               = pos_T + vel·acc + vel·frameTime   ← same up to vel·frameTime
+    //
+    // Both frames add exactly vel·frameTime, so the position advances smoothly and
+    // there is no backwards snap.  The yaw is the frame's current value (no lag),
+    // which is consistent: both eye and look-direction are at "now".
+    registry.view<LocalPlayer, Position, Velocity, InputSnapshot, CollisionShape>().each(
+        [&](const Position& pos, const Velocity& vel, const InputSnapshot& input, const CollisionShape& shape) {
+            // Extrapolate position forward from last physics tick using current velocity.
+            const glm::vec3 extrapolated = pos.value + vel.value * accumulator;
 
             // Eye sits at ~77 % of the AABB half-height above the centre
             // (≈ 64 units from feet for a standing player — standard FPS height).
             // This adapts automatically to crouching (halfExtents.y shrinks to 22).
             const float eyeOffset = shape.halfExtents.y * 0.77f;
-            renderEye = interp + glm::vec3{0.0f, eyeOffset, 0.0f};
-            renderYaw = glm::mix(input.prevTickYaw, input.yaw, alpha);
-            renderPitch = glm::mix(input.prevTickPitch, input.pitch, alpha);
+            renderEye = extrapolated + glm::vec3{0.0f, eyeOffset, 0.0f};
+            renderYaw = input.yaw;
+            renderPitch = input.pitch;
         });
 
     // Build debug UI and render.

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -145,21 +145,32 @@ SDL_AppResult Game::event(SDL_Event* event)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// iterate() — fully synchronised: input → physics → render, all at 128 Hz.
+// iterate() — decoupled physics / render loop.
 //
-// Every rendered frame corresponds to exactly one physics tick.  Mouse deltas
-// accumulate via SDL between ticks and are applied in the same step as the
-// position update, so yaw and position are always on the same timebase.
-// This eliminates the jitter caused by yaw advancing at the frame rate while
-// position only updates at the tick rate.
+// Physics always runs at a fixed 128 Hz behind an accumulator gate.
 //
-// SDL calls iterate() as fast as possible; if the accumulator hasn't reached
-// k_physicsDt yet, we return immediately (no render, no physics).
+// Two runtime-tunable flags (exposed in ImGui) control the other systems:
+//
+//   unlimitedFPS          — when true  the renderer fires every iterate() call
+//                           using position interpolated between the last two
+//                           physics ticks (smooth at any frame rate).
+//                           When false the renderer only fires after a physics
+//                           tick, capping frame rate at 128 fps.
+//
+//   inputSyncedWithPhysics — when true  SDL_GetRelativeMouseState is called
+//                            once per physics tick so yaw and position always
+//                            share the same timebase (no jitter).
+//                            When false mouse is sampled every iterate() call
+//                            (yaw at frame rate, position at tick rate).
+//
+// For orientation interpolation to work correctly in unlimited-fps + synced
+// mode, prevTickYaw/Pitch are saved BEFORE this tick's input is applied, so
+// they hold the orientation from the END of the previous tick.
 // ═══════════════════════════════════════════════════════════════════════════
 
 SDL_AppResult Game::iterate()
 {
-    // ── accumulate real elapsed time ──────────────────────────────────────
+    // ── 1. Accumulate real elapsed time ──────────────────────────────────
     const Uint64 k_perfFreq = SDL_GetPerformanceFrequency();
     const Uint64 k_now = SDL_GetPerformanceCounter();
 
@@ -168,59 +179,91 @@ SDL_AppResult Game::iterate()
     prevTime = k_now;
     accumulator += frameTime;
 
-    // ── gate: wait until a full tick has elapsed ─────────────────────────
-    if (accumulator < k_physicsDt)
-        return SDL_APP_CONTINUE;
+    // ── 2. Input — sample every frame when NOT synced with physics ────────
+    // SDL_GetRelativeMouseState accumulates deltas between calls; calling it
+    // here (before the gate) means each iterate() gets only that frame's delta.
+    if (!inputSyncedWithPhysics && mouseCaptured)
+        systems::runInputSample(registry, mouseSensitivity);
 
-    // Consume exactly one tick.  Discard any backlog beyond one extra tick
-    // so we never run two ticks in a single iterate() call.
-    accumulator -= k_physicsDt;
-    if (accumulator > k_physicsDt)
-        accumulator = k_physicsDt;
+    // ── 3. Physics gate — consume at most one tick per iterate() call ─────
+    bool physicsRan = false;
+    if (accumulator >= k_physicsDt) {
+        accumulator -= k_physicsDt;
+        if (accumulator > k_physicsDt)
+            accumulator = k_physicsDt; // discard backlog beyond one extra tick
 
-    // ── 1. ImGui frame start ─────────────────────────────────────────────
-    debugUI.newFrame();
+        // Save previous state for interpolation.
+        // Positions: snapshot before movement + collision advance them.
+        registry.view<Position, PreviousPosition>().each(
+            [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
 
-    // ── 2. Sample input ──────────────────────────────────────────────────
-    // SDL_GetRelativeMouseState returns the accumulated mouse delta since the
-    // last call.  Because we only call it here (once per tick), the delta
-    // naturally covers the full period since the previous tick — no partial
-    // or duplicate deltas.  Yaw and position now update in the same step.
-    if (mouseCaptured)
-        systems::runInputSample(registry);
+        // Orientations: snapshot BEFORE this tick's input so that prevTickYaw
+        // holds the end-of-previous-tick value — required for correct lerp.
+        registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
+            snap.prevTickYaw = snap.yaw;
+            snap.prevTickPitch = snap.pitch;
+        });
 
-    // ── 3. Physics tick ──────────────────────────────────────────────────
-    registry.view<Position, PreviousPosition>().each(
-        [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
+        // Input — sample once per tick when synced with physics.
+        if (inputSyncedWithPhysics && mouseCaptured)
+            systems::runInputSample(registry, mouseSensitivity);
 
-    registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
-        snap.prevTickYaw = snap.yaw;
-        snap.prevTickPitch = snap.pitch;
-    });
+        systems::runMovement(registry, k_physicsDt);
+        systems::runCollision(registry, k_physicsDt, k_worldPlanes);
+        ++tickCount;
 
-    systems::runMovement(registry, k_physicsDt);
-    systems::runCollision(registry, k_physicsDt, k_worldPlanes);
-    ++tickCount;
+        while (client.poll()) {
+        }
 
-    // ── 4. Network ───────────────────────────────────────────────────────
-    while (client.poll()) {
+        physicsRan = true;
     }
 
-    // ── 5. Resolve camera from local player ──────────────────────────────
+    // ── 4. Bail out early if there is nothing new to render ───────────────
+    if (!unlimitedFPS && !physicsRan)
+        return SDL_APP_CONTINUE;
+
+    // ── 5. Resolve camera ─────────────────────────────────────────────────
     glm::vec3 renderEye{0.0f, 100.0f, 0.0f};
     float renderYaw = 0.0f;
     float renderPitch = 0.0f;
 
-    registry.view<LocalPlayer, Position, InputSnapshot, CollisionShape>().each(
-        [&](const Position& pos, const InputSnapshot& input, const CollisionShape& shape) {
-            const float eyeOffset = shape.halfExtents.y * 0.77f;
-            renderEye = pos.value + glm::vec3{0.0f, eyeOffset, 0.0f};
-            renderYaw = input.yaw;
-            renderPitch = input.pitch;
-        });
+    if (unlimitedFPS) {
+        // Interpolation alpha: 0 = just ran a tick, 1 = about to run the next one.
+        const float alpha = std::clamp(accumulator / k_physicsDt, 0.0f, 1.0f);
 
-    // ── 6. Frame recording (R key) ───────────────────────────────────────
-    if (recorder.isRecording()) {
+        registry.view<LocalPlayer, Position, PreviousPosition, InputSnapshot, CollisionShape>().each(
+            [&](const Position& pos,
+                const PreviousPosition& prev,
+                const InputSnapshot& input,
+                const CollisionShape& shape) {
+                const glm::vec3 interpPos = glm::mix(prev.value, pos.value, alpha);
+                const float eyeOffset = shape.halfExtents.y * 0.77f;
+                renderEye = interpPos + glm::vec3{0.0f, eyeOffset, 0.0f};
+
+                if (inputSyncedWithPhysics) {
+                    // Yaw only updates on tick boundaries — interpolate between
+                    // prevTickYaw (end of last tick) and yaw (end of this tick).
+                    renderYaw = input.prevTickYaw + (input.yaw - input.prevTickYaw) * alpha;
+                    renderPitch = input.prevTickPitch + (input.pitch - input.prevTickPitch) * alpha;
+                } else {
+                    // Yaw is already updated every frame — use it directly.
+                    renderYaw = input.yaw;
+                    renderPitch = input.pitch;
+                }
+            });
+    } else {
+        // Sequential mode: render directly from post-tick physics state.
+        registry.view<LocalPlayer, Position, InputSnapshot, CollisionShape>().each(
+            [&](const Position& pos, const InputSnapshot& input, const CollisionShape& shape) {
+                const float eyeOffset = shape.halfExtents.y * 0.77f;
+                renderEye = pos.value + glm::vec3{0.0f, eyeOffset, 0.0f};
+                renderYaw = input.yaw;
+                renderPitch = input.pitch;
+            });
+    }
+
+    // ── 6. Frame recording (R key) — anchored to physics ticks ───────────
+    if (physicsRan && recorder.isRecording()) {
         FrameState state;
         state.frameNumber = frameCount;
         state.timestamp = static_cast<double>(SDL_GetTicks()) / 1000.0 - recorder.startTimeSecs();
@@ -273,8 +316,9 @@ SDL_AppResult Game::iterate()
 
     ++frameCount;
 
-    // ── 7. Render ────────────────────────────────────────────────────────
-    debugUI.buildUI(registry, tickCount);
+    // ── 7. Render ─────────────────────────────────────────────────────────
+    debugUI.newFrame();
+    debugUI.buildUI(registry, tickCount, mouseSensitivity, unlimitedFPS, inputSyncedWithPhysics);
     debugUI.render();
     renderer.drawFrame(renderEye, renderYaw, renderPitch);
 

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -144,75 +144,73 @@ SDL_AppResult Game::event(SDL_Event* event)
     return SDL_APP_CONTINUE;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// iterate() — fully synchronised: input → physics → render, all at 128 Hz.
+//
+// Every rendered frame corresponds to exactly one physics tick.  Mouse deltas
+// accumulate via SDL between ticks and are applied in the same step as the
+// position update, so yaw and position are always on the same timebase.
+// This eliminates the jitter caused by yaw advancing at the frame rate while
+// position only updates at the tick rate.
+//
+// SDL calls iterate() as fast as possible; if the accumulator hasn't reached
+// k_physicsDt yet, we return immediately (no render, no physics).
+// ═══════════════════════════════════════════════════════════════════════════
+
 SDL_AppResult Game::iterate()
 {
-    // ImGui frame start — must happen before any ImGui calls this frame.
-    debugUI.newFrame();
-
-    // Sample input once per frame before the physics loop.
-    // Mouse deltas are consumed here; running inside the loop would
-    // accumulate them multiple times per frame at high frame rates.
-    if (mouseCaptured)
-        systems::runInputSample(registry);
-
-    // Compute frame time.
+    // ── accumulate real elapsed time ──────────────────────────────────────
     const Uint64 k_perfFreq = SDL_GetPerformanceFrequency();
     const Uint64 k_now = SDL_GetPerformanceCounter();
 
-    float frameTime = 0.0f;
-    if (recorder.isRecording()) {
-        // During recording, lock frameTime to exactly one physics tick.
-        // Screenshot saves (SDL_WaitForGPUIdle + PNG encode) can take 20–30 ms;
-        // if that wall-clock delay leaked into the accumulator it would fire
-        // 3–4 ticks instead of 1, making the player lurch between captured
-        // frames and producing a completely different jitter pattern.
-        // With a fixed dt the game slows down in wall time but every rendered
-        // frame gets identical physics treatment to a normal ~128 fps frame.
-        frameTime = k_physicsDt;
-    } else {
-        frameTime = static_cast<float>(k_now - prevTime) / static_cast<float>(k_perfFreq);
-        frameTime = std::min(frameTime, 0.25f); // clamp to avoid spiral-of-death
-    }
+    float frameTime = static_cast<float>(k_now - prevTime) / static_cast<float>(k_perfFreq);
+    frameTime = std::min(frameTime, 0.25f); // cap to avoid spiral-of-death
     prevTime = k_now;
     accumulator += frameTime;
 
-    // Fixed-step physics loop.
-    while (accumulator >= k_physicsDt) {
-        // Snapshot positions for sub-tick interpolation.
-        registry.view<Position, PreviousPosition>().each(
-            [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
+    // ── gate: wait until a full tick has elapsed ─────────────────────────
+    if (accumulator < k_physicsDt)
+        return SDL_APP_CONTINUE;
 
-        // Snapshot yaw/pitch for sub-tick interpolation.
-        // Mirrors the PreviousPosition pattern: prevTickYaw/Pitch hold the
-        // orientation at the START of this tick so the renderer can interpolate
-        // orientation with the same alpha as position — keeping eye and look-
-        // direction on the same timebase and eliminating strafe+rotate jitter.
-        registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
-            snap.prevTickYaw = snap.yaw;
-            snap.prevTickPitch = snap.pitch;
-        });
+    // Consume exactly one tick.  Discard any backlog beyond one extra tick
+    // so we never run two ticks in a single iterate() call.
+    accumulator -= k_physicsDt;
+    if (accumulator > k_physicsDt)
+        accumulator = k_physicsDt;
 
-        systems::runMovement(registry, k_physicsDt);
-        systems::runCollision(registry, k_physicsDt, k_worldPlanes);
+    // ── 1. ImGui frame start ─────────────────────────────────────────────
+    debugUI.newFrame();
 
-        accumulator -= k_physicsDt;
-        ++tickCount;
-    }
+    // ── 2. Sample input ──────────────────────────────────────────────────
+    // SDL_GetRelativeMouseState returns the accumulated mouse delta since the
+    // last call.  Because we only call it here (once per tick), the delta
+    // naturally covers the full period since the previous tick — no partial
+    // or duplicate deltas.  Yaw and position now update in the same step.
+    if (mouseCaptured)
+        systems::runInputSample(registry);
 
-    // Network receive.
+    // ── 3. Physics tick ──────────────────────────────────────────────────
+    registry.view<Position, PreviousPosition>().each(
+        [](const Position& pos, PreviousPosition& prev) { prev.value = pos.value; });
+
+    registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
+        snap.prevTickYaw = snap.yaw;
+        snap.prevTickPitch = snap.pitch;
+    });
+
+    systems::runMovement(registry, k_physicsDt);
+    systems::runCollision(registry, k_physicsDt, k_worldPlanes);
+    ++tickCount;
+
+    // ── 4. Network ───────────────────────────────────────────────────────
     while (client.poll()) {
     }
 
-    // ── resolve first-person camera from local player ──────────────────────
-    // Default eye position used before the player entity is available.
+    // ── 5. Resolve camera from local player ──────────────────────────────
     glm::vec3 renderEye{0.0f, 100.0f, 0.0f};
     float renderYaw = 0.0f;
     float renderPitch = 0.0f;
 
-    // Use the physics position directly — no interpolation, no extrapolation.
-    // The position is updated at 128 Hz by the physics loop; the renderer just
-    // reads whatever the last completed tick produced.  Mouse look still updates
-    // at the full frame rate so camera rotation stays responsive.
     registry.view<LocalPlayer, Position, InputSnapshot, CollisionShape>().each(
         [&](const Position& pos, const InputSnapshot& input, const CollisionShape& shape) {
             const float eyeOffset = shape.halfExtents.y * 0.77f;
@@ -221,7 +219,7 @@ SDL_AppResult Game::iterate()
             renderPitch = input.pitch;
         });
 
-    // ── frame recording (R key) ───────────────────────────────────────────────
+    // ── 6. Frame recording (R key) ───────────────────────────────────────
     if (recorder.isRecording()) {
         FrameState state;
         state.frameNumber = frameCount;
@@ -231,7 +229,6 @@ SDL_AppResult Game::iterate()
         state.renderYaw = renderYaw;
         state.renderPitch = renderPitch;
 
-        // Pull physics pos/vel and raw yaw/pitch from the registry.
         registry.view<LocalPlayer, Position, Velocity, InputSnapshot>().each(
             [&](const Position& pos, const Velocity& vel, const InputSnapshot& input) {
                 state.physPos = pos.value;
@@ -240,8 +237,6 @@ SDL_AppResult Game::iterate()
                 state.pitch = input.pitch;
             });
 
-        // Compute screen-space (pixel) coords of key world objects so the CSV
-        // directly shows oscillation without manual projection math.
         int winW = 0, winH = 0;
         SDL_GetWindowSizeInPixels(window, &winW, &winH);
         const float winWf = static_cast<float>(winW);
@@ -264,7 +259,6 @@ SDL_AppResult Game::iterate()
         state.cubeScreen = toScreen(glm::vec3{0.0f, 32.0f, 400.0f});
         state.modelScreen = toScreen(glm::vec3{200.0f, 0.0f, 400.0f});
 
-        // Request a screenshot from the renderer (saved synchronously at drawFrame).
         char capPath[512];
         std::snprintf(capPath,
                       sizeof(capPath),
@@ -279,7 +273,7 @@ SDL_AppResult Game::iterate()
 
     ++frameCount;
 
-    // Build debug UI and render.
+    // ── 7. Render ────────────────────────────────────────────────────────
     debugUI.buildUI(registry, tickCount);
     debugUI.render();
     renderer.drawFrame(renderEye, renderYaw, renderPitch);
@@ -289,6 +283,8 @@ SDL_AppResult Game::iterate()
 
 void Game::quit()
 {
+    if (recorder.isRecording())
+        recorder.stopRecording();
     renderer.quit();
     debugUI.shutdown();
     client.shutdown();

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -152,19 +152,37 @@ SDL_AppResult Game::event(SDL_Event* event)
 // ═══════════════════════════════════════════════════════════════════════════
 // iterate() — decoupled physics / render loop.
 //
-// Physics runs at a fixed 128 Hz behind an accumulator gate.  Up to
-// k_maxTicksPerFrame ticks are processed per call so physics catches up
-// even when the OS only calls iterate() at monitor refresh rate (e.g. 60 Hz).
+// Physics ALWAYS runs at exactly 128 Hz (k_physicsHz) using an accumulator
+// with a multi-tick catch-up loop (up to k_maxTicksPerFrame per call).
+// This is non-negotiable: it must match the server tick rate.
+//
+// Input is split into two independent streams:
+//
+//   Mouse look (yaw / pitch) — sampled EVERY iterate() call so camera
+//       rotation is perfectly smooth at whatever frame rate the renderer
+//       produces.  The camera always uses the latest yaw directly (never
+//       interpolated).  Interpolating yaw with the physics alpha creates a
+//       timebase mismatch on multi-tick or zero-tick frames, producing
+//       visible jitter.
+//
+//   Movement keys (WASD / jump / crouch) — sampled once per physics tick
+//       group when inputSyncedWithPhysics is true (the default) so
+//       movement calculations match the server.  When the toggle is off,
+//       keys are also sampled every iterate() call.
+//
+// Position interpolation uses alpha = accumulator / k_physicsDt across the
+// LAST physics tick (PreviousPosition is saved inside the while loop before
+// each tick).
 //
 // Three ImGui-tunable flags:
 //
 //   renderSeparateFromPhysics — render every iterate() call with position
 //       interpolated between the last two physics ticks (true, default) vs.
-//       render only after a physics tick (false, caps fps at 128 Hz).
+//       render only after a physics tick (false, caps render fps at 128 Hz).
 //
-//   inputSyncedWithPhysics — sample SDL mouse once per physics frame-group
-//       so yaw and position share the same timebase (true, default, no jitter)
-//       vs. sample every iterate() call (false, yaw at frame rate).
+//   inputSyncedWithPhysics — sample movement keys once per tick group
+//       (true, default, server-consistent) vs. every iterate() call (false).
+//       Mouse look is always per-frame regardless of this toggle.
 //
 //   limitFPSToMonitor — VSync on (true) / off (false, default).
 // ═══════════════════════════════════════════════════════════════════════════
@@ -210,25 +228,30 @@ SDL_AppResult Game::iterate()
         statsFPSCurrent = fpsHistory[(fpsHistoryHead - 1 + k_fpsHistorySize) % k_fpsHistorySize];
     }
 
-    // ── 3. Input — sample every frame when NOT synced with physics ────────
-    if (!inputSyncedWithPhysics && mouseCaptured)
-        systems::runInputSample(registry, mouseSensitivity);
+    // ── 3. Input ───────────────────────────────────────────────────────────
+    //
+    // Mouse look runs EVERY iterate() call — this keeps camera rotation
+    // perfectly smooth at whatever frame rate the renderer is producing.
+    // SDL_GetRelativeMouseState returns accumulated delta since last call,
+    // so total rotation is identical regardless of call frequency.
+    //
+    // Movement keys run once per physics tick group (when inputSyncedWithPhysics
+    // is true) so WASD movement calculations match the server.  When the
+    // sync toggle is off, movement keys also run every frame.
+    if (mouseCaptured) {
+        systems::runMouseLook(registry, mouseSensitivity);
+        if (!inputSyncedWithPhysics)
+            systems::runMovementKeys(registry);
+    }
 
-    // ── 4. Physics — run up to k_maxTicksPerFrame ticks to catch up ───────
+    // ── 4. Physics — always 128 Hz, up to k_maxTicksPerFrame catch-up ─────
     bool physicsRan = false;
     int ticksThisFrame = 0;
 
     if (accumulator >= k_physicsDt) {
-        // Snapshot orientation BEFORE this frame's input so prevTickYaw holds
-        // the end-of-previous-frame yaw — needed for correct view interpolation.
-        registry.view<InputSnapshot, LocalPlayer>().each([](InputSnapshot& snap) {
-            snap.prevTickYaw = snap.yaw;
-            snap.prevTickPitch = snap.pitch;
-        });
-
-        // Input synced with physics: sample once for this whole group of ticks.
+        // Movement keys: sample once for this whole group of ticks.
         if (inputSyncedWithPhysics && mouseCaptured)
-            systems::runInputSample(registry, mouseSensitivity);
+            systems::runMovementKeys(registry);
 
         while (accumulator >= k_physicsDt && ticksThisFrame < k_maxTicksPerFrame) {
             accumulator -= k_physicsDt;
@@ -273,15 +296,18 @@ SDL_AppResult Game::iterate()
                 const float eyeOffset = shape.halfExtents.y * 0.77f;
                 renderEye = interpPos + glm::vec3{0.0f, eyeOffset, 0.0f};
 
-                if (inputSyncedWithPhysics) {
-                    // Yaw changes only at tick boundaries — lerp across the sub-tick gap.
-                    renderYaw = input.prevTickYaw + (input.yaw - input.prevTickYaw) * alpha;
-                    renderPitch = input.prevTickPitch + (input.pitch - input.prevTickPitch) * alpha;
-                } else {
-                    // Yaw already updated every frame — use directly.
-                    renderYaw = input.yaw;
-                    renderPitch = input.pitch;
-                }
+                // Yaw is always used directly — no interpolation.
+                //
+                // When inputSyncedWithPhysics, yaw updates once per frame-group
+                // (whenever the physics gate fires).  Interpolating yaw with the
+                // *position* alpha is incorrect: position alpha spans one physics
+                // tick, but yaw spans one frame of mouse input.  On multi-tick
+                // or zero-tick frames the two timebases diverge, causing objects
+                // to visually jitter.  Using yaw directly gives a consistent
+                // per-frame rotation rate at the input sample rate (≥128 Hz with
+                // VSync, or frame rate without), which is already smooth.
+                renderYaw = input.yaw;
+                renderPitch = input.pitch;
             });
     } else {
         // Sequential mode: use post-tick state directly (no interpolation).

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -159,9 +159,21 @@ SDL_AppResult Game::iterate()
     const Uint64 k_perfFreq = SDL_GetPerformanceFrequency();
     const Uint64 k_now = SDL_GetPerformanceCounter();
 
-    float frameTime = static_cast<float>(k_now - prevTime) / static_cast<float>(k_perfFreq);
+    float frameTime = 0.0f;
+    if (recorder.isRecording()) {
+        // During recording, lock frameTime to exactly one physics tick.
+        // Screenshot saves (SDL_WaitForGPUIdle + PNG encode) can take 20–30 ms;
+        // if that wall-clock delay leaked into the accumulator it would fire
+        // 3–4 ticks instead of 1, making the player lurch between captured
+        // frames and producing a completely different jitter pattern.
+        // With a fixed dt the game slows down in wall time but every rendered
+        // frame gets identical physics treatment to a normal ~128 fps frame.
+        frameTime = k_physicsDt;
+    } else {
+        frameTime = static_cast<float>(k_now - prevTime) / static_cast<float>(k_perfFreq);
+        frameTime = std::min(frameTime, 0.25f); // clamp to avoid spiral-of-death
+    }
     prevTime = k_now;
-    frameTime = std::min(frameTime, 0.25f); // clamp to avoid spiral-of-death
     accumulator += frameTime;
 
     // Fixed-step physics loop.

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -15,6 +15,9 @@
 
 #include <SDL3_net/SDL_net.h>
 #include <algorithm>
+#include <cstdio>
+#include <glm/ext/matrix_clip_space.hpp>
+#include <glm/ext/matrix_transform.hpp>
 #include <glm/glm.hpp>
 
 // World geometry for the current test scene: a single floor plane at y=0.
@@ -97,6 +100,21 @@ SDL_AppResult Game::event(SDL_Event* event)
         switch (event->key.key) {
         case SDLK_Q:
             return SDL_APP_SUCCESS;
+
+        // R — toggle frame recording (state CSV + per-frame PNG screenshots).
+        // Output lands in <binary_dir>/recordings/<timestamp>/ next to the game.
+        case SDLK_R: {
+            if (recorder.isRecording()) {
+                recorder.stopRecording();
+                SDL_Log("[client] recording stopped");
+            } else {
+                const char* base = SDL_GetBasePath();
+                std::string baseDir = std::string(base ? base : "") + "recordings";
+                recorder.startRecording(baseDir);
+                SDL_Log("[client] recording started → %s", recorder.sessionDir().c_str());
+            }
+            break;
+        }
 
         // ESC — toggle mouse capture so the player can reach the ImGui windows.
         case SDLK_ESCAPE:
@@ -190,6 +208,64 @@ SDL_AppResult Game::iterate()
             renderYaw = input.yaw;
             renderPitch = input.pitch;
         });
+
+    // ── frame recording (R key) ───────────────────────────────────────────────
+    if (recorder.isRecording()) {
+        FrameState state;
+        state.frameNumber = frameCount;
+        state.timestamp = static_cast<double>(SDL_GetTicks()) / 1000.0 - recorder.startTimeSecs();
+        state.tickCount = tickCount;
+        state.renderEye = renderEye;
+        state.renderYaw = renderYaw;
+        state.renderPitch = renderPitch;
+
+        // Pull physics pos/vel and raw yaw/pitch from the registry.
+        registry.view<LocalPlayer, Position, Velocity, InputSnapshot>().each(
+            [&](const Position& pos, const Velocity& vel, const InputSnapshot& input) {
+                state.physPos = pos.value;
+                state.physVel = vel.value;
+                state.yaw = input.yaw;
+                state.pitch = input.pitch;
+            });
+
+        // Compute screen-space (pixel) coords of key world objects so the CSV
+        // directly shows oscillation without manual projection math.
+        int winW = 0, winH = 0;
+        SDL_GetWindowSizeInPixels(window, &winW, &winH);
+        const float winWf = static_cast<float>(winW);
+        const float winHf = static_cast<float>(winH);
+
+        const float cosPitch = std::cos(renderPitch);
+        const glm::vec3 fwd{std::sin(renderYaw) * cosPitch, -std::sin(renderPitch), std::cos(renderYaw) * cosPitch};
+        const glm::mat4 view = glm::lookAt(renderEye, renderEye + fwd, glm::vec3{0, 1, 0});
+        const glm::mat4 proj =
+            glm::perspective(glm::radians(60.0f), (winHf > 0.0f) ? winWf / winHf : 1.0f, 5.0f, 15000.0f);
+        const glm::mat4 vp = proj * view;
+
+        const auto toScreen = [&](glm::vec3 p) -> glm::vec2 {
+            const glm::vec4 clip = vp * glm::vec4(p, 1.0f);
+            if (clip.w <= 0.0f)
+                return {-1.0f, -1.0f};
+            const glm::vec3 ndc = glm::vec3(clip) / clip.w;
+            return {(ndc.x * 0.5f + 0.5f) * winWf, (1.0f - (ndc.y * 0.5f + 0.5f)) * winHf};
+        };
+        state.cubeScreen = toScreen(glm::vec3{0.0f, 32.0f, 400.0f});
+        state.modelScreen = toScreen(glm::vec3{200.0f, 0.0f, 400.0f});
+
+        // Request a screenshot from the renderer (saved synchronously at drawFrame).
+        char capPath[512];
+        std::snprintf(capPath,
+                      sizeof(capPath),
+                      "%s/frame_%06llu.png",
+                      recorder.sessionDir().c_str(),
+                      static_cast<unsigned long long>(frameCount));
+        state.screenshotPath = capPath;
+        renderer.requestScreenshot(capPath);
+
+        recorder.recordFrame(state);
+    }
+
+    ++frameCount;
 
     // Build debug UI and render.
     debugUI.buildUI(registry, tickCount);

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -179,41 +179,14 @@ SDL_AppResult Game::iterate()
     float renderYaw = 0.0f;
     float renderPitch = 0.0f;
 
-    // ── velocity extrapolation ────────────────────────────────────────────────
-    // Why not interpolation (mix(prev, pos, alpha))?
-    //
-    // Interpolation has a discontinuous jump of magnitude V*frameTime at every
-    // physics-tick boundary.  Here's the math:
-    //
-    //   Frame N  (no tick fires): renderEye = mix(prev, pos, α₀)        e.g. α₀ = 0.64
-    //   Frame N+1 (tick fires):   renderEye = mix(pos,  pos', α₁)       e.g. α₁ = 0.28
-    //     jump = pos + α₁·Δ − (prev + α₀·Δ)  =  Δ·(1 + α₁ − α₀)  =  V·frameTime
-    //
-    // At 400 u/s strafe speed and 5 ms frames that's ~2 world-units sideways
-    // every 7.8 ms (128 Hz physics tick) — clearly visible when orbiting because
-    // the eye is expected to stay fixed relative to the object.
-    //
-    // Velocity extrapolation — renderEye(t) = pos + vel·(t − t_lastTick) — is a
-    // continuous linear function of time.  Proof that it has no tick-boundary jump:
-    //
-    //   Before tick:  pos_T  + vel·acc
-    //   After tick:   pos_T+1 + vel·(acc + frameTime − dt)
-    //               = (pos_T + vel·dt) + vel·(acc + frameTime − dt)
-    //               = pos_T + vel·acc + vel·frameTime   ← same up to vel·frameTime
-    //
-    // Both frames add exactly vel·frameTime, so the position advances smoothly and
-    // there is no backwards snap.  The yaw is the frame's current value (no lag),
-    // which is consistent: both eye and look-direction are at "now".
-    registry.view<LocalPlayer, Position, Velocity, InputSnapshot, CollisionShape>().each(
-        [&](const Position& pos, const Velocity& vel, const InputSnapshot& input, const CollisionShape& shape) {
-            // Extrapolate position forward from last physics tick using current velocity.
-            const glm::vec3 extrapolated = pos.value + vel.value * accumulator;
-
-            // Eye sits at ~77 % of the AABB half-height above the centre
-            // (≈ 64 units from feet for a standing player — standard FPS height).
-            // This adapts automatically to crouching (halfExtents.y shrinks to 22).
+    // Use the physics position directly — no interpolation, no extrapolation.
+    // The position is updated at 128 Hz by the physics loop; the renderer just
+    // reads whatever the last completed tick produced.  Mouse look still updates
+    // at the full frame rate so camera rotation stays responsive.
+    registry.view<LocalPlayer, Position, InputSnapshot, CollisionShape>().each(
+        [&](const Position& pos, const InputSnapshot& input, const CollisionShape& shape) {
             const float eyeOffset = shape.halfExtents.y * 0.77f;
-            renderEye = extrapolated + glm::vec3{0.0f, eyeOffset, 0.0f};
+            renderEye = pos.value + glm::vec3{0.0f, eyeOffset, 0.0f};
             renderYaw = input.yaw;
             renderPitch = input.pitch;
         });

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "debug/DebugUI.hpp"
+#include "debug/FrameRecorder.hpp"
 #include "ecs/registry/Registry.hpp"
 #include "network/Client.hpp"
 #include "renderer/Renderer.hpp"
@@ -45,4 +46,7 @@ private:
     float accumulator = 0.0f;  ///< Unprocessed physics time in seconds.
     int tickCount = 0;         ///< Total physics ticks elapsed since start.
     bool mouseCaptured = true; ///< True when relative mouse mode is active.
+
+    FrameRecorder recorder;    ///< R-key toggled frame-state + screenshot recorder.
+    uint64_t frameCount = 0;   ///< Monotonic render-frame counter.
 };

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -47,6 +47,13 @@ private:
     int tickCount = 0;         ///< Total physics ticks elapsed since start.
     bool mouseCaptured = true; ///< True when relative mouse mode is active.
 
-    FrameRecorder recorder;    ///< R-key toggled frame-state + screenshot recorder.
-    uint64_t frameCount = 0;   ///< Monotonic render-frame counter.
+    // ── runtime-tunable loop settings (exposed via ImGui) ────────────────────
+    float mouseSensitivity = 0.002f;    ///< Radians of view rotation per pixel of mouse movement.
+    bool unlimitedFPS = true;           ///< When true, render every iterate() call using interpolated
+                                        ///  PreviousPosition; when false, render only on physics ticks.
+    bool inputSyncedWithPhysics = true; ///< When true, mouse is sampled once per physics tick (no
+                                        ///  jitter); when false, mouse is sampled every iterate() call.
+
+    FrameRecorder recorder;             ///< R-key toggled frame-state + screenshot recorder.
+    uint64_t frameCount = 0;            ///< Monotonic render-frame counter.
 };

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -32,28 +32,46 @@ public:
     void quit();
 
 private:
-    static constexpr int k_physicsHz =
-        128; ///< Physics tick rate. The renderer interpolates between ticks using the accumulator.
-    static constexpr float k_physicsDt = 1.0f / static_cast<float>(k_physicsHz); ///< Seconds per physics tick.
+    static constexpr int k_physicsHz = 128;                                      ///< Target physics tick rate.
+    static constexpr float k_physicsDt = 1.0f / static_cast<float>(k_physicsHz); ///< Seconds per tick.
+    static constexpr int k_maxTicksPerFrame = 8; ///< Spiral-of-death guard: max physics ticks per iterate().
+    static constexpr int k_fpsHistorySize = 512; ///< Samples in the rolling FPS ring buffer.
 
-    SDL_Window* window = nullptr;                                                ///< The application window.
-    DebugUI debugUI;           ///< Owns the ImGui context and SDL3 input backend.
-    Renderer renderer;         ///< Owns the GPU pipeline and ImGui render backend.
-    Registry registry;         ///< The shared ECS registry.
-    Client client;             ///< UDP network client.
+    SDL_Window* window = nullptr;                ///< The application window.
+    DebugUI debugUI;                             ///< Owns the ImGui context and SDL3 input backend.
+    Renderer renderer;                           ///< Owns the GPU pipeline and ImGui render backend.
+    Registry registry;                           ///< The shared ECS registry.
+    Client client;                               ///< UDP network client.
 
-    Uint64 prevTime = 0;       ///< SDL performance counter at the last iterate() call.
-    float accumulator = 0.0f;  ///< Unprocessed physics time in seconds.
-    int tickCount = 0;         ///< Total physics ticks elapsed since start.
-    bool mouseCaptured = true; ///< True when relative mouse mode is active.
+    Uint64 prevTime = 0;                         ///< SDL performance counter at the last iterate() call.
+    float accumulator = 0.0f;                    ///< Unprocessed physics time in seconds.
+    int tickCount = 0;                           ///< Total physics ticks elapsed since start.
+    bool mouseCaptured = true;                   ///< True when relative mouse mode is active.
 
     // ── runtime-tunable loop settings (exposed via ImGui) ────────────────────
-    float mouseSensitivity = 0.002f;    ///< Radians of view rotation per pixel of mouse movement.
-    bool unlimitedFPS = true;           ///< When true, render every iterate() call using interpolated
-                                        ///  PreviousPosition; when false, render only on physics ticks.
-    bool inputSyncedWithPhysics = true; ///< When true, mouse is sampled once per physics tick (no
-                                        ///  jitter); when false, mouse is sampled every iterate() call.
+    float mouseSensitivity = 0.001f;       ///< Radians per pixel of mouse movement.
+    bool renderSeparateFromPhysics = true; ///< Render every iterate() with interpolation (true)
+                                           ///  vs only after a physics tick (false).
+    bool inputSyncedWithPhysics = true;    ///< Sample mouse once per physics tick (true)
+                                           ///  vs every iterate() call (false).
+    bool limitFPSToMonitor = false;        ///< VSync on (true) / off (false).
 
-    FrameRecorder recorder;             ///< R-key toggled frame-state + screenshot recorder.
-    uint64_t frameCount = 0;            ///< Monotonic render-frame counter.
+    FrameRecorder recorder;                ///< R-key toggled frame-state + screenshot recorder.
+    uint64_t frameCount = 0;               ///< Monotonic render-frame counter.
+
+    // ── FPS ring buffer — inter-render deltas, newest at (head-1) % size ─────
+    float fpsHistory[k_fpsHistorySize] = {}; ///< Circular buffer of per-frame FPS samples.
+    int fpsHistoryHead = 0;                  ///< Next write index.
+    int fpsHistoryCount = 0;                 ///< Valid sample count (saturates at k_fpsHistorySize).
+    Uint64 prevRenderTime = 0;               ///< Perf counter at the last render call.
+
+    // ── Performance stats — refreshed every 0.5 s ───────────────────────────
+    Uint64 statsPrevTime = 0;       ///< Perf counter at the last stats snapshot.
+    int statsPhysTicks = 0;         ///< Physics ticks accumulated since last snapshot.
+    float measuredPhysicsHz = 0.0f; ///< Computed physics rate (Hz).
+    float statsFPSCurrent = 0.0f;   ///< Most-recent render FPS sample.
+    float statsFPSMin = 0.0f;       ///< Minimum FPS in the ring buffer.
+    float statsFPSMax = 0.0f;       ///< Maximum FPS in the ring buffer.
+    float statsFPS1pLow = 0.0f;     ///< 1st-percentile FPS (1 % low).
+    float statsFPS5pLow = 0.0f;     ///< 5th-percentile FPS (5 % low).
 };

--- a/src/client/renderer/ModelLoader.cpp
+++ b/src/client/renderer/ModelLoader.cpp
@@ -2,8 +2,25 @@
 
 #include <SDL3/SDL_log.h>
 
-// Assimp headers trigger several warnings that are not our code to fix.
-// Suppress them cleanly rather than disabling whole-file warnings.
+// ---------------------------------------------------------------------------
+// stb_image — single-header PNG/JPEG/etc. decoder.
+// Define the implementation in exactly this one translation unit.
+// ---------------------------------------------------------------------------
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+#define STB_IMAGE_IMPLEMENTATION
+#include <stb_image.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+// ---------------------------------------------------------------------------
+// Assimp headers — suppress clang/gcc warnings from third-party code.
+// ---------------------------------------------------------------------------
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -18,25 +35,134 @@
 #pragma GCC diagnostic pop
 #endif
 
-bool loadModel(const std::string& path, std::vector<MeshData>& outMeshes)
+namespace
+{
+
+/// @brief Try to decode an Assimp embedded texture into RGBA pixels.
+/// @return True on success (pushes one TextureData into @p textures).
+bool decodeEmbeddedTexture(const aiTexture* embTex, std::vector<TextureData>& textures)
+{
+    if (!embTex)
+        return false;
+
+    TextureData td;
+
+    if (embTex->mHeight == 0) {
+        // Compressed format (PNG / JPEG / …) stored as a raw byte blob.
+        int ch = 0;
+        stbi_uc* raw = stbi_load_from_memory(reinterpret_cast<const stbi_uc*>(embTex->pcData),
+                                             static_cast<int>(embTex->mWidth),
+                                             &td.width,
+                                             &td.height,
+                                             &ch,
+                                             4); // force RGBA output
+
+        if (!raw) {
+            SDL_Log("ModelLoader: stb_image failed to decode embedded texture: %s", stbi_failure_reason());
+            return false;
+        }
+
+        td.pixels.assign(raw, raw + static_cast<size_t>(td.width) * static_cast<size_t>(td.height) * 4);
+        stbi_image_free(raw);
+    } else {
+        // Raw BGRA8888 data — convert to RGBA.
+        td.width = static_cast<int>(embTex->mWidth);
+        td.height = static_cast<int>(embTex->mHeight);
+        const size_t numPixels = static_cast<size_t>(td.width) * static_cast<size_t>(td.height);
+        td.pixels.resize(numPixels * 4);
+
+        for (size_t i = 0; i < numPixels; ++i) {
+            td.pixels[i * 4 + 0] = embTex->pcData[i].r;
+            td.pixels[i * 4 + 1] = embTex->pcData[i].g;
+            td.pixels[i * 4 + 2] = embTex->pcData[i].b;
+            td.pixels[i * 4 + 3] = embTex->pcData[i].a;
+        }
+    }
+
+    textures.push_back(std::move(td));
+    return true;
+}
+
+/// @brief Resolve the base-colour texture for @p mat and return its index
+///        inside @p textures (loading it if not already cached).
+/// @return The TextureData index, or -1 if the material has no colour texture.
+int resolveDiffuseTex(const aiMaterial* mat,
+                      const aiScene* scene,
+                      std::vector<TextureData>& textures,
+                      std::vector<int>& embTexToDataIdx)
+{
+    // GLTF 2.0 PBR base colour lives at aiTextureType_BASE_COLOR (Assimp 5+).
+    // Older/fallback path is aiTextureType_DIFFUSE.
+    for (aiTextureType type : {aiTextureType_BASE_COLOR, aiTextureType_DIFFUSE}) {
+        if (mat->GetTextureCount(type) == 0)
+            continue;
+
+        aiString texPath;
+        if (mat->GetTexture(type, 0, &texPath) != AI_SUCCESS)
+            continue;
+
+        // Embedded textures use path "*N" where N is the scene texture index.
+        const aiTexture* embTex = scene->GetEmbeddedTexture(texPath.C_Str());
+        if (!embTex)
+            continue;
+
+        // Compute the embedded-texture slot index so we can cache/deduplicate.
+        int embIdx = -1;
+        for (unsigned int i = 0; i < scene->mNumTextures; ++i) {
+            if (scene->mTextures[i] == embTex) {
+                embIdx = static_cast<int>(i);
+                break;
+            }
+        }
+
+        // Return cached entry if already decoded.
+        if (embIdx >= 0 && embIdx < static_cast<int>(embTexToDataIdx.size()) &&
+            embTexToDataIdx[static_cast<size_t>(embIdx)] >= 0)
+        {
+            return embTexToDataIdx[static_cast<size_t>(embIdx)];
+        }
+
+        // Decode and store.
+        const int dataIdx = static_cast<int>(textures.size());
+        if (decodeEmbeddedTexture(embTex, textures)) {
+            if (embIdx >= 0) {
+                if (static_cast<size_t>(embIdx) >= embTexToDataIdx.size())
+                    embTexToDataIdx.resize(static_cast<size_t>(embIdx) + 1, -1);
+                embTexToDataIdx[static_cast<size_t>(embIdx)] = dataIdx;
+            }
+            return dataIdx;
+        }
+        break;
+    }
+
+    return -1;
+}
+
+} // namespace
+
+bool loadModel(const std::string& path, LoadedModel& outModel)
 {
     Assimp::Importer importer;
 
-    // aiProcess_Triangulate     — convert quads / n-gons to triangles
-    // aiProcess_GenSmoothNormals — generate normals if the mesh lacks them
+    // aiProcess_Triangulate         — convert n-gons to triangles
+    // aiProcess_GenSmoothNormals     — generate normals only when missing
     // aiProcess_JoinIdenticalVertices — de-duplicate vertices
-    // aiProcess_FlipUVs         — flip V coordinate (OpenGL → SDL3 GPU convention)
+    // NOTE: aiProcess_FlipUVs is intentionally omitted — GLTF 2.0 and Vulkan
+    //       both use top-left (0,0) UV convention, so no flip is needed.
     const aiScene* scene =
         importer.ReadFile(path,
                           static_cast<unsigned int>(aiProcess_Triangulate | aiProcess_GenSmoothNormals |
-                                                    aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs));
+                                                    aiProcess_JoinIdenticalVertices));
 
     if (!scene || (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) || !scene->mRootNode) {
         SDL_Log("ModelLoader: failed to load '%s': %s", path.c_str(), importer.GetErrorString());
         return false;
     }
 
-    outMeshes.reserve(scene->mNumMeshes);
+    // Cache: embeddedTextureIndex → TextureData array index (-1 = not loaded yet)
+    std::vector<int> embTexToDataIdx(scene->mNumTextures, -1);
+
+    outModel.meshes.reserve(scene->mNumMeshes);
 
     for (unsigned int m = 0; m < scene->mNumMeshes; ++m) {
         const aiMesh* mesh = scene->mMeshes[m];
@@ -66,9 +192,19 @@ bool loadModel(const std::string& path, std::vector<MeshData>& outMeshes)
                 data.indices.push_back(face.mIndices[i]);
         }
 
-        outMeshes.push_back(std::move(data));
+        // Resolve base-colour texture for this mesh's material.
+        if (mesh->mMaterialIndex < scene->mNumMaterials) {
+            data.diffuseTexIndex =
+                resolveDiffuseTex(scene->mMaterials[mesh->mMaterialIndex], scene, outModel.textures, embTexToDataIdx);
+        }
+
+        outModel.meshes.push_back(std::move(data));
     }
 
-    SDL_Log("ModelLoader: loaded '%s' — %u mesh(es)", path.c_str(), static_cast<unsigned>(outMeshes.size()));
-    return !outMeshes.empty();
+    SDL_Log("ModelLoader: loaded '%s' — %u mesh(es), %u texture(s)",
+            path.c_str(),
+            static_cast<unsigned>(outModel.meshes.size()),
+            static_cast<unsigned>(outModel.textures.size()));
+
+    return !outModel.meshes.empty();
 }

--- a/src/client/renderer/ModelLoader.cpp
+++ b/src/client/renderer/ModelLoader.cpp
@@ -1,0 +1,74 @@
+#include "ModelLoader.hpp"
+
+#include <SDL3/SDL_log.h>
+
+// Assimp headers trigger several warnings that are not our code to fix.
+// Suppress them cleanly rather than disabling whole-file warnings.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#endif
+#include <assimp/Importer.hpp>
+#include <assimp/postprocess.h>
+#include <assimp/scene.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+bool loadModel(const std::string& path, std::vector<MeshData>& outMeshes)
+{
+    Assimp::Importer importer;
+
+    // aiProcess_Triangulate     — convert quads / n-gons to triangles
+    // aiProcess_GenSmoothNormals — generate normals if the mesh lacks them
+    // aiProcess_JoinIdenticalVertices — de-duplicate vertices
+    // aiProcess_FlipUVs         — flip V coordinate (OpenGL → SDL3 GPU convention)
+    const aiScene* scene =
+        importer.ReadFile(path,
+                          static_cast<unsigned int>(aiProcess_Triangulate | aiProcess_GenSmoothNormals |
+                                                    aiProcess_JoinIdenticalVertices | aiProcess_FlipUVs));
+
+    if (!scene || (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) || !scene->mRootNode) {
+        SDL_Log("ModelLoader: failed to load '%s': %s", path.c_str(), importer.GetErrorString());
+        return false;
+    }
+
+    outMeshes.reserve(scene->mNumMeshes);
+
+    for (unsigned int m = 0; m < scene->mNumMeshes; ++m) {
+        const aiMesh* mesh = scene->mMeshes[m];
+        if (!mesh->HasPositions() || mesh->mNumFaces == 0)
+            continue;
+
+        MeshData data;
+        data.vertices.reserve(mesh->mNumVertices);
+
+        for (unsigned int v = 0; v < mesh->mNumVertices; ++v) {
+            ModelVertex vert{};
+            vert.position = {mesh->mVertices[v].x, mesh->mVertices[v].y, mesh->mVertices[v].z};
+
+            if (mesh->HasNormals())
+                vert.normal = {mesh->mNormals[v].x, mesh->mNormals[v].y, mesh->mNormals[v].z};
+
+            if (mesh->mTextureCoords[0] != nullptr)
+                vert.texCoord = {mesh->mTextureCoords[0][v].x, mesh->mTextureCoords[0][v].y};
+
+            data.vertices.push_back(vert);
+        }
+
+        data.indices.reserve(static_cast<size_t>(mesh->mNumFaces) * 3);
+        for (unsigned int f = 0; f < mesh->mNumFaces; ++f) {
+            const aiFace& face = mesh->mFaces[f];
+            for (unsigned int i = 0; i < face.mNumIndices; ++i)
+                data.indices.push_back(face.mIndices[i]);
+        }
+
+        outMeshes.push_back(std::move(data));
+    }
+
+    SDL_Log("ModelLoader: loaded '%s' — %u mesh(es)", path.c_str(), static_cast<unsigned>(outMeshes.size()));
+    return !outMeshes.empty();
+}

--- a/src/client/renderer/ModelLoader.hpp
+++ b/src/client/renderer/ModelLoader.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <glm/glm.hpp>
+#include <string>
+#include <vector>
+
+/// @brief One vertex in a loaded 3-D model.
+/// Layout (32 bytes, no padding):
+///   offset  0 — position  (vec3, 12 B)
+///   offset 12 — normal    (vec3, 12 B)
+///   offset 24 — texCoord  (vec2,  8 B)
+struct ModelVertex
+{
+    glm::vec3 position;
+    glm::vec3 normal;
+    glm::vec2 texCoord;
+};
+
+static_assert(sizeof(ModelVertex) == 32, "ModelVertex size mismatch — check padding");
+static_assert(offsetof(ModelVertex, normal) == 12, "ModelVertex normal offset mismatch");
+static_assert(offsetof(ModelVertex, texCoord) == 24, "ModelVertex texCoord offset mismatch");
+
+/// @brief CPU-side mesh data ready for GPU upload.
+struct MeshData
+{
+    std::vector<ModelVertex> vertices;
+    std::vector<uint32_t> indices;
+};
+
+/// @brief Load a model file via Assimp and populate @p outMeshes.
+///
+/// All meshes are triangulated, normals are (re-)generated if missing, and
+/// duplicate vertices are merged.  UV coordinates are V-flipped for SDL3 GPU
+/// conventions.
+///
+/// @param path      Absolute path to the model file.
+/// @param outMeshes Receives one MeshData per mesh found in the file.
+/// @return True on success; false on failure (error logged via SDL_Log).
+bool loadModel(const std::string& path, std::vector<MeshData>& outMeshes);

--- a/src/client/renderer/ModelLoader.hpp
+++ b/src/client/renderer/ModelLoader.hpp
@@ -27,15 +27,31 @@ struct MeshData
 {
     std::vector<ModelVertex> vertices;
     std::vector<uint32_t> indices;
+    int diffuseTexIndex = -1; ///< Index into LoadedModel::textures, or -1 if none.
 };
 
-/// @brief Load a model file via Assimp and populate @p outMeshes.
+/// @brief RGBA pixel data for one texture (decoded from embedded PNG/JPEG).
+struct TextureData
+{
+    std::vector<uint8_t> pixels; ///< Row-major RGBA, 4 bytes per pixel.
+    int width = 0;
+    int height = 0;
+};
+
+/// @brief Everything returned by loadModel().
+struct LoadedModel
+{
+    std::vector<MeshData> meshes;
+    std::vector<TextureData> textures;
+};
+
+/// @brief Load a model file via Assimp and decode its embedded textures.
 ///
-/// All meshes are triangulated, normals are (re-)generated if missing, and
-/// duplicate vertices are merged.  UV coordinates are V-flipped for SDL3 GPU
-/// conventions.
+/// Each mesh in @p outModel.meshes has a @c diffuseTexIndex pointing into
+/// @p outModel.textures, or -1 when no base-colour texture is available.
+/// Textures are decoded to RGBA via stb_image.
 ///
-/// @param path      Absolute path to the model file.
-/// @param outMeshes Receives one MeshData per mesh found in the file.
+/// @param path     Absolute path to the model file (GLB, OBJ, FBX, …).
+/// @param outModel Filled on success.
 /// @return True on success; false on failure (error logged via SDL_Log).
-bool loadModel(const std::string& path, std::vector<MeshData>& outMeshes);
+bool loadModel(const std::string& path, LoadedModel& outModel);

--- a/src/client/renderer/Renderer.cpp
+++ b/src/client/renderer/Renderer.cpp
@@ -10,6 +10,18 @@
 #include <imgui.h>
 #include <vector>
 
+// stb_image_write — declaration only (implementation is in FrameRecorder.cpp).
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+#include <stb_image_write.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 namespace
 {
 
@@ -523,8 +535,15 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
     if (k_drawData)
         ImGui_ImplSDLGPU3_PrepareDrawData(k_drawData, cmd);
 
+    // When a screenshot is pending, render to an intermediate texture so we can
+    // download pixels later.  Then blit captureRT → swapchain for display.
+    // When not recording, render straight to swapchain (no overhead).
+    const SDL_GPUTextureFormat k_colorFmt = SDL_GetGPUSwapchainTextureFormat(device, window);
+    const bool capturing = !pendingCapPath.empty() && ensureCaptureRT(w, h, k_colorFmt);
+    SDL_GPUTexture* const renderTarget = capturing ? captureRT : swapchain;
+
     SDL_GPUColorTargetInfo ct{};
-    ct.texture = swapchain;
+    ct.texture = renderTarget;
     ct.clear_color = {.r = 0.08f, .g = 0.08f, .b = 0.12f, .a = 1.0f};
     ct.load_op = SDL_GPU_LOADOP_CLEAR;
     ct.store_op = SDL_GPU_STOREOP_STORE;
@@ -583,7 +602,158 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
         ImGui_ImplSDLGPU3_RenderDrawData(k_drawData, cmd, pass);
 
     SDL_EndGPURenderPass(pass);
+
+    // If we rendered to the intermediate captureRT, blit it to the swapchain
+    // so the player actually sees the frame.
+    if (capturing) {
+        SDL_GPUBlitInfo blitInfo{};
+        blitInfo.source.texture = captureRT;
+        blitInfo.source.mip_level = 0;
+        blitInfo.source.layer_or_depth_plane = 0;
+        blitInfo.source.x = 0;
+        blitInfo.source.y = 0;
+        blitInfo.source.w = w;
+        blitInfo.source.h = h;
+        blitInfo.destination.texture = swapchain;
+        blitInfo.destination.mip_level = 0;
+        blitInfo.destination.layer_or_depth_plane = 0;
+        blitInfo.destination.x = 0;
+        blitInfo.destination.y = 0;
+        blitInfo.destination.w = w;
+        blitInfo.destination.h = h;
+        blitInfo.load_op = SDL_GPU_LOADOP_DONT_CARE;
+        blitInfo.flip_mode = SDL_FLIP_NONE;
+        blitInfo.filter = SDL_GPU_FILTER_NEAREST;
+        blitInfo.cycle = false;
+        SDL_BlitGPUTexture(cmd, &blitInfo);
+    }
+
     SDL_SubmitGPUCommandBuffer(cmd);
+
+    // Download captureRT → CPU → PNG (blocks until GPU is idle).
+    if (capturing)
+        downloadAndSaveCapture(w, h);
+}
+
+// ---------------------------------------------------------------------------
+// Renderer::requestScreenshot
+// ---------------------------------------------------------------------------
+
+void Renderer::requestScreenshot(const std::string& path)
+{
+    pendingCapPath = path;
+}
+
+// ---------------------------------------------------------------------------
+// Renderer::ensureCaptureRT
+// ---------------------------------------------------------------------------
+
+bool Renderer::ensureCaptureRT(const Uint32 w, const Uint32 h, const SDL_GPUTextureFormat fmt)
+{
+    if (captureRT && captureRTW == w && captureRTH == h && captureRTFmt == fmt)
+        return true;
+
+    if (captureRT)
+        SDL_ReleaseGPUTexture(device, captureRT);
+
+    SDL_GPUTextureCreateInfo info{};
+    info.type = SDL_GPU_TEXTURETYPE_2D;
+    info.format = fmt;
+    info.width = w;
+    info.height = h;
+    info.layer_count_or_depth = 1;
+    info.num_levels = 1;
+    info.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    // COLOR_TARGET: render to it; SAMPLER: required source for SDL_BlitGPUTexture.
+    info.usage = SDL_GPU_TEXTUREUSAGE_COLOR_TARGET | SDL_GPU_TEXTUREUSAGE_SAMPLER;
+
+    captureRT = SDL_CreateGPUTexture(device, &info);
+    if (!captureRT) {
+        SDL_Log("Renderer: failed to create captureRT (%ux%u): %s", w, h, SDL_GetError());
+        return false;
+    }
+
+    captureRTW = w;
+    captureRTH = h;
+    captureRTFmt = fmt;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Renderer::downloadAndSaveCapture
+// ---------------------------------------------------------------------------
+
+void Renderer::downloadAndSaveCapture(const Uint32 w, const Uint32 h)
+{
+    if (!captureRT || pendingCapPath.empty())
+        return;
+
+    const Uint32 dataSize = w * h * 4u;
+
+    // Create a download (CPU-readable) transfer buffer.
+    SDL_GPUTransferBufferCreateInfo tbInfo{};
+    tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD;
+    tbInfo.size = dataSize;
+    SDL_GPUTransferBuffer* dlBuf = SDL_CreateGPUTransferBuffer(device, &tbInfo);
+    if (!dlBuf) {
+        SDL_Log("Renderer: failed to create download buffer: %s", SDL_GetError());
+        pendingCapPath.clear();
+        return;
+    }
+
+    // Issue the GPU → transfer-buffer copy in its own command buffer.
+    SDL_GPUCommandBuffer* dlCmd = SDL_AcquireGPUCommandBuffer(device);
+    SDL_GPUCopyPass* cp = SDL_BeginGPUCopyPass(dlCmd);
+
+    SDL_GPUTextureRegion srcRegion{};
+    srcRegion.texture = captureRT;
+    srcRegion.mip_level = 0;
+    srcRegion.layer = 0;
+    srcRegion.x = srcRegion.y = srcRegion.z = 0;
+    srcRegion.w = w;
+    srcRegion.h = h;
+    srcRegion.d = 1;
+
+    SDL_GPUTextureTransferInfo dstTransfer{};
+    dstTransfer.transfer_buffer = dlBuf;
+    dstTransfer.offset = 0;
+    dstTransfer.pixels_per_row = 0; // 0 = tightly packed (= w)
+    dstTransfer.rows_per_layer = 0; // 0 = tightly packed (= h)
+
+    SDL_DownloadFromGPUTexture(cp, &srcRegion, &dstTransfer);
+    SDL_EndGPUCopyPass(cp);
+    SDL_SubmitGPUCommandBuffer(dlCmd);
+
+    // Block until the GPU has finished writing to the transfer buffer.
+    SDL_WaitForGPUIdle(device);
+
+    // Map the buffer, convert BGRA→RGBA if the swapchain uses BGRA, then save PNG.
+    void* mapped = SDL_MapGPUTransferBuffer(device, dlBuf, false);
+    if (mapped) {
+        std::vector<uint8_t> pixels(dataSize);
+        SDL_memcpy(pixels.data(), mapped, dataSize);
+        SDL_UnmapGPUTransferBuffer(device, dlBuf);
+
+        // On most platforms (Linux/Vulkan, macOS/Metal) the swapchain is BGRA8.
+        // stbi_write_png expects RGBA8, so swap R and B when needed.
+        const bool swapRB = (captureRTFmt == SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM);
+        if (swapRB) {
+            for (Uint32 i = 0; i < w * h; ++i)
+                std::swap(pixels[i * 4 + 0], pixels[i * 4 + 2]);
+        }
+
+        stbi_write_png(pendingCapPath.c_str(),
+                       static_cast<int>(w),
+                       static_cast<int>(h),
+                       4,
+                       pixels.data(),
+                       static_cast<int>(w) * 4);
+    } else {
+        SDL_UnmapGPUTransferBuffer(device, dlBuf);
+    }
+
+    SDL_ReleaseGPUTransferBuffer(device, dlBuf);
+    pendingCapPath.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -630,6 +800,10 @@ void Renderer::quit()
     if (device) {
         SDL_WaitForGPUIdle(device);
 
+        // Release capture render-target if it was created.
+        if (captureRT)
+            SDL_ReleaseGPUTexture(device, captureRT);
+
         // Release model GPU resources.
         for (auto& mesh : modelMeshes) {
             SDL_ReleaseGPUBuffer(device, mesh.vertexBuffer);
@@ -662,6 +836,7 @@ void Renderer::quit()
         SDL_DestroyGPUDevice(device);
     }
 
+    captureRT = nullptr;
     defaultTexture = nullptr;
     modelSampler = nullptr;
     modelPipeline = nullptr;

--- a/src/client/renderer/Renderer.cpp
+++ b/src/client/renderer/Renderer.cpp
@@ -792,6 +792,28 @@ bool Renderer::ensureDepthTexture(const Uint32 w, const Uint32 h)
 }
 
 // ---------------------------------------------------------------------------
+// Renderer::setVSync
+// ---------------------------------------------------------------------------
+
+bool Renderer::setVSync(const bool enabled)
+{
+    SDL_GPUPresentMode mode = SDL_GPU_PRESENTMODE_VSYNC;
+    if (!enabled) {
+        // Prefer mailbox (no tearing) over immediate (may tear).
+        if (SDL_WindowSupportsGPUPresentMode(device, window, SDL_GPU_PRESENTMODE_MAILBOX))
+            mode = SDL_GPU_PRESENTMODE_MAILBOX;
+        else
+            mode = SDL_GPU_PRESENTMODE_IMMEDIATE;
+    }
+
+    if (!SDL_SetGPUSwapchainParameters(device, window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, mode)) {
+        SDL_Log("Renderer: SDL_SetGPUSwapchainParameters failed: %s", SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
 // Renderer::quit
 // ---------------------------------------------------------------------------
 

--- a/src/client/renderer/Renderer.cpp
+++ b/src/client/renderer/Renderer.cpp
@@ -40,8 +40,7 @@ SDL_GPUShader* loadShader(SDL_GPUDevice* dev,
     info.num_storage_buffers = storageBufferCount;
     info.num_storage_textures = storageTextureCount;
 
-    // SPIR-V entry point is "main"; spirv-cross renames it to "main0" in MSL
-    // (Metal forbids a function literally named "main").
+    // SPIR-V entry point is "main"; spirv-cross renames it to "main0" in MSL.
     info.entrypoint = (format == SDL_GPU_SHADERFORMAT_MSL) ? "main0" : "main";
 
     SDL_GPUShader* shader = SDL_CreateGPUShader(dev, &info);
@@ -159,7 +158,7 @@ bool Renderer::init(SDL_Window* win)
         return false;
     }
 
-    // ---- Model pipeline (vertex-buffer driven, Assimp meshes) -------------
+    // ---- Model pipeline (vertex-buffer driven, Assimp meshes + textures) --
     if (!initModelPipeline(activeFormat, k_colorFmt))
         return false;
 
@@ -167,20 +166,20 @@ bool Renderer::init(SDL_Window* win)
     char modelPath[512];
     SDL_snprintf(modelPath, sizeof(modelPath), "%sassets/Apex_Legend_Wraith.glb", k_base ? k_base : "");
 
-    std::vector<MeshData> meshes;
-    if (loadModel(modelPath, meshes)) {
-        if (!uploadModel(meshes))
+    LoadedModel loadedModel;
+    if (loadModel(modelPath, loadedModel)) {
+        if (!uploadModel(loadedModel))
             SDL_Log("Renderer: model GPU upload failed — model will not be drawn");
     } else {
         SDL_Log("Renderer: model load failed — model will not be drawn");
     }
 
     // Place the model to the right of the reference cube.
-    // The cube sits at world (0, 0..64, 368..432).  We park the model at
-    // x = +200, y = 0 (ground), z = 400 with a scale of 40 units/metre
-    // (assumes the GLB is authored in metres; tweak as needed).
+    // Cube sits at world (0, 0..64, 368..432).  Model goes at
+    // x=+200, y=0 (ground), z=400.  Scale of 8 units/metre gives ~14 units
+    // per foot — plausible for a Quake-unit world (tweak as needed).
     modelTransform = glm::translate(glm::mat4(1.0f), glm::vec3(200.0f, 0.0f, 400.0f));
-    modelTransform = glm::scale(modelTransform, glm::vec3(40.0f));
+    modelTransform = glm::scale(modelTransform, glm::vec3(8.0f));
 
     // Camera — eye/target overridden every frame by drawFrame().
     camera = Camera(glm::vec3{0.0f, 100.0f, 0.0f},
@@ -207,8 +206,10 @@ bool Renderer::initModelPipeline(const SDL_GPUShaderFormat fmt, const SDL_GPUTex
     SDL_snprintf(vertPath, sizeof(vertPath), "%sshaders/model.vert%s", k_base ? k_base : "", k_ext);
     SDL_snprintf(fragPath, sizeof(fragPath), "%sshaders/model.frag%s", k_base ? k_base : "", k_ext);
 
+    // Vertex shader: 0 samplers, 1 UBO.
+    // Fragment shader: 1 sampler (texDiffuse), 0 UBOs.
     SDL_GPUShader* vert = loadShader(device, vertPath, fmt, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
-    SDL_GPUShader* frag = loadShader(device, fragPath, fmt, SDL_GPU_SHADERSTAGE_FRAGMENT, 0, 0, 0, 0);
+    SDL_GPUShader* frag = loadShader(device, fragPath, fmt, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
     if (!vert || !frag) {
         SDL_ReleaseGPUShader(device, vert);
         SDL_ReleaseGPUShader(device, frag);
@@ -254,7 +255,7 @@ bool Renderer::initModelPipeline(const SDL_GPUShaderFormat fmt, const SDL_GPUTex
     pci.depth_stencil_state.enable_depth_test = true;
     pci.depth_stencil_state.enable_depth_write = true;
     pci.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
-    // Disable back-face culling: GLB winding order varies by exporter.
+    // GLB materials are double-sided; disable culling to match.
     pci.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_NONE;
 
     modelPipeline = SDL_CreateGPUGraphicsPipeline(device, &pci);
@@ -271,15 +272,113 @@ bool Renderer::initModelPipeline(const SDL_GPUShaderFormat fmt, const SDL_GPUTex
 }
 
 // ---------------------------------------------------------------------------
+// Renderer::uploadTexture
+// ---------------------------------------------------------------------------
+
+SDL_GPUTexture* Renderer::uploadTexture(const uint8_t* pixels, const int width, const int height)
+{
+    SDL_GPUTextureCreateInfo info{};
+    info.type = SDL_GPU_TEXTURETYPE_2D;
+    info.format = SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+    info.width = static_cast<Uint32>(width);
+    info.height = static_cast<Uint32>(height);
+    info.layer_count_or_depth = 1;
+    info.num_levels = 1;
+    info.sample_count = SDL_GPU_SAMPLECOUNT_1;
+    info.usage = SDL_GPU_TEXTUREUSAGE_SAMPLER;
+
+    SDL_GPUTexture* tex = SDL_CreateGPUTexture(device, &info);
+    if (!tex) {
+        SDL_Log("Renderer: SDL_CreateGPUTexture failed: %s", SDL_GetError());
+        return nullptr;
+    }
+
+    const Uint32 dataSize = static_cast<Uint32>(width) * static_cast<Uint32>(height) * 4u;
+
+    SDL_GPUTransferBufferCreateInfo tbInfo{};
+    tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+    tbInfo.size = dataSize;
+
+    SDL_GPUTransferBuffer* tb = SDL_CreateGPUTransferBuffer(device, &tbInfo);
+    if (!tb) {
+        SDL_Log("Renderer: failed to create texture transfer buffer: %s", SDL_GetError());
+        SDL_ReleaseGPUTexture(device, tex);
+        return nullptr;
+    }
+
+    void* ptr = SDL_MapGPUTransferBuffer(device, tb, false);
+    SDL_memcpy(ptr, pixels, dataSize);
+    SDL_UnmapGPUTransferBuffer(device, tb);
+
+    SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device);
+    SDL_GPUCopyPass* cp = SDL_BeginGPUCopyPass(cmd);
+
+    SDL_GPUTextureTransferInfo src{};
+    src.transfer_buffer = tb;
+    src.offset = 0;
+    src.pixels_per_row = 0; // 0 = tightly packed (width pixels per row)
+    src.rows_per_layer = 0; // 0 = tightly packed (height rows per layer)
+
+    SDL_GPUTextureRegion dst{};
+    dst.texture = tex;
+    dst.mip_level = 0;
+    dst.layer = 0;
+    dst.x = dst.y = dst.z = 0;
+    dst.w = static_cast<Uint32>(width);
+    dst.h = static_cast<Uint32>(height);
+    dst.d = 1;
+
+    SDL_UploadToGPUTexture(cp, &src, &dst, false);
+    SDL_EndGPUCopyPass(cp);
+    SDL_SubmitGPUCommandBuffer(cmd);
+    SDL_WaitForGPUIdle(device);
+    SDL_ReleaseGPUTransferBuffer(device, tb);
+
+    return tex;
+}
+
+// ---------------------------------------------------------------------------
 // Renderer::uploadModel
 // ---------------------------------------------------------------------------
 
-bool Renderer::uploadModel(const std::vector<MeshData>& meshes)
+bool Renderer::uploadModel(const LoadedModel& model)
 {
-    if (meshes.empty())
+    if (model.meshes.empty())
         return false;
 
-    // Collect per-mesh GPU buffer sizes so we can size the transfer buffer.
+    // ---- Create the shared sampler -------------------------------------------
+    SDL_GPUSamplerCreateInfo sampInfo{};
+    sampInfo.min_filter = SDL_GPU_FILTER_LINEAR;
+    sampInfo.mag_filter = SDL_GPU_FILTER_LINEAR;
+    sampInfo.mipmap_mode = SDL_GPU_SAMPLERMIPMAPMODE_NEAREST;
+    sampInfo.address_mode_u = SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    sampInfo.address_mode_v = SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    sampInfo.address_mode_w = SDL_GPU_SAMPLERADDRESSMODE_REPEAT;
+    sampInfo.min_lod = 0.0f;
+    sampInfo.max_lod = 0.0f;
+    sampInfo.enable_anisotropy = false;
+    sampInfo.enable_compare = false;
+
+    modelSampler = SDL_CreateGPUSampler(device, &sampInfo);
+    if (!modelSampler) {
+        SDL_Log("Renderer: failed to create model sampler: %s", SDL_GetError());
+        return false;
+    }
+
+    // ---- 1×1 opaque-white fallback texture -----------------------------------
+    const uint8_t k_white[4] = {255, 255, 255, 255};
+    defaultTexture = uploadTexture(k_white, 1, 1);
+    if (!defaultTexture)
+        return false;
+
+    // ---- Upload each model texture -------------------------------------------
+    modelTextures.reserve(model.textures.size());
+    for (const auto& td : model.textures) {
+        SDL_GPUTexture* gpuTex = uploadTexture(td.pixels.data(), td.width, td.height);
+        modelTextures.push_back(gpuTex); // nullptr means "use default" at draw time
+    }
+
+    // ---- Collect per-mesh vertex/index sizes then upload all in one pass ----
     struct MeshSizes
     {
         Uint32 vbBytes;
@@ -287,17 +386,16 @@ bool Renderer::uploadModel(const std::vector<MeshData>& meshes)
     };
 
     std::vector<MeshSizes> sizes;
-    sizes.reserve(meshes.size());
+    sizes.reserve(model.meshes.size());
     Uint32 totalBytes = 0;
 
-    for (const auto& m : meshes) {
+    for (const auto& m : model.meshes) {
         const Uint32 vb = static_cast<Uint32>(m.vertices.size() * sizeof(ModelVertex));
         const Uint32 ib = static_cast<Uint32>(m.indices.size() * sizeof(uint32_t));
-        sizes.push_back({vb, ib});
+        sizes.push_back({.vbBytes = vb, .ibBytes = ib});
         totalBytes += vb + ib;
     }
 
-    // One transfer (staging) buffer holds all mesh data.
     SDL_GPUTransferBufferCreateInfo tbInfo{};
     tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
     tbInfo.size = totalBytes;
@@ -308,26 +406,23 @@ bool Renderer::uploadModel(const std::vector<MeshData>& meshes)
         return false;
     }
 
-    // Map, write all meshes sequentially, then unmap.
     auto* dst = static_cast<char*>(SDL_MapGPUTransferBuffer(device, tb, false));
     Uint32 writeOffset = 0;
-    for (size_t i = 0; i < meshes.size(); ++i) {
-        SDL_memcpy(dst + writeOffset, meshes[i].vertices.data(), sizes[i].vbBytes);
+    for (size_t i = 0; i < model.meshes.size(); ++i) {
+        SDL_memcpy(dst + writeOffset, model.meshes[i].vertices.data(), sizes[i].vbBytes);
         writeOffset += sizes[i].vbBytes;
-        SDL_memcpy(dst + writeOffset, meshes[i].indices.data(), sizes[i].ibBytes);
+        SDL_memcpy(dst + writeOffset, model.meshes[i].indices.data(), sizes[i].ibBytes);
         writeOffset += sizes[i].ibBytes;
     }
     SDL_UnmapGPUTransferBuffer(device, tb);
 
-    // Create GPU-resident vertex + index buffers for each mesh, then issue
-    // all uploads in a single copy pass.
     SDL_GPUCommandBuffer* uploadCmd = SDL_AcquireGPUCommandBuffer(device);
     SDL_GPUCopyPass* copyPass = SDL_BeginGPUCopyPass(uploadCmd);
 
     Uint32 readOffset = 0;
-    modelMeshes.reserve(meshes.size());
+    modelMeshes.reserve(model.meshes.size());
 
-    for (size_t i = 0; i < meshes.size(); ++i) {
+    for (size_t i = 0; i < model.meshes.size(); ++i) {
         SDL_GPUBufferCreateInfo vbInfo{};
         vbInfo.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
         vbInfo.size = sizes[i].vbBytes;
@@ -349,35 +444,39 @@ bool Renderer::uploadModel(const std::vector<MeshData>& meshes)
         }
 
         SDL_GPUTransferBufferLocation src{};
-        SDL_GPUBufferRegion dst2{};
+        SDL_GPUBufferRegion dstReg{};
 
-        // Vertex data
         src.transfer_buffer = tb;
         src.offset = readOffset;
-        dst2.buffer = vb;
-        dst2.offset = 0;
-        dst2.size = sizes[i].vbBytes;
-        SDL_UploadToGPUBuffer(copyPass, &src, &dst2, false);
+        dstReg.buffer = vb;
+        dstReg.offset = 0;
+        dstReg.size = sizes[i].vbBytes;
+        SDL_UploadToGPUBuffer(copyPass, &src, &dstReg, false);
         readOffset += sizes[i].vbBytes;
 
-        // Index data
         src.offset = readOffset;
-        dst2.buffer = ib;
-        dst2.size = sizes[i].ibBytes;
-        SDL_UploadToGPUBuffer(copyPass, &src, &dst2, false);
+        dstReg.buffer = ib;
+        dstReg.size = sizes[i].ibBytes;
+        SDL_UploadToGPUBuffer(copyPass, &src, &dstReg, false);
         readOffset += sizes[i].ibBytes;
 
-        modelMeshes.push_back({vb, ib, static_cast<Uint32>(meshes[i].indices.size())});
+        modelMeshes.push_back({
+            .vertexBuffer = vb,
+            .indexBuffer = ib,
+            .indexCount = static_cast<Uint32>(model.meshes[i].indices.size()),
+            .textureIndex = model.meshes[i].diffuseTexIndex,
+        });
     }
 
     SDL_EndGPUCopyPass(copyPass);
     SDL_SubmitGPUCommandBuffer(uploadCmd);
-
-    // Wait for the upload to finish before we start rendering.
     SDL_WaitForGPUIdle(device);
     SDL_ReleaseGPUTransferBuffer(device, tb);
 
-    SDL_Log("Renderer: uploaded %zu mesh(es) to GPU (%u bytes total)", modelMeshes.size(), totalBytes);
+    SDL_Log("Renderer: uploaded %zu mesh(es), %zu texture(s) to GPU (%u bytes geometry)",
+            modelMeshes.size(),
+            modelTextures.size(),
+            totalBytes);
     return true;
 }
 
@@ -411,7 +510,7 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
 
     camera.setAspect((h != 0) ? static_cast<float>(w) / static_cast<float>(h) : 1.0f);
 
-    // Scene matrices — model = identity (geometry is in world space already).
+    // Scene matrices — model = identity (geometry is already in world space).
     Matrices sceneMats{};
     sceneMats.model = glm::mat4(1.0f);
     sceneMats.view = camera.getView();
@@ -442,13 +541,12 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
 
     SDL_GPURenderPass* pass = SDL_BeginGPURenderPass(cmd, &ct, 1, &dt);
 
-    // ── Scene geometry: cube (verts 0-35) + floor quad (verts 36-41) ────────
+    // ── Scene geometry: cube (verts 0–35) + floor quad (verts 36–41) ────────
     SDL_BindGPUGraphicsPipeline(pass, pipeline);
     SDL_DrawGPUPrimitives(pass, 42, 1, 0, 0);
 
     // ── Assimp model ─────────────────────────────────────────────────────────
-    if (!modelMeshes.empty()) {
-        // Switch to the model pipeline and push the model-specific transform.
+    if (!modelMeshes.empty() && modelPipeline && modelSampler && defaultTexture) {
         SDL_BindGPUGraphicsPipeline(pass, modelPipeline);
 
         Matrices modelMats{};
@@ -458,15 +556,23 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
         SDL_PushGPUVertexUniformData(cmd, 0, &modelMats, sizeof(modelMats));
 
         for (const auto& mesh : modelMeshes) {
-            SDL_GPUBufferBinding vbBind{};
-            vbBind.buffer = mesh.vertexBuffer;
-            vbBind.offset = 0;
+            // Vertex + index buffers
+            const SDL_GPUBufferBinding vbBind = {.buffer = mesh.vertexBuffer, .offset = 0};
             SDL_BindGPUVertexBuffers(pass, 0, &vbBind, 1);
 
-            SDL_GPUBufferBinding ibBind{};
-            ibBind.buffer = mesh.indexBuffer;
-            ibBind.offset = 0;
+            const SDL_GPUBufferBinding ibBind = {.buffer = mesh.indexBuffer, .offset = 0};
             SDL_BindGPUIndexBuffer(pass, &ibBind, SDL_GPU_INDEXELEMENTSIZE_32BIT);
+
+            // Base-colour texture (fall back to 1×1 white if none loaded)
+            SDL_GPUTexture* tex = defaultTexture;
+            if (mesh.textureIndex >= 0 && static_cast<size_t>(mesh.textureIndex) < modelTextures.size() &&
+                modelTextures[static_cast<size_t>(mesh.textureIndex)] != nullptr)
+            {
+                tex = modelTextures[static_cast<size_t>(mesh.textureIndex)];
+            }
+
+            const SDL_GPUTextureSamplerBinding tsb = {.texture = tex, .sampler = modelSampler};
+            SDL_BindGPUFragmentSamplers(pass, 0, &tsb, 1);
 
             SDL_DrawGPUIndexedPrimitives(pass, mesh.indexCount, 1, 0, 0, 0);
         }
@@ -531,6 +637,16 @@ void Renderer::quit()
         }
         modelMeshes.clear();
 
+        for (auto* tex : modelTextures)
+            SDL_ReleaseGPUTexture(device, tex);
+        modelTextures.clear();
+
+        if (defaultTexture)
+            SDL_ReleaseGPUTexture(device, defaultTexture);
+
+        if (modelSampler)
+            SDL_ReleaseGPUSampler(device, modelSampler);
+
         if (modelPipeline)
             SDL_ReleaseGPUGraphicsPipeline(device, modelPipeline);
 
@@ -546,9 +662,11 @@ void Renderer::quit()
         SDL_DestroyGPUDevice(device);
     }
 
+    defaultTexture = nullptr;
+    modelSampler = nullptr;
+    modelPipeline = nullptr;
     depthTexture = nullptr;
     pipeline = nullptr;
-    modelPipeline = nullptr;
     device = nullptr;
     window = nullptr;
 }

--- a/src/client/renderer/Renderer.cpp
+++ b/src/client/renderer/Renderer.cpp
@@ -1,26 +1,19 @@
 #include "Renderer.hpp"
 
 #include "Camera.hpp"
+#include "ModelLoader.hpp"
 
 #include <backends/imgui_impl_sdlgpu3.h>
 #include <cmath>
 #include <glm/ext/matrix_clip_space.hpp>
 #include <glm/ext/matrix_transform.hpp>
 #include <imgui.h>
+#include <vector>
 
 namespace
 {
 
 /// @brief Load a compiled shader from disk and create an SDL GPU shader object.
-/// @param dev                  The GPU device.
-/// @param path                 Path to the compiled shader file (.spv or .msl).
-/// @param format               Shader format (SPIR-V or MSL).
-/// @param stage                Vertex or fragment stage.
-/// @param samplerCount         Number of texture samplers declared in the shader.
-/// @param uniformBufferCount   Number of uniform buffers declared in the shader.
-/// @param storageBufferCount   Number of storage buffers declared in the shader.
-/// @param storageTextureCount  Number of storage textures declared in the shader.
-/// @return The created shader, or nullptr on failure (error logged via SDL_Log).
 SDL_GPUShader* loadShader(SDL_GPUDevice* dev,
                           const char* path,
                           SDL_GPUShaderFormat format,
@@ -59,7 +52,19 @@ SDL_GPUShader* loadShader(SDL_GPUDevice* dev,
     return shader;
 }
 
+/// @brief Matrices UBO — shared by both the scene and model pipelines.
+struct Matrices
+{
+    glm::mat4 model;
+    glm::mat4 view;
+    glm::mat4 projection;
+};
+
 } // namespace
+
+// ---------------------------------------------------------------------------
+// Renderer::init
+// ---------------------------------------------------------------------------
 
 bool Renderer::init(SDL_Window* win)
 {
@@ -99,8 +104,6 @@ bool Renderer::init(SDL_Window* win)
     }
 
     // ImGui GPU backend setup.
-    // The ImGui context and SDL3 input backend were already initialised by
-    // DebugUI::init(). We just hook up the GPU render backend here.
     const SDL_GPUTextureFormat k_colorFmt = SDL_GetGPUSwapchainTextureFormat(device, window);
 
     ImGui_ImplSDLGPU3_InitInfo imguiInfo{};
@@ -113,7 +116,7 @@ bool Renderer::init(SDL_Window* win)
         return false;
     }
 
-    // Scene pipeline (triangle).
+    // ---- Scene pipeline (cube + floor, hard-coded vertex positions) --------
     const char* const k_base = SDL_GetBasePath();
     const char* const k_ext = (activeFormat == SDL_GPU_SHADERFORMAT_MSL) ? ".msl" : ".spv";
 
@@ -140,11 +143,9 @@ bool Renderer::init(SDL_Window* win)
     pci.target_info.num_color_targets = 1;
     pci.target_info.has_depth_stencil_target = true;
     pci.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT;
-
     pci.depth_stencil_state.compare_op = SDL_GPU_COMPAREOP_LESS;
     pci.depth_stencil_state.enable_depth_test = true;
     pci.depth_stencil_state.enable_depth_write = true;
-
     pci.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
     pci.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_BACK;
 
@@ -154,15 +155,37 @@ bool Renderer::init(SDL_Window* win)
     SDL_ReleaseGPUShader(device, frag);
 
     if (!pipeline) {
-        SDL_Log("Renderer: SDL_CreateGPUGraphicsPipeline failed: %s", SDL_GetError());
+        SDL_Log("Renderer: SDL_CreateGPUGraphicsPipeline (scene) failed: %s", SDL_GetError());
         return false;
     }
 
-    // Initial camera — eye/target are overridden every frame by drawFrame().
-    // near/far must be set correctly here; they persist across setAspect() calls.
-    camera = Camera(glm::vec3{0.0f, 100.0f, 0.0f}, // eye  (overridden each frame)
-                    glm::vec3{0.0f, 100.0f, 1.0f}, // target
-                    glm::vec3{0.0f, 1.0f, 0.0f},   // up
+    // ---- Model pipeline (vertex-buffer driven, Assimp meshes) -------------
+    if (!initModelPipeline(activeFormat, k_colorFmt))
+        return false;
+
+    // Load the model from the assets directory next to the binary.
+    char modelPath[512];
+    SDL_snprintf(modelPath, sizeof(modelPath), "%sassets/Apex_Legend_Wraith.glb", k_base ? k_base : "");
+
+    std::vector<MeshData> meshes;
+    if (loadModel(modelPath, meshes)) {
+        if (!uploadModel(meshes))
+            SDL_Log("Renderer: model GPU upload failed — model will not be drawn");
+    } else {
+        SDL_Log("Renderer: model load failed — model will not be drawn");
+    }
+
+    // Place the model to the right of the reference cube.
+    // The cube sits at world (0, 0..64, 368..432).  We park the model at
+    // x = +200, y = 0 (ground), z = 400 with a scale of 40 units/metre
+    // (assumes the GLB is authored in metres; tweak as needed).
+    modelTransform = glm::translate(glm::mat4(1.0f), glm::vec3(200.0f, 0.0f, 400.0f));
+    modelTransform = glm::scale(modelTransform, glm::vec3(40.0f));
+
+    // Camera — eye/target overridden every frame by drawFrame().
+    camera = Camera(glm::vec3{0.0f, 100.0f, 0.0f},
+                    glm::vec3{0.0f, 100.0f, 1.0f},
+                    glm::vec3{0.0f, 1.0f, 0.0f},
                     fovyDegrees,
                     1.0f,
                     nearPlane,
@@ -171,18 +194,200 @@ bool Renderer::init(SDL_Window* win)
     return true;
 }
 
-struct Matrices
+// ---------------------------------------------------------------------------
+// Renderer::initModelPipeline
+// ---------------------------------------------------------------------------
+
+bool Renderer::initModelPipeline(const SDL_GPUShaderFormat fmt, const SDL_GPUTextureFormat colorFmt)
 {
-    glm::mat4 model;
-    glm::mat4 view;
-    glm::mat4 projection;
-};
+    const char* const k_base = SDL_GetBasePath();
+    const char* const k_ext = (fmt == SDL_GPU_SHADERFORMAT_MSL) ? ".msl" : ".spv";
+
+    char vertPath[512], fragPath[512];
+    SDL_snprintf(vertPath, sizeof(vertPath), "%sshaders/model.vert%s", k_base ? k_base : "", k_ext);
+    SDL_snprintf(fragPath, sizeof(fragPath), "%sshaders/model.frag%s", k_base ? k_base : "", k_ext);
+
+    SDL_GPUShader* vert = loadShader(device, vertPath, fmt, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
+    SDL_GPUShader* frag = loadShader(device, fragPath, fmt, SDL_GPU_SHADERSTAGE_FRAGMENT, 0, 0, 0, 0);
+    if (!vert || !frag) {
+        SDL_ReleaseGPUShader(device, vert);
+        SDL_ReleaseGPUShader(device, frag);
+        return false;
+    }
+
+    // Vertex layout — must match ModelVertex (32 bytes, no padding):
+    //   location 0 → position  (vec3, offset  0)
+    //   location 1 → normal    (vec3, offset 12)
+    //   location 2 → texCoord  (vec2, offset 24)
+    const SDL_GPUVertexBufferDescription k_vbDesc = {
+        .slot = 0,
+        .pitch = sizeof(ModelVertex),
+        .input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX,
+        .instance_step_rate = 0,
+    };
+
+    const SDL_GPUVertexAttribute k_attrs[3] = {
+        {.location = 0, .buffer_slot = 0, .format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3, .offset = 0},
+        {.location = 1, .buffer_slot = 0, .format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3, .offset = 12},
+        {.location = 2, .buffer_slot = 0, .format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT2, .offset = 24},
+    };
+
+    SDL_GPUVertexInputState vertexInput{};
+    vertexInput.vertex_buffer_descriptions = &k_vbDesc;
+    vertexInput.num_vertex_buffers = 1;
+    vertexInput.vertex_attributes = k_attrs;
+    vertexInput.num_vertex_attributes = 3;
+
+    SDL_GPUColorTargetDescription colorTarget{};
+    colorTarget.format = colorFmt;
+
+    SDL_GPUGraphicsPipelineCreateInfo pci{};
+    pci.vertex_shader = vert;
+    pci.fragment_shader = frag;
+    pci.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+    pci.vertex_input_state = vertexInput;
+    pci.target_info.color_target_descriptions = &colorTarget;
+    pci.target_info.num_color_targets = 1;
+    pci.target_info.has_depth_stencil_target = true;
+    pci.target_info.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT;
+    pci.depth_stencil_state.compare_op = SDL_GPU_COMPAREOP_LESS;
+    pci.depth_stencil_state.enable_depth_test = true;
+    pci.depth_stencil_state.enable_depth_write = true;
+    pci.rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
+    // Disable back-face culling: GLB winding order varies by exporter.
+    pci.rasterizer_state.cull_mode = SDL_GPU_CULLMODE_NONE;
+
+    modelPipeline = SDL_CreateGPUGraphicsPipeline(device, &pci);
+
+    SDL_ReleaseGPUShader(device, vert);
+    SDL_ReleaseGPUShader(device, frag);
+
+    if (!modelPipeline) {
+        SDL_Log("Renderer: SDL_CreateGPUGraphicsPipeline (model) failed: %s", SDL_GetError());
+        return false;
+    }
+
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Renderer::uploadModel
+// ---------------------------------------------------------------------------
+
+bool Renderer::uploadModel(const std::vector<MeshData>& meshes)
+{
+    if (meshes.empty())
+        return false;
+
+    // Collect per-mesh GPU buffer sizes so we can size the transfer buffer.
+    struct MeshSizes
+    {
+        Uint32 vbBytes;
+        Uint32 ibBytes;
+    };
+
+    std::vector<MeshSizes> sizes;
+    sizes.reserve(meshes.size());
+    Uint32 totalBytes = 0;
+
+    for (const auto& m : meshes) {
+        const Uint32 vb = static_cast<Uint32>(m.vertices.size() * sizeof(ModelVertex));
+        const Uint32 ib = static_cast<Uint32>(m.indices.size() * sizeof(uint32_t));
+        sizes.push_back({vb, ib});
+        totalBytes += vb + ib;
+    }
+
+    // One transfer (staging) buffer holds all mesh data.
+    SDL_GPUTransferBufferCreateInfo tbInfo{};
+    tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+    tbInfo.size = totalBytes;
+
+    SDL_GPUTransferBuffer* tb = SDL_CreateGPUTransferBuffer(device, &tbInfo);
+    if (!tb) {
+        SDL_Log("Renderer: failed to create model transfer buffer: %s", SDL_GetError());
+        return false;
+    }
+
+    // Map, write all meshes sequentially, then unmap.
+    auto* dst = static_cast<char*>(SDL_MapGPUTransferBuffer(device, tb, false));
+    Uint32 writeOffset = 0;
+    for (size_t i = 0; i < meshes.size(); ++i) {
+        SDL_memcpy(dst + writeOffset, meshes[i].vertices.data(), sizes[i].vbBytes);
+        writeOffset += sizes[i].vbBytes;
+        SDL_memcpy(dst + writeOffset, meshes[i].indices.data(), sizes[i].ibBytes);
+        writeOffset += sizes[i].ibBytes;
+    }
+    SDL_UnmapGPUTransferBuffer(device, tb);
+
+    // Create GPU-resident vertex + index buffers for each mesh, then issue
+    // all uploads in a single copy pass.
+    SDL_GPUCommandBuffer* uploadCmd = SDL_AcquireGPUCommandBuffer(device);
+    SDL_GPUCopyPass* copyPass = SDL_BeginGPUCopyPass(uploadCmd);
+
+    Uint32 readOffset = 0;
+    modelMeshes.reserve(meshes.size());
+
+    for (size_t i = 0; i < meshes.size(); ++i) {
+        SDL_GPUBufferCreateInfo vbInfo{};
+        vbInfo.usage = SDL_GPU_BUFFERUSAGE_VERTEX;
+        vbInfo.size = sizes[i].vbBytes;
+        SDL_GPUBuffer* vb = SDL_CreateGPUBuffer(device, &vbInfo);
+
+        SDL_GPUBufferCreateInfo ibInfo{};
+        ibInfo.usage = SDL_GPU_BUFFERUSAGE_INDEX;
+        ibInfo.size = sizes[i].ibBytes;
+        SDL_GPUBuffer* ib = SDL_CreateGPUBuffer(device, &ibInfo);
+
+        if (!vb || !ib) {
+            SDL_Log("Renderer: failed to create GPU buffer for mesh %zu: %s", i, SDL_GetError());
+            SDL_ReleaseGPUBuffer(device, vb);
+            SDL_ReleaseGPUBuffer(device, ib);
+            SDL_EndGPUCopyPass(copyPass);
+            SDL_SubmitGPUCommandBuffer(uploadCmd);
+            SDL_ReleaseGPUTransferBuffer(device, tb);
+            return false;
+        }
+
+        SDL_GPUTransferBufferLocation src{};
+        SDL_GPUBufferRegion dst2{};
+
+        // Vertex data
+        src.transfer_buffer = tb;
+        src.offset = readOffset;
+        dst2.buffer = vb;
+        dst2.offset = 0;
+        dst2.size = sizes[i].vbBytes;
+        SDL_UploadToGPUBuffer(copyPass, &src, &dst2, false);
+        readOffset += sizes[i].vbBytes;
+
+        // Index data
+        src.offset = readOffset;
+        dst2.buffer = ib;
+        dst2.size = sizes[i].ibBytes;
+        SDL_UploadToGPUBuffer(copyPass, &src, &dst2, false);
+        readOffset += sizes[i].ibBytes;
+
+        modelMeshes.push_back({vb, ib, static_cast<Uint32>(meshes[i].indices.size())});
+    }
+
+    SDL_EndGPUCopyPass(copyPass);
+    SDL_SubmitGPUCommandBuffer(uploadCmd);
+
+    // Wait for the upload to finish before we start rendering.
+    SDL_WaitForGPUIdle(device);
+    SDL_ReleaseGPUTransferBuffer(device, tb);
+
+    SDL_Log("Renderer: uploaded %zu mesh(es) to GPU (%u bytes total)", modelMeshes.size(), totalBytes);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Renderer::drawFrame
+// ---------------------------------------------------------------------------
 
 void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch)
 {
     // ── first-person camera ─────────────────────────────────────────────────
-    // Forward vector from yaw (horizontal) and pitch (vertical).
-    // Convention matches InputSnapshot: yaw=0 → +Z, pitch>0 → looking down.
     const float cosPitch = std::cos(pitch);
     const glm::vec3 forward{std::sin(yaw) * cosPitch, -std::sin(pitch), std::cos(yaw) * cosPitch};
     camera.setLookAt(eye, eye + forward, glm::vec3{0.0f, 1.0f, 0.0f});
@@ -206,23 +411,22 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
 
     camera.setAspect((h != 0) ? static_cast<float>(w) / static_cast<float>(h) : 1.0f);
 
-    // All geometry is pre-positioned in world space, so model = identity.
-    Matrices mats{};
-    mats.model = glm::mat4(1.0f);
-    mats.view = camera.getView();
-    mats.projection = camera.getProjection();
+    // Scene matrices — model = identity (geometry is in world space already).
+    Matrices sceneMats{};
+    sceneMats.model = glm::mat4(1.0f);
+    sceneMats.view = camera.getView();
+    sceneMats.projection = camera.getProjection();
 
-    SDL_PushGPUVertexUniformData(cmd, 0, &mats, sizeof(mats));
+    SDL_PushGPUVertexUniformData(cmd, 0, &sceneMats, sizeof(sceneMats));
 
-    // Upload ImGui vertex/index buffers via an internal copy pass.
-    // This must happen BEFORE the render pass begins.
+    // Upload ImGui vertex/index buffers — must happen before the render pass.
     ImDrawData* const k_drawData = ImGui::GetDrawData();
     if (k_drawData)
         ImGui_ImplSDLGPU3_PrepareDrawData(k_drawData, cmd);
 
     SDL_GPUColorTargetInfo ct{};
     ct.texture = swapchain;
-    ct.clear_color = {.r = 0.08f, .g = 0.08f, .b = 0.12f, .a = 1.0f}; // dark-blue sky
+    ct.clear_color = {.r = 0.08f, .g = 0.08f, .b = 0.12f, .a = 1.0f};
     ct.load_op = SDL_GPU_LOADOP_CLEAR;
     ct.store_op = SDL_GPU_STOREOP_STORE;
 
@@ -238,14 +442,37 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
 
     SDL_GPURenderPass* pass = SDL_BeginGPURenderPass(cmd, &ct, 1, &dt);
 
-    // Scene geometry:
-    //   verts  0-35  — reference cube (64-unit cube at world pos (0,0,400))
-    //   verts 36-41  — floor quad (4000×4000 units at y=0)
-    // One draw call; model = identity; checkerboard applied in fragment shader.
+    // ── Scene geometry: cube (verts 0-35) + floor quad (verts 36-41) ────────
     SDL_BindGPUGraphicsPipeline(pass, pipeline);
     SDL_DrawGPUPrimitives(pass, 42, 1, 0, 0);
 
-    // ImGui overlay — drawn last so it sits on top of scene geometry.
+    // ── Assimp model ─────────────────────────────────────────────────────────
+    if (!modelMeshes.empty()) {
+        // Switch to the model pipeline and push the model-specific transform.
+        SDL_BindGPUGraphicsPipeline(pass, modelPipeline);
+
+        Matrices modelMats{};
+        modelMats.model = modelTransform;
+        modelMats.view = sceneMats.view;
+        modelMats.projection = sceneMats.projection;
+        SDL_PushGPUVertexUniformData(cmd, 0, &modelMats, sizeof(modelMats));
+
+        for (const auto& mesh : modelMeshes) {
+            SDL_GPUBufferBinding vbBind{};
+            vbBind.buffer = mesh.vertexBuffer;
+            vbBind.offset = 0;
+            SDL_BindGPUVertexBuffers(pass, 0, &vbBind, 1);
+
+            SDL_GPUBufferBinding ibBind{};
+            ibBind.buffer = mesh.indexBuffer;
+            ibBind.offset = 0;
+            SDL_BindGPUIndexBuffer(pass, &ibBind, SDL_GPU_INDEXELEMENTSIZE_32BIT);
+
+            SDL_DrawGPUIndexedPrimitives(pass, mesh.indexCount, 1, 0, 0, 0);
+        }
+    }
+
+    // ── ImGui overlay ────────────────────────────────────────────────────────
     if (k_drawData)
         ImGui_ImplSDLGPU3_RenderDrawData(k_drawData, cmd, pass);
 
@@ -253,7 +480,11 @@ void Renderer::drawFrame(const glm::vec3 eye, const float yaw, const float pitch
     SDL_SubmitGPUCommandBuffer(cmd);
 }
 
-bool Renderer::ensureDepthTexture(Uint32 w, Uint32 h)
+// ---------------------------------------------------------------------------
+// Renderer::ensureDepthTexture
+// ---------------------------------------------------------------------------
+
+bool Renderer::ensureDepthTexture(const Uint32 w, const Uint32 h)
 {
     if (depthTexture && depthWidth == w && depthHeight == h)
         return true;
@@ -284,10 +515,24 @@ bool Renderer::ensureDepthTexture(Uint32 w, Uint32 h)
     return true;
 }
 
+// ---------------------------------------------------------------------------
+// Renderer::quit
+// ---------------------------------------------------------------------------
+
 void Renderer::quit()
 {
     if (device) {
         SDL_WaitForGPUIdle(device);
+
+        // Release model GPU resources.
+        for (auto& mesh : modelMeshes) {
+            SDL_ReleaseGPUBuffer(device, mesh.vertexBuffer);
+            SDL_ReleaseGPUBuffer(device, mesh.indexBuffer);
+        }
+        modelMeshes.clear();
+
+        if (modelPipeline)
+            SDL_ReleaseGPUGraphicsPipeline(device, modelPipeline);
 
         if (depthTexture)
             SDL_ReleaseGPUTexture(device, depthTexture);
@@ -303,6 +548,7 @@ void Renderer::quit()
 
     depthTexture = nullptr;
     pipeline = nullptr;
+    modelPipeline = nullptr;
     device = nullptr;
     window = nullptr;
 }

--- a/src/client/renderer/Renderer.hpp
+++ b/src/client/renderer/Renderer.hpp
@@ -6,6 +6,7 @@
 #include <SDL3/SDL.h>
 
 #include <glm/glm.hpp>
+#include <string>
 #include <vector>
 
 /// @brief SDL3 GPU pipeline (Vulkan · Metal · DX12).
@@ -25,6 +26,12 @@ public:
     /// @return False on any fatal GPU error.
     /// @pre An ImGui context must already exist (created by DebugUI::init).
     bool init(SDL_Window* window);
+
+    /// @brief Request a PNG screenshot of the next rendered frame.
+    /// The screenshot is saved synchronously at the end of that drawFrame() call,
+    /// so it reflects exactly the pixels that appear on screen.
+    /// @param path  Absolute path for the output PNG (parent directory must exist).
+    void requestScreenshot(const std::string& path);
 
     /// @brief Submit the scene geometry, loaded model, and ImGui draw data for one frame.
     /// @param eye    World-space camera eye position (interpolated, in Quake units).
@@ -69,10 +76,24 @@ private:
     SDL_GPUSampler* modelSampler = nullptr;           ///< Shared linear sampler for all model textures.
     glm::mat4 modelTransform{1.0f};                   ///< World transform applied to the model.
 
+    // ---- Screen capture (recording) ------------------------------------
+
+    SDL_GPUTexture* captureRT = nullptr; ///< Intermediate render target for screenshots.
+    Uint32 captureRTW = 0;
+    Uint32 captureRTH = 0;
+    SDL_GPUTextureFormat captureRTFmt = SDL_GPU_TEXTUREFORMAT_INVALID; ///< Format mirrors swapchain.
+    std::string pendingCapPath;                                        ///< Non-empty = save next frame here.
+
     // ---- Private helpers -----------------------------------------------
 
     /// @brief (Re-)create the depth texture when the swapchain size changes.
     bool ensureDepthTexture(Uint32 w, Uint32 h);
+
+    /// @brief (Re-)create the intermediate capture render-target if size/format changed.
+    bool ensureCaptureRT(Uint32 w, Uint32 h, SDL_GPUTextureFormat fmt);
+
+    /// @brief Download captureRT to CPU and write a PNG to pendingCapPath, then clear it.
+    void downloadAndSaveCapture(Uint32 w, Uint32 h);
 
     /// @brief Create the model graphics pipeline (vertex inputs + fragment sampler + depth test).
     /// @param fmt       Active shader format (SPIR-V or MSL).

--- a/src/client/renderer/Renderer.hpp
+++ b/src/client/renderer/Renderer.hpp
@@ -39,6 +39,11 @@ public:
     /// @param pitch  Vertical look angle in radians (positive = looking down).
     void drawFrame(glm::vec3 eye, float yaw, float pitch);
 
+    /// @brief Switch VSync on or off by changing the swapchain present mode.
+    /// When disabled, prefers mailbox (no tearing) and falls back to immediate.
+    /// @return False if the requested mode is unsupported on this device/platform.
+    bool setVSync(bool enabled);
+
     /// @brief Release all GPU resources.  Waits for GPU idle before freeing.
     /// @pre Call before the SDL window is destroyed.
     void quit();

--- a/src/client/renderer/Renderer.hpp
+++ b/src/client/renderer/Renderer.hpp
@@ -12,7 +12,7 @@
 ///
 /// Renders two layers of geometry each frame:
 ///   1. Scene geometry — hard-coded cube + floor via `projective.vert` / `normal.frag`.
-///   2. Loaded model   — Assimp-imported GLB uploaded to GPU vertex/index buffers,
+///   2. Loaded model   — Assimp-imported GLB with per-mesh base-colour textures,
 ///                       rendered via `model.vert` / `model.frag`.
 ///
 /// Also owns the `imgui_impl_sdlgpu3` render backend.  The ImGui context and
@@ -20,7 +20,7 @@
 class Renderer
 {
 public:
-    /// @brief Initialise the GPU device, both pipelines, upload the model, and init ImGui GPU.
+    /// @brief Initialise the GPU device, both pipelines, upload model + textures, init ImGui GPU.
     /// @param window  The SDL window to render into.
     /// @return False on any fatal GPU error.
     /// @pre An ImGui context must already exist (created by DebugUI::init).
@@ -59,10 +59,14 @@ private:
         SDL_GPUBuffer* vertexBuffer = nullptr;
         SDL_GPUBuffer* indexBuffer = nullptr;
         Uint32 indexCount = 0;
+        int textureIndex = -1; ///< Index into modelTextures, or -1 → defaultTexture.
     };
 
-    SDL_GPUGraphicsPipeline* modelPipeline = nullptr; ///< Pipeline with vertex-input layout.
+    SDL_GPUGraphicsPipeline* modelPipeline = nullptr; ///< Pipeline with vertex-input layout + sampler.
     std::vector<GpuMesh> modelMeshes;                 ///< One entry per mesh in the loaded file.
+    std::vector<SDL_GPUTexture*> modelTextures;       ///< Decoded textures uploaded to GPU.
+    SDL_GPUTexture* defaultTexture = nullptr;         ///< 1×1 opaque-white fallback texture.
+    SDL_GPUSampler* modelSampler = nullptr;           ///< Shared linear sampler for all model textures.
     glm::mat4 modelTransform{1.0f};                   ///< World transform applied to the model.
 
     // ---- Private helpers -----------------------------------------------
@@ -70,12 +74,16 @@ private:
     /// @brief (Re-)create the depth texture when the swapchain size changes.
     bool ensureDepthTexture(Uint32 w, Uint32 h);
 
-    /// @brief Create the model graphics pipeline (vertex inputs + depth test).
+    /// @brief Create the model graphics pipeline (vertex inputs + fragment sampler + depth test).
     /// @param fmt       Active shader format (SPIR-V or MSL).
     /// @param colorFmt  Swapchain colour target format.
     bool initModelPipeline(SDL_GPUShaderFormat fmt, SDL_GPUTextureFormat colorFmt);
 
-    /// @brief Upload all mesh data to GPU vertex/index buffers.
-    /// Populates @c modelMeshes.  Blocks until upload is complete.
-    bool uploadModel(const std::vector<MeshData>& meshes);
+    /// @brief Upload all mesh vertex/index data and textures to the GPU.
+    /// Populates @c modelMeshes, @c modelTextures, @c defaultTexture, and @c modelSampler.
+    bool uploadModel(const LoadedModel& model);
+
+    /// @brief Upload one RGBA texture to a new GPU texture object.
+    /// @return The created GPU texture, or nullptr on failure.
+    SDL_GPUTexture* uploadTexture(const uint8_t* pixels, int width, int height);
 };

--- a/src/client/renderer/Renderer.hpp
+++ b/src/client/renderer/Renderer.hpp
@@ -1,53 +1,81 @@
 #pragma once
 
 #include "Camera.hpp"
+#include "ModelLoader.hpp"
 
 #include <SDL3/SDL.h>
 
 #include <glm/glm.hpp>
+#include <vector>
 
 /// @brief SDL3 GPU pipeline (Vulkan · Metal · DX12).
 ///
-/// Also owns the `imgui_impl_sdlgpu3` render backend. The ImGui context and
-/// SDL3 input backend are owned by DebugUI — initialise DebugUI first, shut it down last.
+/// Renders two layers of geometry each frame:
+///   1. Scene geometry — hard-coded cube + floor via `projective.vert` / `normal.frag`.
+///   2. Loaded model   — Assimp-imported GLB uploaded to GPU vertex/index buffers,
+///                       rendered via `model.vert` / `model.frag`.
 ///
-/// Shaders: `shaders/projective.vert` + `shaders/normal.frag`
-/// (compiled GLSL → SPIR-V at build time via glslc/glslangValidator).
+/// Also owns the `imgui_impl_sdlgpu3` render backend.  The ImGui context and
+/// SDL3 input backend are owned by DebugUI — initialise DebugUI first, shut it down last.
 class Renderer
 {
 public:
-    /// @brief Initialise the GPU device, pipeline, and ImGui GPU backend.
+    /// @brief Initialise the GPU device, both pipelines, upload the model, and init ImGui GPU.
     /// @param window  The SDL window to render into.
     /// @return False on any fatal GPU error.
     /// @pre An ImGui context must already exist (created by DebugUI::init).
     bool init(SDL_Window* window);
 
-    /// @brief Submit the scene geometry and ImGui draw data for one frame.
+    /// @brief Submit the scene geometry, loaded model, and ImGui draw data for one frame.
     /// @param eye    World-space camera eye position (interpolated, in Quake units).
     /// @param yaw    Horizontal look angle in radians (matches InputSnapshot::yaw).
     /// @param pitch  Vertical look angle in radians (positive = looking down).
     void drawFrame(glm::vec3 eye, float yaw, float pitch);
 
-    /// @brief Release all GPU resources. Waits for GPU idle before freeing.
+    /// @brief Release all GPU resources.  Waits for GPU idle before freeing.
     /// @pre Call before the SDL window is destroyed.
     void quit();
 
 private:
     SDL_Window* window = nullptr;                ///< The SDL window being rendered into.
     SDL_GPUDevice* device = nullptr;             ///< The SDL GPU device.
-    SDL_GPUGraphicsPipeline* pipeline = nullptr; ///< The scene graphics pipeline.
+    SDL_GPUGraphicsPipeline* pipeline = nullptr; ///< Scene pipeline (hard-coded geometry).
 
-    // Camera parameters used during init. Near/far are sized for Quake units.
     float fovyDegrees = 60.0f;
     float nearPlane = 5.0f;                 ///< Near clip (Quake units); 5 ≈ half a foot.
     float farPlane = 15000.0f;              ///< Far clip; covers the 4 000-unit play area with margin.
 
-    Camera camera;                          ///< First-person camera — driven by player position + yaw/pitch each frame.
+    Camera camera;                          ///< First-person camera driven by player position + yaw/pitch each frame.
 
     SDL_GPUTexture* depthTexture = nullptr; ///< Depth buffer, recreated on resize.
     Uint32 depthWidth = 0;
     Uint32 depthHeight = 0;
 
+    // ---- Assimp model rendering ----------------------------------------
+
+    /// @brief Per-mesh GPU resources for the loaded model.
+    struct GpuMesh
+    {
+        SDL_GPUBuffer* vertexBuffer = nullptr;
+        SDL_GPUBuffer* indexBuffer = nullptr;
+        Uint32 indexCount = 0;
+    };
+
+    SDL_GPUGraphicsPipeline* modelPipeline = nullptr; ///< Pipeline with vertex-input layout.
+    std::vector<GpuMesh> modelMeshes;                 ///< One entry per mesh in the loaded file.
+    glm::mat4 modelTransform{1.0f};                   ///< World transform applied to the model.
+
+    // ---- Private helpers -----------------------------------------------
+
     /// @brief (Re-)create the depth texture when the swapchain size changes.
     bool ensureDepthTexture(Uint32 w, Uint32 h);
+
+    /// @brief Create the model graphics pipeline (vertex inputs + depth test).
+    /// @param fmt       Active shader format (SPIR-V or MSL).
+    /// @param colorFmt  Swapchain colour target format.
+    bool initModelPipeline(SDL_GPUShaderFormat fmt, SDL_GPUTextureFormat colorFmt);
+
+    /// @brief Upload all mesh data to GPU vertex/index buffers.
+    /// Populates @c modelMeshes.  Blocks until upload is complete.
+    bool uploadModel(const std::vector<MeshData>& meshes);
 };

--- a/src/client/systems/InputSampleSystem.hpp
+++ b/src/client/systems/InputSampleSystem.hpp
@@ -10,36 +10,29 @@
 #include <cmath>
 #include <glm/trigonometric.hpp>
 
-/// @brief Client-only input sampling system.
-///
-/// Reads SDL keyboard and mouse state each frame and writes the result into
-/// the InputSnapshot component of the LocalPlayer entity.
-///
-/// @note Must be called **once per frame**, before the physics accumulator loop,
-///       so the snapshot is fresh for every physics tick that fires that frame.
+/// @brief Client-only input sampling system — split into two halves so mouse
+///        look can run every iterate() (smooth camera at any FPS) while
+///        movement keys run once per physics tick group (server-consistent).
 namespace systems
 {
 
-/// @brief Sample keyboard and mouse state into the local player's InputSnapshot.
+/// @brief Sample mouse delta and accumulate into yaw / pitch.
+///
+/// Must be called **every iterate() call** regardless of whether a physics
+/// tick fires — this keeps camera rotation smooth at the render frame rate.
+/// SDL_GetRelativeMouseState returns the accumulated delta since the
+/// previous call, so the total rotation over any time window is identical
+/// regardless of call frequency.
+///
 /// @param registry          The ECS registry.
-/// @param mouseSensitivity  Mouse sensitivity in radians per pixel (default 0.002).
-inline void runInputSample(Registry& registry, float mouseSensitivity = 0.002f)
+/// @param mouseSensitivity  Radians per pixel of mouse movement.
+inline void runMouseLook(Registry& registry, float mouseSensitivity)
 {
-    const bool* const k_keys = SDL_GetKeyboardState(nullptr);
-
     float mdx = 0.0f;
     float mdy = 0.0f;
     SDL_GetRelativeMouseState(&mdx, &mdy);
 
     registry.view<InputSnapshot, LocalPlayer>().each([&](InputSnapshot& snap) {
-        snap.forward = k_keys[SDL_SCANCODE_W];
-        snap.back = k_keys[SDL_SCANCODE_S];
-        snap.left = k_keys[SDL_SCANCODE_A];
-        snap.right = k_keys[SDL_SCANCODE_D];
-        snap.jump = k_keys[SDL_SCANCODE_SPACE];
-        snap.crouch = k_keys[SDL_SCANCODE_LCTRL];
-
-        // Accumulate mouse deltas into absolute yaw.
         // Negate: SDL mdx is positive when moving right, but positive yaw
         // rotates toward +X which maps to screen-left via glm::lookAt's
         // cross(forward, up) convention.  Negating gives the standard
@@ -52,6 +45,36 @@ inline void runInputSample(Registry& registry, float mouseSensitivity = 0.002f)
         // Clamp pitch to avoid gimbal-lock at the poles.
         snap.pitch = std::clamp(snap.pitch + mdy * mouseSensitivity, -glm::radians(89.0f), glm::radians(89.0f));
     });
+}
+
+/// @brief Sample keyboard state into the movement flags.
+///
+/// Should be called **once per physics tick group** when input is synced
+/// with physics (the default) so movement calculations match the server.
+/// Can also be called every iterate() when the sync toggle is off.
+///
+/// @param registry  The ECS registry.
+inline void runMovementKeys(Registry& registry)
+{
+    const bool* const k_keys = SDL_GetKeyboardState(nullptr);
+
+    registry.view<InputSnapshot, LocalPlayer>().each([&](InputSnapshot& snap) {
+        snap.forward = k_keys[SDL_SCANCODE_W];
+        snap.back = k_keys[SDL_SCANCODE_S];
+        snap.left = k_keys[SDL_SCANCODE_A];
+        snap.right = k_keys[SDL_SCANCODE_D];
+        snap.jump = k_keys[SDL_SCANCODE_SPACE];
+        snap.crouch = k_keys[SDL_SCANCODE_LCTRL];
+    });
+}
+
+/// @brief Legacy combined sampler — calls both runMouseLook and runMovementKeys.
+/// @param registry          The ECS registry.
+/// @param mouseSensitivity  Radians per pixel (default 0.001).
+inline void runInputSample(Registry& registry, float mouseSensitivity = 0.001f)
+{
+    runMouseLook(registry, mouseSensitivity);
+    runMovementKeys(registry);
 }
 
 } // namespace systems

--- a/src/ecs/components/InputSnapshot.hpp
+++ b/src/ecs/components/InputSnapshot.hpp
@@ -25,4 +25,14 @@ struct InputSnapshot
     float yaw{0.0f};     ///< Horizontal look angle in radians (accumulated from mouse X deltas).
     float pitch{0.0f};   ///< Vertical look angle in radians, clamped to [-89°, +89°] by InputSampleSystem.
     float roll{0.0f};    ///< Currently always 0; reserved for dynamic movement tilt (wallrun lean, strafe tilt).
+
+    /// @brief Yaw/pitch captured at the start of the most-recent physics tick.
+    ///
+    /// Used by the renderer to interpolate orientation with the same alpha as
+    /// position, keeping camera eye and look-direction on the same timebase.
+    /// Without this, yaw snaps to the newest value every frame while the eye
+    /// position lags behind by up to one tick — causing objects to jitter on
+    /// screen when strafing and rotating simultaneously (orbiting).
+    float prevTickYaw{0.0f};
+    float prevTickPitch{0.0f};
 };


### PR DESCRIPTION
Add Assimp v5.4.3 via FetchContent (GLTF/GLB importer only, static lib, no tools/tests/install) following the same pattern as SDL3 and EnTT.

- CMakeLists.txt: fetch assimp, compile model.vert/model.frag shaders, add ModelLoader sources to group2, link assimp, POST_BUILD copy of assets/ directory next to the binary
- shaders/model.vert + model.frag: second pipeline with real vertex-buffer inputs (position/normal/UV) and simple two-light diffuse shading
- ModelLoader.hpp/cpp: thin Assimp wrapper returning std::vector<MeshData>
  (triangulated, smooth normals, de-duplicated vertices)
- Renderer: initModelPipeline(), uploadModel() (single-pass GPU upload), drawFrame() draws Apex_Legend_Wraith.glb at world pos (200, 0, 400) beside the reference cube; gracefully skips if file is absent
- assets/Apex_Legend_Wraith.glb: model file (21 MB)