### PR TITLE
Fix silent fallback to legacy renderer, add explicit routing logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,62 @@ foreach(SHADER_SRC ${SHADER_SOURCES})
     endif()
 endforeach()
 
+# ---------------------------------------------------------------------------
+# New-renderer shaders (shaders-new/ directory)
+# ---------------------------------------------------------------------------
+# Compiled separately so the new renderer can load from "shaders-new/" at
+# runtime without colliding with the legacy renderer's shader directory.
+set(SHADER_NEW_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/shaders-new")
+set(SHADER_NEW_OUT_DIR "${CMAKE_BINARY_DIR}/shaders-new")
+file(MAKE_DIRECTORY "${SHADER_NEW_OUT_DIR}")
+
+set(SHADER_NEW_SOURCES
+    geometry.vert geometry.frag
+)
+
+foreach(SHADER_SRC ${SHADER_NEW_SOURCES})
+    # GLSL → SPIR-V
+    set(SPV_OUT "${SHADER_NEW_OUT_DIR}/${SHADER_SRC}.spv")
+    add_custom_command(
+        OUTPUT  "${SPV_OUT}"
+        COMMAND ${SHADER_COMPILE_TOOL} ${SHADER_COMPILE_FLAGS}
+                -o "${SPV_OUT}" "${SHADER_NEW_SRC_DIR}/${SHADER_SRC}"
+        DEPENDS "${SHADER_NEW_SRC_DIR}/${SHADER_SRC}"
+        COMMENT "Compiling new-renderer shader ${SHADER_SRC} → SPIR-V"
+        VERBATIM
+    )
+    list(APPEND SHADER_OUTPUTS "${SPV_OUT}")
+
+    # SPIR-V → MSL (Metal backend on macOS)
+    if(APPLE)
+        if(SPV_TO_MSL)
+            set(MSL_OUT "${SHADER_NEW_OUT_DIR}/${SHADER_SRC}.msl")
+            add_custom_command(
+                OUTPUT  "${MSL_OUT}"
+                COMMAND "${SPV_TO_MSL}" "${SPV_OUT}" "${MSL_OUT}"
+                DEPENDS "${SPV_OUT}"
+                COMMENT "Transpiling new-renderer shader ${SHADER_SRC} → MSL"
+                VERBATIM
+            )
+            list(APPEND SHADER_OUTPUTS "${MSL_OUT}")
+        elseif(SPIRV_CROSS)
+            set(MSL_OUT "${SHADER_NEW_OUT_DIR}/${SHADER_SRC}.msl")
+            add_custom_command(
+                OUTPUT  "${MSL_OUT}"
+                COMMAND "${SPIRV_CROSS}" --msl "${SPV_OUT}" --output "${MSL_OUT}"
+                COMMAND python3
+                        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/fix_msl_compute_bindings.py"
+                        "${SPIRV_CROSS}" "${SPV_OUT}" "${MSL_OUT}"
+                DEPENDS "${SPV_OUT}"
+                        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/fix_msl_compute_bindings.py"
+                COMMENT "Transpiling new-renderer shader ${SHADER_SRC} → MSL (fallback)"
+                VERBATIM
+            )
+            list(APPEND SHADER_OUTPUTS "${MSL_OUT}")
+        endif()
+    endif()
+endforeach()
+
 add_custom_target(shaders ALL DEPENDS ${SHADER_OUTPUTS})
 
 # ===========================================================================

--- a/src/client/renderer-new/Renderer.cpp
+++ b/src/client/renderer-new/Renderer.cpp
@@ -176,7 +176,10 @@ SDL_GPUShader* loadShader(SDL_GPUDevice* dev,
     return shader;
 }
 
-SDL_GPUGraphicsPipeline* createGeometryPipeline(SDL_GPUDevice* device, SDL_Window* window, SDL_GPUShaderFormat shaderFormat,const std::string& k_shadersDir)
+SDL_GPUGraphicsPipeline* createGeometryPipeline(SDL_GPUDevice* device,
+                                                SDL_Window* window,
+                                                SDL_GPUShaderFormat shaderFormat,
+                                                const std::string& k_shadersDir)
 {
     const std::string vertexShaderPath = k_shadersDir + "geometry.vert";
     Uint32 vertexShaderSamplerCount = 0;
@@ -346,8 +349,8 @@ bool NewRenderer::initCommon(SDL_Window* /*win*/)
         return false;
     }
 
-    shadersDir_ = "shaders-new";
-    pipeline_ = createGeometryPipeline(device_, window_, shaderFormat_,shadersDir_);
+    shadersDir_ = "shaders-new/";
+    pipeline_ = createGeometryPipeline(device_, window_, shaderFormat_, shadersDir_);
     if (!pipeline_) {
         SDL_Log("NewRenderer: SDL_CreateGPUGraphicsPipeline failed: %s", SDL_GetError());
         return false;
@@ -422,17 +425,20 @@ void NewRenderer::drawFrame(const glm::vec3 eye, const float yaw, const float pi
 
     SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device_);
     if (!cmd) {
+        SDL_Log("NewRenderer::drawFrame: SDL_AcquireGPUCommandBuffer failed: %s", SDL_GetError());
         return;
     }
 
     SDL_GPUTexture* swapchain = nullptr;
     Uint32 w = 0, h = 0;
     if (!SDL_AcquireGPUSwapchainTexture(cmd, window_, &swapchain, &w, &h) || !swapchain) {
+        SDL_Log("NewRenderer::drawFrame: SDL_AcquireGPUSwapchainTexture failed: %s", SDL_GetError());
         SDL_SubmitGPUCommandBuffer(cmd);
         return;
     }
 
     if (!ensureDepthTexture(w, h)) {
+        SDL_Log("NewRenderer::drawFrame: ensureDepthTexture failed");
         SDL_SubmitGPUCommandBuffer(cmd);
         return;
     }

--- a/src/client/renderer/HybridRenderer.cpp
+++ b/src/client/renderer/HybridRenderer.cpp
@@ -5,6 +5,68 @@
 
 #include <SDL3/SDL.h>
 
+namespace
+{
+
+/// @brief Human-readable name for each renderer feature (for logging).
+const char* featureName(RendererFeature f)
+{
+    switch (f) {
+    case RendererFeature::Init:
+        return "Init";
+    case RendererFeature::DrawFrame:
+        return "DrawFrame";
+    case RendererFeature::Quit:
+        return "Quit";
+    case RendererFeature::GetDevice:
+        return "GetDevice";
+    case RendererFeature::GetShaderFormat:
+        return "GetShaderFormat";
+    case RendererFeature::GetCamera:
+        return "GetCamera";
+    case RendererFeature::SetParticleSystem:
+        return "SetParticleSystem";
+    case RendererFeature::LoadSceneModel:
+        return "LoadSceneModel";
+    case RendererFeature::UploadSceneModel:
+        return "UploadSceneModel";
+    case RendererFeature::SetVSync:
+        return "SetVSync";
+    case RendererFeature::UpdateModelMeshVertices:
+        return "UpdateModelMeshVertices";
+    case RendererFeature::SetEntityRenderList:
+        return "SetEntityRenderList";
+    case RendererFeature::SetWeaponViewmodel:
+        return "SetWeaponViewmodel";
+    case RendererFeature::RequestScreenshot:
+        return "RequestScreenshot";
+    case RendererFeature::ModelCount:
+        return "ModelCount";
+    }
+    return "Unknown";
+}
+
+/// @brief All features whose routing is interesting to report at init.
+constexpr RendererFeature k_allFeatures[] = {
+    RendererFeature::Init,
+    RendererFeature::DrawFrame,
+    RendererFeature::Quit,
+    RendererFeature::GetDevice,
+    RendererFeature::GetShaderFormat,
+    RendererFeature::GetCamera,
+    RendererFeature::SetParticleSystem,
+    RendererFeature::LoadSceneModel,
+    RendererFeature::UploadSceneModel,
+    RendererFeature::SetVSync,
+    RendererFeature::UpdateModelMeshVertices,
+    RendererFeature::SetEntityRenderList,
+    RendererFeature::SetWeaponViewmodel,
+    RendererFeature::RequestScreenshot,
+    RendererFeature::ModelCount,
+};
+
+} // namespace
+
 HybridRenderer::HybridRenderer() : ssrMode(legacy_.ssrMode), toggles(legacy_.toggles) {}
 
 bool HybridRenderer::supports(RendererFeature /*feature*/) const
@@ -15,31 +77,62 @@ bool HybridRenderer::supports(RendererFeature /*feature*/) const
 
 bool HybridRenderer::init(SDL_Window* window)
 {
+    SDL_Log("HybridRenderer: ==== INIT BEGIN ====");
+
     // The legacy renderer owns the GPU device + window claim + ImGui GPU
     // backend, because (a) it's fully functional and (b) most routed calls
     // still land on it. The new renderer piggy-backs on the same device.
     if (!legacy_.init(window)) {
-        SDL_Log("HybridRenderer: legacy renderer init failed");
+        SDL_Log("HybridRenderer: FATAL -- legacy renderer init failed");
         return false;
     }
     legacyInitialised_ = true;
+    SDL_Log("HybridRenderer: legacy renderer init OK");
 
     // If the new renderer implements drawFrame, bring it up too -- sharing
     // the legacy renderer's device so both can issue commands.
     if (next_.supports(RendererFeature::DrawFrame) || next_.supports(RendererFeature::Init)) {
+        SDL_Log("HybridRenderer: new renderer claims DrawFrame/Init support -- attempting init...");
         if (!next_.init(window, legacy_.getDevice())) {
-            SDL_Log("HybridRenderer: new renderer init failed -- continuing with legacy only");
+            SDL_Log("HybridRenderer: ERROR -- new renderer init FAILED");
+            SDL_Log("HybridRenderer: new renderer will NOT be used for any feature");
         } else {
             nextInitialised_ = true;
+            SDL_Log("HybridRenderer: new renderer init OK");
         }
+    } else {
+        SDL_Log("HybridRenderer: new renderer does not claim DrawFrame or Init -- skipping init");
     }
+
+    // Print the full routing table so it's unambiguous which renderer handles
+    // each feature. This runs once at startup.
+    SDL_Log("HybridRenderer: ---- ROUTING TABLE ----");
+    for (RendererFeature f : k_allFeatures) {
+        const bool newClaims = next_.supports(f);
+        const bool useNew = nextInitialised_ && newClaims;
+        SDL_Log("HybridRenderer:   %-25s -> %s%s",
+                featureName(f),
+                useNew ? "NEW" : "LEGACY",
+                (newClaims && !nextInitialised_) ? "  (new claims support but init failed!)" : "");
+    }
+    SDL_Log("HybridRenderer: ==== INIT DONE (drawFrame -> %s) ====",
+            (nextInitialised_ && next_.supports(RendererFeature::DrawFrame)) ? "NEW" : "LEGACY");
 
     return true;
 }
 
 void HybridRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
 {
-    if (nextInitialised_ && next_.supports(RendererFeature::DrawFrame))
+    const bool useNew = nextInitialised_ && next_.supports(RendererFeature::DrawFrame);
+
+    // Log once on the very first frame so the user sees it even without scrolling
+    // back to init.
+    if (!drawFrameLogged_) {
+        SDL_Log("HybridRenderer::drawFrame: first frame -> %s renderer", useNew ? "NEW" : "LEGACY");
+        drawFrameLogged_ = true;
+    }
+
+    if (useNew)
         next_.drawFrame(eye, yaw, pitch, roll);
     else
         legacy_.drawFrame(eye, yaw, pitch, roll);
@@ -49,10 +142,12 @@ void HybridRenderer::quit()
 {
     // Tear down new first so its buffers release before the shared device dies.
     if (nextInitialised_) {
+        SDL_Log("HybridRenderer: quitting new renderer");
         next_.quit();
         nextInitialised_ = false;
     }
     if (legacyInitialised_) {
+        SDL_Log("HybridRenderer: quitting legacy renderer");
         legacy_.quit();
         legacyInitialised_ = false;
     }

--- a/src/client/renderer/HybridRenderer.hpp
+++ b/src/client/renderer/HybridRenderer.hpp
@@ -69,4 +69,5 @@ private:
     /// tear down exactly what `init()` brought up, in the right order.
     bool legacyInitialised_ = false;
     bool nextInitialised_ = false;
+    bool drawFrameLogged_ = false; ///< True after the first drawFrame routing decision is logged.
 };


### PR DESCRIPTION
The new renderer was never actually running due to two bugs:
- Missing trailing '/' in shadersDir_ ("shaders-new" + "geometry.vert" produced "shaders-newgeometry.vert"), causing shader load failure and silent fallback to legacy.
- CMake never compiled shaders-new/ sources to .spv, so even with the correct path no compiled shaders would exist at runtime.

Also makes renderer selection fully explicit: HybridRenderer now prints a routing table at init showing which renderer handles each feature, logs the first drawFrame dispatch, and NewRenderer::drawFrame logs errors instead of returning silently on GPU failures.