### PR TITLE
Match Manager System

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,6 +952,8 @@ add_executable(server
         src/network/MatchStatus.hpp
         src/server/systems/MatchController.hpp
         src/server/systems/MatchController.cpp
+        src/ecs/systems/MatchSystem.hpp
+        src/ecs/systems/MatchSystem.cpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,7 @@ add_executable(client
         src/ecs/systems/PlayerStatusSystem.hpp
         src/ecs/systems/PlayerStatusSystem.cpp
         src/ecs/components/Player.hpp
+        src/network/MatchStatus.hpp
 )
 
 target_include_directories(client PRIVATE
@@ -948,6 +949,9 @@ add_executable(server
         src/ecs/systems/PlayerStatusSystem.hpp
         src/ecs/systems/PlayerStatusSystem.cpp
         src/ecs/components/Player.hpp
+        src/network/MatchStatus.hpp
+        src/server/systems/MatchController.hpp
+        src/server/systems/MatchController.cpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)

--- a/config.toml
+++ b/config.toml
@@ -2,9 +2,9 @@
 # All keys are optional; missing keys fall back to compiled-in defaults.
 
 [client-network]
-host = "192.168.1.1"
+host = "127.0.0.1"
 port = 9999
 
 [server-network]
-host = "192.168.1.1"
+host = "127.0.0.1"
 port = 9999

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -1228,11 +1228,12 @@ void DebugUI::buildScoreboardUI(const Registry& registry, MatchPhase phase, floa
     ImGui::Separator();
 
     constexpr ImGuiTableFlags k_tableFlags = ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV;
-    if (ImGui::BeginTable("scores", 4, k_tableFlags)) {
+    if (ImGui::BeginTable("scores", 5, k_tableFlags)) {
         ImGui::TableSetupColumn("Player", ImGuiTableColumnFlags_WidthStretch);
         ImGui::TableSetupColumn("K", ImGuiTableColumnFlags_WidthFixed, 30.0f);
         ImGui::TableSetupColumn("D", ImGuiTableColumnFlags_WidthFixed, 30.0f);
         ImGui::TableSetupColumn("Sc", ImGuiTableColumnFlags_WidthFixed, 35.0f);
+        ImGui::TableSetupColumn("Won", ImGuiTableColumnFlags_WidthFixed, 35.0f);
         ImGui::TableHeadersRow();
 
         int row = 0;
@@ -1257,6 +1258,8 @@ void DebugUI::buildScoreboardUI(const Registry& registry, MatchPhase phase, floa
                 ImGui::Text("%d", stats.deaths);
                 ImGui::TableSetColumnIndex(3);
                 ImGui::Text("%d", stats.score);
+                ImGui::TableSetColumnIndex(4);
+                ImGui::Text("%s", stats.hasWon ? "Yes" : "No");
 
                 ++row;
             }

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -197,7 +197,6 @@ void DebugUI::buildUI(const Registry& registry,
         buildBhopAnalyzer(registry);
 
     buildWeaponUI(registry);
-    buildScoreboardUI(registry);
 }
 
 // Contents of the ECS Inspector window, factored out so the Begin/End wrapping
@@ -1183,7 +1182,7 @@ void DebugUI::buildWeaponUI(const Registry& registry)
     ImGui::End();
 }
 
-void DebugUI::buildScoreboardUI(const Registry& registry)
+void DebugUI::buildScoreboardUI(const Registry& registry, MatchPhase phase, float countdownTimer)
 {
     if (!showScoreboard_)
         return;
@@ -1207,6 +1206,26 @@ void DebugUI::buildScoreboardUI(const Registry& registry)
         ImGui::End();
         return;
     }
+
+    // Phase banner
+    const char* phaseStr = "Warmup";
+    switch (phase) {
+    case MatchPhase::COUNTDOWN:
+        phaseStr = "Starting...";
+        break;
+    case MatchPhase::IN_PROGRESS:
+        phaseStr = "In Progress";
+        break;
+    case MatchPhase::FINISHED:
+        phaseStr = "Finished";
+        break;
+    default:
+        break;
+    }
+    ImGui::TextUnformatted(phaseStr);
+    if (phase == MatchPhase::COUNTDOWN || phase == MatchPhase::FINISHED)
+        ImGui::Text("%.1fs", static_cast<double>(countdownTimer));
+    ImGui::Separator();
 
     constexpr ImGuiTableFlags k_tableFlags = ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV;
     if (ImGui::BeginTable("scores", 4, k_tableFlags)) {

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -7,6 +7,7 @@
 #include "ecs/components/Health.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LocalPlayer.hpp"
+#include "ecs/components/PlayerMatchStats.hpp"
 #include "ecs/components/PlayerState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/PreviousPosition.hpp"
@@ -119,6 +120,7 @@ void DebugUI::toggleAllPanels(std::initializer_list<bool*> externalPanels)
         &showLightingControls,
         &showSkybox,
         &showNetworkStats,
+        &showScoreboard_,
     };
 
     // If anything is currently visible (owned or external), hide everything;
@@ -195,6 +197,7 @@ void DebugUI::buildUI(const Registry& registry,
         buildBhopAnalyzer(registry);
 
     buildWeaponUI(registry);
+    buildScoreboardUI(registry);
 }
 
 // Contents of the ECS Inspector window, factored out so the Begin/End wrapping
@@ -1175,6 +1178,74 @@ void DebugUI::buildWeaponUI(const Registry& registry)
             "Health:  %.0f / %.0f", static_cast<double>(health.health), static_cast<double>(systems::healthMax));
     } else {
         ImGui::TextDisabled("Health state unavailable");
+    }
+
+    ImGui::End();
+}
+
+void DebugUI::buildScoreboardUI(const Registry& registry)
+{
+    if (!showScoreboard_)
+        return;
+
+    // Find local player entity to highlight it in the table.
+    entt::entity localPlayer = entt::null;
+    const auto* const k_es = registry.storage<entt::entity>();
+    if (k_es) {
+        for (auto e : *k_es) {
+            if (registry.valid(e) && registry.all_of<LocalPlayer>(e)) {
+                localPlayer = e;
+                break;
+            }
+        }
+    }
+
+    ImGui::SetNextWindowPos({10.0f, 10.0f}, ImGuiCond_FirstUseEver);
+    constexpr ImGuiWindowFlags k_flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse |
+                                         ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize;
+    if (!ImGui::Begin("Scoreboard", &showScoreboard_, k_flags)) {
+        ImGui::End();
+        return;
+    }
+
+    constexpr ImGuiTableFlags k_tableFlags = ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV;
+    if (ImGui::BeginTable("scores", 4, k_tableFlags)) {
+        ImGui::TableSetupColumn("Player", ImGuiTableColumnFlags_WidthStretch);
+        ImGui::TableSetupColumn("K", ImGuiTableColumnFlags_WidthFixed, 30.0f);
+        ImGui::TableSetupColumn("D", ImGuiTableColumnFlags_WidthFixed, 30.0f);
+        ImGui::TableSetupColumn("Sc", ImGuiTableColumnFlags_WidthFixed, 35.0f);
+        ImGui::TableHeadersRow();
+
+        int row = 0;
+        if (k_es) {
+            for (auto e : *k_es) {
+                if (!registry.valid(e) || !registry.all_of<PlayerMatchStats>(e))
+                    continue;
+
+                const auto& stats = registry.get<PlayerMatchStats>(e);
+                const bool k_isLocal = (e == localPlayer);
+
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                if (k_isLocal)
+                    ImGui::TextColored({0.3f, 1.0f, 0.3f, 1.0f}, "> You");
+                else
+                    ImGui::Text("Player %d", row + 1);
+
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("%d", stats.kills);
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("%d", stats.deaths);
+                ImGui::TableSetColumnIndex(3);
+                ImGui::Text("%d", stats.score);
+
+                ++row;
+            }
+        }
+        if (row == 0)
+            ImGui::TextDisabled("No players");
+
+        ImGui::EndTable();
     }
 
     ImGui::End();

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "ecs/registry/Registry.hpp"
+#include "network/MatchStatus.hpp"
 
 #include <SDL3/SDL.h>
 
@@ -92,7 +93,9 @@ public:
     void buildWeaponUI(const Registry& registry);
 
     /// @brief Build the persistent scoreboard HUD showing all players' kills, deaths, and score.
-    void buildScoreboardUI(const Registry& registry);
+    /// @param phase          Current match phase received from the server.
+    /// @param countdownTimer Seconds remaining; displayed only during COUNTDOWN and FINISHED phases.
+    void buildScoreboardUI(const Registry& registry, MatchPhase phase, float countdownTimer);
 
     /// @brief Finalise the ImGui frame. Call after all ImGui draw calls, before Renderer::drawFrame().
     void render();

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -91,6 +91,9 @@ public:
     void buildNetworkUI(const NetworkStats& stats);
     void buildWeaponUI(const Registry& registry);
 
+    /// @brief Build the persistent scoreboard HUD showing all players' kills, deaths, and score.
+    void buildScoreboardUI(const Registry& registry);
+
     /// @brief Finalise the ImGui frame. Call after all ImGui draw calls, before Renderer::drawFrame().
     void render();
 
@@ -114,6 +117,7 @@ private:
     bool showLightingControls = true; ///< Show the Lighting Controls window.
     bool showSkybox = true;           ///< Show the Skybox window.
     bool showNetworkStats = true;     ///< Show the Network Stats window.
+    bool showScoreboard_ = true;      ///< Show the scoreboard HUD window.
 
     /// Per-component visibility toggles — persistent across frames.
     bool showPosition = true;       ///< Show Position component row.

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -152,6 +152,11 @@ bool Game::init()
         }
     });
 
+    client.onMatchStateUpdate([this](const MatchStatePacket& packet) {
+        currentMatchPhase = packet.phase;
+        countdownTimer = packet.countdownTimer;
+    });
+
     // Initialize runtime 3P weapon params from defaults
     for (int i = 0; i < 4; ++i)
         tpWeaponParams_[i] = getThirdPersonWeaponParams(static_cast<WeaponType>(i));
@@ -1065,6 +1070,7 @@ SDL_AppResult Game::iterate()
                     statsFPS1pLow,
                     statsFPS5pLow);
     debugUI.buildNetworkUI(client.getNetStats());
+    debugUI.buildScoreboardUI(registry, currentMatchPhase, countdownTimer);
     debugUI.buildParticleUI(particleSystem, cachedEye_, cachedCamFwd_);
     buildAnimationTesterUI(animUI_, registry, kRigScale_, kRigVerticalOffset_);
 #ifdef USE_HYBRID_RENDERER

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -12,6 +12,7 @@
 #include "ecs/components/ViewmodelConfig.hpp"
 #include "ecs/registry/Registry.hpp"
 #include "network/Client.hpp"
+#include "network/MatchStatus.hpp"
 #include "network/NetworkConfig.hpp"
 #include "particles/ParticleSystem.hpp"
 #ifdef USE_HYBRID_RENDERER
@@ -187,4 +188,8 @@ private:
     /// and emplaces the component.  Safe to call even if the rig failed to load
     /// (logs a warning and leaves the entity un-animated).
     void attachAnimatedCharacter(entt::entity e);
+
+    // Match State
+    MatchPhase currentMatchPhase = MatchPhase::WARMUP; ///< Latest match phase update from the server.
+    float countdownTimer = 0.0f; ///< Countdown timer for transitions between match phases (e.g. warmup to in-progress).
 };

--- a/src/client/network/Client.cpp
+++ b/src/client/network/Client.cpp
@@ -3,6 +3,7 @@
 
 #include "Client.hpp"
 
+#include "network/MatchStatus.hpp"
 #include "network/PacketType.hpp"
 #include "network/RegistrySerialization.hpp"
 
@@ -168,6 +169,15 @@ bool Client::poll(Registry& registry)
                 stats.avgRttMs = rtt;
             else
                 stats.avgRttMs = stats.avgRttMs * 0.8f + rtt * 0.2f;
+            break;
+        }
+        case PacketType::MATCH_STATE: {
+            if (payloadSize != sizeof(MatchStatePacket))
+                break;
+            MatchStatePacket matchState;
+            std::memcpy(&matchState, payload, sizeof(MatchStatePacket));
+            if (matchStateUpdateFn_)
+                matchStateUpdateFn_(matchState);
             break;
         }
         default:

--- a/src/client/network/Client.hpp
+++ b/src/client/network/Client.hpp
@@ -5,6 +5,7 @@
 
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/registry/Registry.hpp"
+#include "network/MatchStatus.hpp"
 #include "network/MessageStream.hpp"
 #include "network/RegistrySerialization.hpp"
 #include "network/ShotEvent.hpp"
@@ -34,6 +35,7 @@ class Client
 public:
     using LocalPlayerReadyFn = std::function<void(entt::entity localEntity)>;
     using ParticleEventCallback = std::function<void(const NetParticleEvent& evt, entt::entity localEntity)>;
+    using MatchStateUpdateFn = std::function<void(const MatchStatePacket&)>;
 
     /// @brief Create the TCP socket and connect to the server.
     /// @param addr  Hostname or IP address of the server.
@@ -60,6 +62,7 @@ public:
 
     void onLocalPlayerReady(LocalPlayerReadyFn fn) { localPlayerReadyFn = std::move(fn); }
     void onParticleEvent(ParticleEventCallback fn) { particleEventFn_ = std::move(fn); }
+    void onMatchStateUpdate(MatchStateUpdateFn fn) { matchStateUpdateFn_ = std::move(fn); }
 
     /// @brief Receive and process one pending message.
     /// @return True if a message was received, false if the queue is empty.
@@ -74,6 +77,7 @@ private:
     std::optional<registry_serialization::Loader> registryLoader;
     LocalPlayerReadyFn localPlayerReadyFn;         ///< Called once the server assigns a player entity.
     ParticleEventCallback particleEventFn_;        ///< Called for each replicated particle event from server.
+    MatchStateUpdateFn matchStateUpdateFn_;        ///< Called whenever a MATCH_STATE packet is received.
     std::optional<entt::entity> localPlayerEntity; ///< The local player's entity, once assigned by the server.
     bool localPlayerReadyNotified = false;         ///< True if localPlayerReadyFn has been called.
 

--- a/src/ecs/components/PlayerMatchStats.hpp
+++ b/src/ecs/components/PlayerMatchStats.hpp
@@ -4,7 +4,8 @@
 #pragma once
 struct PlayerMatchStats
 {
-    int score = 0;  // Player's current score
-    int kills = 0;  // Number of kills player has achieved
-    int deaths = 0; // Number of times player has died
+    int score = 0;       // Player's current score
+    int kills = 0;       // Number of kills player has achieved
+    int deaths = 0;      // Number of times player has died
+    bool hasWon = false; // Whether the player has won the match (e.g. reached kill threshold)
 };

--- a/src/ecs/components/PlayerMatchStats.hpp
+++ b/src/ecs/components/PlayerMatchStats.hpp
@@ -1,0 +1,10 @@
+/// @file PlayerMatchStats.hpp
+/// @brief Component for player match-related stats
+
+#pragma once
+struct PlayerMatchStats
+{
+    int score = 0;  // Player's current score
+    int kills = 0;  // Number of kills player has achieved
+    int deaths = 0; // Number of times player has died
+};

--- a/src/ecs/systems/MatchSystem.cpp
+++ b/src/ecs/systems/MatchSystem.cpp
@@ -1,0 +1,37 @@
+/// @file MatchSystem.cpp
+/// @brief Implementation of the MatchSystem that checks for match win conditions and updates match state
+/// accordingly.
+
+#include "MatchSystem.hpp"
+
+#include "ecs/components/PlayerMatchStats.hpp"
+#include "ecs/registry/Registry.hpp"
+
+namespace systems
+{
+bool handleWinCondition(Registry& registry, int killsToWin)
+{
+    auto view = registry.view<PlayerMatchStats>();
+    bool winConditionMet = false;
+    for (auto entity : view) {
+        if (view.get<PlayerMatchStats>(entity).kills >= killsToWin) {
+            winConditionMet = true;
+            registry.patch<PlayerMatchStats>(entity, [&](PlayerMatchStats& stats) { stats.hasWon = true; });
+        }
+    }
+    return winConditionMet;
+}
+
+void resetStats(Registry& registry)
+{
+    auto view = registry.view<PlayerMatchStats>();
+    for (auto entity : view) {
+        registry.patch<PlayerMatchStats>(entity, [](PlayerMatchStats& stats) {
+            stats.score = 0;
+            stats.kills = 0;
+            stats.deaths = 0;
+            stats.hasWon = false;
+        });
+    }
+}
+} // namespace systems

--- a/src/ecs/systems/MatchSystem.hpp
+++ b/src/ecs/systems/MatchSystem.hpp
@@ -1,0 +1,13 @@
+/// @file MatchSystem.hpp
+/// @brief Match system for handling match logic and win conditions.
+
+#include "ecs/registry/Registry.hpp"
+
+namespace systems
+{
+/// @brief Checks if any player has met win condition and updates their PlayerMatchStats accordingly.
+bool handleWinCondition(Registry& registry, int killsToWin);
+
+/// @brief Resets all players' match scores to initial values.
+void resetStats(Registry& registry);
+} // namespace systems

--- a/src/ecs/systems/PlayerStatusSystem.cpp
+++ b/src/ecs/systems/PlayerStatusSystem.cpp
@@ -6,6 +6,7 @@
 #include "ecs/components/Health.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/Player.hpp"
+#include "ecs/components/PlayerMatchStats.hpp"
 #include "ecs/components/PlayerState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/Velocity.hpp"
@@ -78,8 +79,14 @@ inline void handleRespawn(entt::entity& player, Registry& registry)
 inline void handleDeath(entt::entity& player, Health& playerHealth, entt::entity& killer, Registry& registry)
 {
     if (playerHealth.health <= 0) {
+        // Update death
         registry.get_or_emplace<PlayerState>(player).IsDead = true;
-        // TODO: award score to killer
+        registry.patch<PlayerMatchStats>(player, [&](PlayerMatchStats& stats) { stats.deaths++; });
+
+        // Award killer
+        registry.patch<PlayerMatchStats>(killer, [&](PlayerMatchStats& stats) { stats.kills++; });
+
+        // Respawn
         handleRespawn(player, registry);
     }
 }

--- a/src/network/MatchStatus.hpp
+++ b/src/network/MatchStatus.hpp
@@ -1,0 +1,18 @@
+/// @file MatchStatus.hpp
+/// @brief Shared definitions for match status and state synchronization between server and clients.
+#pragma once
+
+enum class MatchPhase : uint8_t
+{
+    WARMUP,
+    COUNTDOWN,
+    IN_PROGRESS,
+    FINISHED
+};
+
+struct MatchStatePacket
+{
+    MatchPhase phase;
+    float countdownTimer; // Time remaining in current phase, if applicable
+    int winnerId;         // Player ID of winner, if in FINISHED phase
+};

--- a/src/network/PacketType.hpp
+++ b/src/network/PacketType.hpp
@@ -17,4 +17,7 @@ enum class PacketType : uint8_t
     // Bidirectional (latency measurement)
     PING, // Client -> Server (carries uint64_t timestamp)
     PONG, // Server -> Client (echoes timestamp back)
+
+    // Server -> All clients (match status updates)
+    MATCH_STATE,
 };

--- a/src/network/RegistrySerialization.cpp
+++ b/src/network/RegistrySerialization.cpp
@@ -3,6 +3,7 @@
 #include "ecs/components/CollisionShape.hpp"
 #include "ecs/components/Health.hpp"
 #include "ecs/components/InputSnapshot.hpp"
+#include "ecs/components/PlayerMatchStats.hpp"
 #include "ecs/components/PlayerState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/Velocity.hpp"
@@ -32,7 +33,8 @@ namespace registry_serialization
 
 // NOTE: this is where any component that should be sent to clients must be listed.
 // The order of components in this tuple is the order they will be serialized in.
-using Synced = std::tuple<entt::entity, Position, Velocity, PlayerState, CollisionShape, WeaponState, Health>;
+using Synced =
+    std::tuple<entt::entity, Position, Velocity, PlayerState, CollisionShape, WeaponState, Health, PlayerMatchStats>;
 
 std::vector<uint8_t> serialize(const entt::registry& registry)
 {

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -123,6 +123,8 @@ void ServerGame::tick(float dt, Uint64 nextTick)
     systems::runCollision(registry, dt, physics::testWorld());
     systems::runPlayerStatus(registry, dt);
 
+    matchController.update(dt, registry, server);
+
     // Update Client by sending the registry
     server.broadcastRegistry(registry);
     server.broadcastParticleEvents(particleEvents);

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -7,6 +7,7 @@
 #include "ecs/components/Health.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/Player.hpp"
+#include "ecs/components/PlayerMatchStats.hpp"
 #include "ecs/components/PlayerState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/Renderable.hpp"
@@ -154,6 +155,7 @@ void ServerGame::initNewPlayerEntity(ClientId clientId)
     registry.emplace<PlayerState>(player);
     registry.emplace<Renderable>(player, Renderable{.modelIndex = 1, .scale = glm::vec3(100.0f)});
     registry.emplace<Health>(player, Health{}); // Defaults to 100/100 health and 100/100 armor
+    registry.emplace<PlayerMatchStats>(player, PlayerMatchStats{});
 
     const WeaponConfig& rifleConfig = getWeaponConfig(WeaponType::Rifle);
     const WeaponConfig& railConfig = getWeaponConfig(WeaponType::RailGun);

--- a/src/server/game/ServerGame.hpp
+++ b/src/server/game/ServerGame.hpp
@@ -6,6 +6,7 @@
 #include "ecs/components/ClientId.hpp"
 #include "ecs/registry/Registry.hpp"
 #include "network/Server.hpp"
+#include "systems/MatchController.hpp"
 
 #include <SDL3/SDL.h>
 
@@ -52,6 +53,7 @@ private:
 
     Server server;                                             ///< Owns the TCP socket and network I/O.
     Registry registry;                                         ///< ECS entity/component store.
+    MatchController matchController;                           ///< Manages match flow and state.
     std::unordered_map<ClientId, entt::entity> clientEntities; ///< Maps client IDs to ECS entities.
     bool running = false;                                      ///< Loop continues while true.
     int tickRateHz = 128;                                      ///< Physics ticks per second.

--- a/src/server/network/Server.cpp
+++ b/src/server/network/Server.cpp
@@ -5,6 +5,7 @@
 
 #include "ecs/components/ClientId.hpp"
 #include "ecs/components/InputSnapshot.hpp"
+#include "network/MatchStatus.hpp"
 #include "network/PacketType.hpp"
 #include "network/RegistrySerialization.hpp"
 #include "systems/EventQueue.hpp"
@@ -214,6 +215,24 @@ void Server::broadcastParticleEvents(const std::vector<NetParticleEvent>& events
     for (const auto& [clientId, conn] : clients) {
         if (!send(clientId, buf.data(), static_cast<int>(buf.size()))) {
             SDL_Log("Server: failed to send PARTICLE_SPAWN packet to client %d", clientId.value);
+        }
+    }
+}
+
+int Server::getClientCount()
+{
+    return static_cast<int>(clients.size());
+}
+
+void Server::broadcastMatchStatus(MatchStatePacket packet)
+{
+    std::vector<uint8_t> buf(sizeof(PacketType) + sizeof(MatchStatePacket));
+    buf[0] = static_cast<uint8_t>(PacketType::MATCH_STATE);
+    std::memcpy(buf.data() + 1, &packet, sizeof(MatchStatePacket));
+
+    for (const auto& [clientId, conn] : clients) {
+        if (!send(clientId, buf.data(), static_cast<int>(buf.size()))) {
+            SDL_Log("Server: failed to send MATCH_STATE packet to client %d", clientId.value);
         }
     }
 }

--- a/src/server/network/Server.cpp
+++ b/src/server/network/Server.cpp
@@ -190,11 +190,8 @@ void Server::broadcastRegistry(const Registry& registry)
 
     buf.insert(buf.begin(), static_cast<uint8_t>(PacketType::UPDATE_REGISTRY));
 
-    for (const auto& [clientId, conn] : clients) {
-        if (!send(clientId, buf.data(), static_cast<int>(buf.size()))) {
-            // might need to do more on failure in the future
-            SDL_Log("Server: failed to send UPDATE_REGISTRY packet to client %d", clientId.value);
-        }
+    if (!broadcast(buf.data(), static_cast<int>(buf.size()))) {
+        SDL_Log("Server: failed to broadcast UPDATE_REGISTRY packet to clients");
     }
 }
 
@@ -212,10 +209,8 @@ void Server::broadcastParticleEvents(const std::vector<NetParticleEvent>& events
     std::memcpy(buf.data() + 1, &count, sizeof(uint32_t));
     std::memcpy(buf.data() + 1 + sizeof(uint32_t), events.data(), count * sizeof(NetParticleEvent));
 
-    for (const auto& [clientId, conn] : clients) {
-        if (!send(clientId, buf.data(), static_cast<int>(buf.size()))) {
-            SDL_Log("Server: failed to send PARTICLE_SPAWN packet to client %d", clientId.value);
-        }
+    if (!broadcast(buf.data(), static_cast<int>(buf.size()))) {
+        SDL_Log("Server: failed to broadcast PARTICLE_SPAWN packet to clients");
     }
 }
 
@@ -230,9 +225,20 @@ void Server::broadcastMatchStatus(MatchStatePacket packet)
     buf[0] = static_cast<uint8_t>(PacketType::MATCH_STATE);
     std::memcpy(buf.data() + 1, &packet, sizeof(MatchStatePacket));
 
+    if (!broadcast(buf.data(), static_cast<int>(buf.size()))) {
+        SDL_Log("Server: failed to broadcast MATCH_STATE packet to clients");
+    }
+}
+
+bool Server::broadcast(const void* data, int len)
+{
+    bool success = true;
     for (const auto& [clientId, conn] : clients) {
-        if (!send(clientId, buf.data(), static_cast<int>(buf.size()))) {
-            SDL_Log("Server: failed to send MATCH_STATE packet to client %d", clientId.value);
+        if (!send(clientId, data, len)) {
+            SDL_Log("Server: failed to send broadcast packet to client %d", clientId.value);
+            success = false;
         }
     }
+
+    return success;
 }

--- a/src/server/network/Server.hpp
+++ b/src/server/network/Server.hpp
@@ -5,6 +5,7 @@
 
 #include "ecs/components/ClientId.hpp"
 #include "ecs/registry/Registry.hpp"
+#include "network/MatchStatus.hpp"
 #include "network/MessageStream.hpp"
 #include "network/ShotEvent.hpp"
 #include "systems/EventQueue.hpp"
@@ -51,6 +52,13 @@ public:
 
     /// @brief Broadcast particle events to all clients for effect replication.
     void broadcastParticleEvents(const std::vector<NetParticleEvent>& events);
+
+    /// @brief Get the number of currently connected clients.
+    /// @return The client count.
+    int getClientCount();
+
+    /// @brief Broadcast match status updates to clients.
+    void broadcastMatchStatus(MatchStatePacket packet);
 
 private:
     /// @brief Per-client connection state.

--- a/src/server/network/Server.hpp
+++ b/src/server/network/Server.hpp
@@ -90,6 +90,9 @@ private:
 
     bool send(const ClientId& clientId, const void* data, int len);
 
+    /// @brief Broadcast raw data to all clients.
+    bool broadcast(const void* data, int len);
+
     NET_Server* server = nullptr;                     ///< Underlying SDL_net server handle.
 
     std::unordered_map<ClientId, Connection> clients; ///< Currently connected clients.

--- a/src/server/systems/MatchController.cpp
+++ b/src/server/systems/MatchController.cpp
@@ -1,0 +1,74 @@
+/// @file MatchController.cpp
+/// @brief Implementation of the MatchController system that manages match flow and state.
+
+#include "MatchController.hpp"
+
+void MatchController::update(float deltaTime, Registry& registry, Server& server)
+{
+    switch (currentPhase) {
+    case MatchPhase::WARMUP: {
+        // NOTE: Change in future to support more dynamic match start conditions
+        // such as manual start by host, min player count
+        if (server.getClientCount() >= 2) {
+            SDL_Log("MatchController: enough players connected, starting countdown");
+            currentPhase = MatchPhase::COUNTDOWN;
+            countdownTimer = k_countdownDuration;
+        }
+        break;
+    }
+    case MatchPhase::COUNTDOWN: {
+        // NOTE: Can still kill players during countdown.
+        countdownTimer -= deltaTime;
+        if (countdownTimer <= 0.0f) {
+            SDL_Log("MatchController: countdown finished, starting match");
+            currentPhase = MatchPhase::IN_PROGRESS;
+            countdownTimer = 0.0f;
+        }
+        break;
+    }
+    case MatchPhase::IN_PROGRESS: {
+        // TODO: check for win condition (e.g. a player reaches k_killsToWin)
+        // upon win, set winnerId and transition to FINISHED phase
+        if (winnerId != -1) {
+            SDL_Log("MatchController: player %d wins, ending match", winnerId);
+            currentPhase = MatchPhase::FINISHED;
+            countdownTimer = k_finishedDuration;
+        }
+        break;
+    }
+    case MatchPhase::FINISHED: {
+        // NOTE: Currently resets to WARMUP after fixed duration
+        countdownTimer -= deltaTime;
+        if (countdownTimer <= 0.0f) {
+            SDL_Log("MatchController: finished duration elapsed");
+            currentPhase = MatchPhase::WARMUP;
+            countdownTimer = 0.0f;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    broadcastMatchState(server);
+}
+
+MatchPhase MatchController::getCurrentPhase()
+{
+    return currentPhase;
+}
+
+int MatchController::getWinnerId()
+{
+    return winnerId;
+}
+
+void MatchController::broadcastMatchState(Server& server)
+{
+    MatchStatePacket packet;
+    packet.phase = currentPhase;
+    packet.countdownTimer = countdownTimer;
+    packet.winnerId = winnerId;
+
+    server.broadcastMatchStatus(packet);
+}

--- a/src/server/systems/MatchController.cpp
+++ b/src/server/systems/MatchController.cpp
@@ -3,6 +3,8 @@
 
 #include "MatchController.hpp"
 
+#include "ecs/systems/MatchSystem.hpp"
+
 void MatchController::update(float deltaTime, Registry& registry, Server& server)
 {
     switch (currentPhase) {
@@ -27,10 +29,8 @@ void MatchController::update(float deltaTime, Registry& registry, Server& server
         break;
     }
     case MatchPhase::IN_PROGRESS: {
-        // TODO: check for win condition (e.g. a player reaches k_killsToWin)
-        // upon win, set winnerId and transition to FINISHED phase
-        if (winnerId != -1) {
-            SDL_Log("MatchController: player %d wins, ending match", winnerId);
+        if (systems::handleWinCondition(registry, k_killsToWin)) {
+            SDL_Log("MatchController: player has won, ending match");
             currentPhase = MatchPhase::FINISHED;
             countdownTimer = k_finishedDuration;
         }
@@ -43,6 +43,7 @@ void MatchController::update(float deltaTime, Registry& registry, Server& server
             SDL_Log("MatchController: finished duration elapsed");
             currentPhase = MatchPhase::WARMUP;
             countdownTimer = 0.0f;
+            systems::resetStats(registry);
         }
         break;
     }

--- a/src/server/systems/MatchController.hpp
+++ b/src/server/systems/MatchController.hpp
@@ -1,0 +1,26 @@
+/// @file MatchControler.hpp
+/// @brief Controls match flow, including starting and ending matches and managing match state.
+#pragma once
+
+#include "ecs/registry/Registry.hpp"
+#include "network/MatchStatus.hpp"
+#include "network/Server.hpp"
+
+class MatchController
+{
+public:
+    void update(float deltaTime, Registry& registry, Server& server);
+    MatchPhase getCurrentPhase();
+    int getWinnerId();
+
+private:
+    MatchPhase currentPhase = MatchPhase::WARMUP;
+    float countdownTimer = 0.0f;
+    int winnerId = -1;
+
+    static constexpr float k_countdownDuration = 5.0f;
+    static constexpr float k_finishedDuration = 5.0f;
+    static constexpr int k_killsToWin = 10;
+
+    void broadcastMatchState(Server& server);
+};


### PR DESCRIPTION
Implemented Match Controller to handle different states in the middle of a game.

Closes #69 

Added:
- Packet sending current match state to client
- Win Condition Check (currently set to 10 kills)
- Kill + Death stats
- Match States: Warmup, Countdown, In Progress, Finished