### PR TITLE
Add death handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,7 @@ add_executable(group2
         src/ecs/components/Player.hpp
         src/client/systems/KillFeedEvent.hpp
         src/ecs/components/RespawnTimer.hpp
+        src/ecs/components/DeathInfo.hpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)
@@ -855,6 +856,7 @@ add_executable(client
         src/network/MatchStatus.hpp
         src/client/systems/KillFeedEvent.hpp
         src/ecs/components/RespawnTimer.hpp
+        src/ecs/components/DeathInfo.hpp
 )
 
 target_include_directories(client PRIVATE
@@ -1010,6 +1012,7 @@ add_executable(server
         src/ecs/systems/MatchSystem.cpp
         src/network/NetKillEvent.hpp
         src/ecs/components/RespawnTimer.hpp
+        src/ecs/components/DeathInfo.hpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,6 +611,7 @@ add_executable(group2
         src/ecs/systems/PlayerStatusSystem.cpp
         src/ecs/components/Player.hpp
         src/client/systems/KillFeedEvent.hpp
+        src/ecs/components/RespawnTimer.hpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)
@@ -853,6 +854,7 @@ add_executable(client
         src/ecs/components/Player.hpp
         src/network/MatchStatus.hpp
         src/client/systems/KillFeedEvent.hpp
+        src/ecs/components/RespawnTimer.hpp
 )
 
 target_include_directories(client PRIVATE
@@ -1007,6 +1009,7 @@ add_executable(server
         src/ecs/systems/MatchSystem.hpp
         src/ecs/systems/MatchSystem.cpp
         src/network/NetKillEvent.hpp
+        src/ecs/components/RespawnTimer.hpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -656,7 +656,8 @@ SDL_AppResult Game::iterate()
         }
 
         if (!client.poll(registry)) {
-            return SDL_APP_FAILURE;
+            // TODO: Update so reset to menu or some other non-crash state
+            return SDL_APP_SUCCESS;
         }
 
         refreshRemotePlayerRenderables();
@@ -1796,7 +1797,7 @@ void Game::refreshRemotePlayerRenderables()
     // crouching changes the half-height — no manual offset update needed.
     registry.view<Position, PlayerState, InputSnapshot, CollisionShape>().each([&](entt::entity e,
                                                                                    const Position&,
-                                                                                   const PlayerState&,
+                                                                                   const PlayerState& state,
                                                                                    const InputSnapshot& input,
                                                                                    const CollisionShape& shape) {
         if (registry.all_of<LocalPlayer>(e))
@@ -1819,7 +1820,7 @@ void Game::refreshRemotePlayerRenderables()
         // FBX pre-rotation.  Add a rig-local fix here if the rig ends up
         // facing the wrong axis after a visual check.
         rend.orientation = glm::angleAxis(input.yaw, glm::vec3{0, 1, 0});
-        rend.visible = true;
+        rend.visible = !state.IsDead;
     });
 }
 

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -9,6 +9,7 @@
 #include "ecs/components/BeamState.hpp"
 #include "ecs/components/ClientId.hpp"
 #include "ecs/components/CollisionShape.hpp"
+#include "ecs/components/DeathInfo.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LocalPlayer.hpp"
 #include "ecs/components/PlayerMatchStats.hpp"
@@ -16,6 +17,7 @@
 #include "ecs/components/Position.hpp"
 #include "ecs/components/PreviousPosition.hpp"
 #include "ecs/components/Renderable.hpp"
+#include "ecs/components/RespawnTimer.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/ViewmodelConfig.hpp"
 #include "ecs/components/WeaponConfig.hpp"
@@ -1634,6 +1636,63 @@ SDL_AppResult Game::iterate()
 
             dl->AddRectFilled(ImVec2(x, y), ImVec2(x + boxW, y + boxH), bg, 3.0f);
             dl->AddText(font, fontSize, ImVec2(x + k_padX, y + (boxH - fontSize) * 0.5f), fg, buf);
+        }
+    }
+
+    // Death HUD — bottom bar shown while local player is dead.
+    {
+        entt::entity localPlayer = entt::null;
+        registry.view<LocalPlayer>().each([&](entt::entity e) { localPlayer = e; });
+
+        if (localPlayer != entt::null && registry.all_of<DeathInfo, RespawnTimer>(localPlayer)) {
+            const auto& deathInfo = registry.get<DeathInfo>(localPlayer);
+            const auto& respawnTimer = registry.get<RespawnTimer>(localPlayer);
+
+            ClientId localClientId{-1};
+            registry.view<LocalPlayer, ClientId>().each([&](const ClientId& cid) { localClientId = cid; });
+
+            char killerBuf[32];
+            const char* killerName;
+            if (localClientId.value != -1 && deathInfo.killerId == localClientId)
+                killerName = "yourself";
+            else {
+                std::snprintf(killerBuf, sizeof(killerBuf), "Player #%d", deathInfo.killerId.value);
+                killerName = killerBuf;
+            }
+
+            char line1[64], line2[64];
+            std::snprintf(line1, sizeof(line1), "Killed by: %s", killerName);
+            std::snprintf(line2,
+                          sizeof(line2),
+                          "Their HP: %.0f  Armor: %.0f  |  Respawning in %.0fs",
+                          static_cast<double>(deathInfo.killerHealth.health),
+                          static_cast<double>(deathInfo.killerHealth.armor),
+                          std::ceil(static_cast<double>(respawnTimer.timeRemaining)));
+
+            int winW = 0, winH = 0;
+            SDL_GetWindowSizeInPixels(window, &winW, &winH);
+
+            ImDrawList* dl = ImGui::GetForegroundDrawList();
+            ImFont* font = ImGui::GetFont();
+            const float fs = ImGui::GetFontSize();
+
+            static constexpr float k_padX = 12.0f;
+            static constexpr float k_padY = 8.0f;
+            static constexpr float k_marginB = 16.0f;
+            static constexpr float k_lineGap = 4.0f;
+
+            const float boxH = fs * 2.0f + k_lineGap + k_padY * 2.0f;
+            const float boxW = static_cast<float>(winW) * 0.4f;
+            const float x = (static_cast<float>(winW) - boxW) * 0.5f;
+            const float y = static_cast<float>(winH) - boxH - k_marginB;
+
+            const ImU32 bg = ImGui::ColorConvertFloat4ToU32(ImVec4(0.0f, 0.0f, 0.0f, 0.65f));
+            const ImU32 fg = ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+            const ImU32 fg2 = ImGui::ColorConvertFloat4ToU32(ImVec4(0.85f, 0.85f, 0.85f, 0.85f));
+
+            dl->AddRectFilled(ImVec2(x, y), ImVec2(x + boxW, y + boxH), bg, 4.0f);
+            dl->AddText(font, fs, ImVec2(x + k_padX, y + k_padY), fg, line1);
+            dl->AddText(font, fs, ImVec2(x + k_padX, y + k_padY + fs + k_lineGap), fg2, line2);
         }
     }
 

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -9,6 +9,7 @@
 #include "ecs/components/BeamState.hpp"
 #include "ecs/components/ClientId.hpp"
 #include "ecs/components/CollisionShape.hpp"
+#include "ecs/components/Controllable.hpp"
 #include "ecs/components/DeathInfo.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LocalPlayer.hpp"
@@ -166,10 +167,26 @@ bool Game::init()
             SDL_Log("[client] glow cylinder uploaded (model index %d)", glowCylinderModelIdx_);
     }
 
+    // Remove Controllable when the local player dies (RespawnTimer added),
+    // restore it when they respawn (RespawnTimer removed).
+    registry.on_construct<RespawnTimer>().connect<[](entt::registry& reg, entt::entity e) {
+        if (reg.all_of<LocalPlayer>(e))
+            reg.remove<Controllable>(e);
+    }>();
+    registry.on_destroy<RespawnTimer>().connect<[](entt::registry& reg, entt::entity e) {
+        if (reg.all_of<LocalPlayer>(e))
+            reg.emplace_or_replace<Controllable>(e);
+    }>();
+
     client.onLocalPlayerReady([this](entt::entity local) {
         registry.emplace<LocalPlayer>(local);
         registry.emplace<InputSnapshot>(local);
         registry.emplace<PreviousPosition>(local, registry.get<Position>(local).value);
+
+        // Only add Controllable if the player is not already dead (edge case:
+        // joining while mid-death on a long-running server).
+        if (!registry.all_of<RespawnTimer>(local))
+            registry.emplace<Controllable>(local);
 
         // Animator runs for local too — future gun-IK / hands-on-weapon work
         // needs an up-to-date upper-body pose even when the body is invisible.

--- a/src/client/systems/InputSampleSystem.hpp
+++ b/src/client/systems/InputSampleSystem.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "ecs/components/Controllable.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LocalPlayer.hpp"
 #include "ecs/registry/Registry.hpp"
@@ -35,7 +36,7 @@ inline void runMouseLook(Registry& registry, float mouseSensitivity)
     float mdy = 0.0f;
     SDL_GetRelativeMouseState(&mdx, &mdy);
 
-    registry.view<InputSnapshot, LocalPlayer>().each([&](InputSnapshot& snap) {
+    registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         // Negate: SDL mdx is positive when moving right, but positive yaw
         // rotates toward +X which maps to screen-left via glm::lookAt's
         // cross(forward, up) convention.  Negating gives the standard
@@ -61,7 +62,7 @@ inline void runMovementKeys(Registry& registry)
 {
     const bool* const kKeys = SDL_GetKeyboardState(nullptr);
 
-    registry.view<InputSnapshot, LocalPlayer>().each([&](InputSnapshot& snap) {
+    registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         snap.forward = kKeys[SDL_SCANCODE_W];
         snap.back = kKeys[SDL_SCANCODE_S];
         snap.left = kKeys[SDL_SCANCODE_A];
@@ -85,7 +86,7 @@ inline void runWeaponKeys(Registry& registry)
     const bool* const kKeys = SDL_GetKeyboardState(nullptr);
     const SDL_MouseButtonFlags mouse = SDL_GetMouseState(nullptr, nullptr);
 
-    registry.view<InputSnapshot, LocalPlayer>().each([&](InputSnapshot& snap) {
+    registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         snap.shooting =
             (mouse & SDL_BUTTON_LMASK) != 0; // Apply bitmask to mouse input, true if left click is held down.
         snap.switchToPrimary = kKeys[SDL_SCANCODE_1];

--- a/src/ecs/components/Controllable.hpp
+++ b/src/ecs/components/Controllable.hpp
@@ -1,0 +1,9 @@
+/// @file Controllable.hpp
+/// @brief Client side Tag component — entity is eligible to receive player input.
+
+#pragma once
+
+/// @brief Client side Tag component — entity is eligible to receive player input.
+/// Removed on death (RespawnTimer added); restored on respawn (RespawnTimer removed).
+struct Controllable
+{};

--- a/src/ecs/components/DeathInfo.hpp
+++ b/src/ecs/components/DeathInfo.hpp
@@ -1,0 +1,13 @@
+/// @file DeathInfo.hpp
+/// @brief Component for enemy information upon death
+
+#pragma once
+
+#include "ecs/components/ClientId.hpp"
+#include "ecs/components/Health.hpp"
+
+struct DeathInfo
+{
+    ClientId killerId;   // ClientId of the killer
+    Health killerHealth; // Health of the killer at the moment of the kill
+};

--- a/src/ecs/components/RespawnTimer.hpp
+++ b/src/ecs/components/RespawnTimer.hpp
@@ -1,0 +1,9 @@
+/// @file RespawnTimer.hpp
+/// @brief Component for tracking player respawn times.
+
+#pragma once
+
+struct RespawnTimer
+{
+    float timeRemaining; // Time remaining until player respawns.
+};

--- a/src/ecs/systems/PlayerStatusSystem.cpp
+++ b/src/ecs/systems/PlayerStatusSystem.cpp
@@ -4,6 +4,7 @@
 #include "PlayerStatusSystem.hpp"
 
 #include "SDL3/SDL_log.h"
+#include "ecs/components/DeathInfo.hpp"
 #include "ecs/components/Health.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/Player.hpp"
@@ -52,6 +53,7 @@ inline void handleRespawn(entt::entity& player, Registry& registry)
     const WeaponConfig& rocketConfig = getWeaponConfig(WeaponType::Rocket);
 
     registry.erase<RespawnTimer>(player);
+    registry.erase<DeathInfo>(player);
     registry.patch<Renderable>(player, [](Renderable& rend) { rend.visible = true; });
     registry.emplace_or_replace<InputSnapshot>(player);
     registry.emplace_or_replace<Position>(player, glm::vec3{0.0f, 200.0f, 0.0f});
@@ -108,14 +110,23 @@ inline void handleDeath(entt::entity& player,
         // Award killer
         registry.get_or_emplace<PlayerMatchStats>(killer).kills++;
 
-        // Place kill event for network baroadcast
-        NetKillEvent event{
-            .killerId = registry.get<ClientId>(killer),
-            .victimId = registry.get<ClientId>(player),
-            .killerHealth = registry.get<Health>(killer),
-        };
+        // Get killer info
+        ClientId killerId = registry.get<ClientId>(killer);
+        Health killerHealth = registry.get<Health>(killer);
 
+        // Death info handling
+        NetKillEvent event{
+            .killerId = killerId,
+            .victimId = registry.get<ClientId>(player),
+            .killerHealth = killerHealth,
+        };
         killEvents.push_back(event);
+
+        registry.emplace_or_replace<DeathInfo>(player,
+                                               DeathInfo{
+                                                   .killerId = killerId,
+                                                   .killerHealth = killerHealth,
+                                               });
     }
 }
 

--- a/src/ecs/systems/PlayerStatusSystem.cpp
+++ b/src/ecs/systems/PlayerStatusSystem.cpp
@@ -10,6 +10,8 @@
 #include "ecs/components/PlayerMatchStats.hpp"
 #include "ecs/components/PlayerState.hpp"
 #include "ecs/components/Position.hpp"
+#include "ecs/components/Renderable.hpp"
+#include "ecs/components/RespawnTimer.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/WeaponConfig.hpp"
 #include "ecs/components/WeaponState.hpp"
@@ -49,6 +51,8 @@ inline void handleRespawn(entt::entity& player, Registry& registry)
     const WeaponConfig& wingmanConfig = getWeaponConfig(WeaponType::EnergyGun);
     const WeaponConfig& rocketConfig = getWeaponConfig(WeaponType::Rocket);
 
+    registry.erase<RespawnTimer>(player);
+    registry.patch<Renderable>(player, [](Renderable& rend) { rend.visible = true; });
     registry.emplace_or_replace<InputSnapshot>(player);
     registry.emplace_or_replace<Position>(player, glm::vec3{0.0f, 200.0f, 0.0f});
     registry.emplace_or_replace<Velocity>(player);
@@ -97,10 +101,12 @@ inline void handleDeath(entt::entity& player,
     if (playerHealth.health <= 0) {
         // Update death
         registry.get_or_emplace<PlayerState>(player).IsDead = true;
+        registry.patch<Renderable>(player, [](Renderable& rend) { rend.visible = false; });
+        registry.emplace_or_replace<RespawnTimer>(player, RespawnTimer{.timeRemaining = 5.0f});
         registry.patch<PlayerMatchStats>(player, [&](PlayerMatchStats& stats) { stats.deaths++; });
 
         // Award killer
-        registry.patch<PlayerMatchStats>(killer, [&](PlayerMatchStats& stats) { stats.kills++; });
+        registry.get_or_emplace<PlayerMatchStats>(killer).kills++;
 
         // Place kill event for network baroadcast
         NetKillEvent event{
@@ -110,15 +116,16 @@ inline void handleDeath(entt::entity& player,
         };
 
         killEvents.push_back(event);
-
-        // Respawn
-        handleRespawn(player, registry);
     }
 }
 
 void applyDamage(
     float damage, entt::entity player, entt::entity& killer, Registry& registry, std::vector<NetKillEvent>& killEvents)
 {
+    // If player is dead, ignore damage
+    if (registry.all_of<RespawnTimer>(player))
+        return;
+
     Health& playerHealth = registry.get_or_emplace<Health>(player);
 
     // Reset heal cooldown on every damage tick
@@ -153,8 +160,16 @@ inline void handleHealing(Health& playerHealth, float dt)
 void runPlayerStatus(Registry& registry, float dt)
 {
     registry.view<Player>().each([&registry, dt](entt::entity e) {
-        Health& playerHealth = registry.get_or_emplace<Health>(e);
-        handleHealing(playerHealth, dt);
+        if (registry.all_of<RespawnTimer>(e)) {
+            auto& respawnTimer = registry.get<RespawnTimer>(e);
+            respawnTimer.timeRemaining -= dt;
+            if (respawnTimer.timeRemaining <= 0) {
+                handleRespawn(e, registry);
+            }
+        } else {
+            Health& playerHealth = registry.get_or_emplace<Health>(e);
+            handleHealing(playerHealth, dt);
+        }
     });
 }
 } // namespace systems

--- a/src/ecs/systems/PlayerStatusSystem.hpp
+++ b/src/ecs/systems/PlayerStatusSystem.hpp
@@ -31,5 +31,4 @@ void applyDamage(
 /// @param registry  The ECS registry.
 /// @param dt        Fixed physics delta time in seconds.
 void runPlayerStatus(Registry& registry, float dt);
-
 } // namespace systems

--- a/src/network/RegistrySerialization.cpp
+++ b/src/network/RegistrySerialization.cpp
@@ -3,12 +3,14 @@
 #include "ecs/components/BeamState.hpp"
 #include "ecs/components/ClientId.hpp"
 #include "ecs/components/CollisionShape.hpp"
+#include "ecs/components/DeathInfo.hpp"
 #include "ecs/components/Health.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/PlayerMatchStats.hpp"
 #include "ecs/components/PlayerState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/Projectile.hpp"
+#include "ecs/components/RespawnTimer.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/WeaponState.hpp"
 #include "entt/entity/fwd.hpp"
@@ -46,7 +48,9 @@ using Synced = std::tuple<entt::entity,
                           PlayerMatchStats,
                           Projectile,
                           BeamState,
-                          ClientId>;
+                          ClientId,
+                          DeathInfo,
+                          RespawnTimer>;
 
 std::vector<uint8_t> serialize(const entt::registry& registry)
 {


### PR DESCRIPTION
Closes #75, closes #76 

Features:
- Shows enemy armor and health upon death
- Adds a respawn timer instead
- Hides render upon death
- Prevents player movement upon death