### PR TITLE
fix: Remove hitbox and gun on player death

### DIFF
--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -1128,6 +1128,8 @@ SDL_AppResult Game::iterate()
                                                                                        const CollisionShape&) {
             if (registry.all_of<LocalPlayer>(e))
                 return;
+            if (registry.all_of<RespawnTimer>(e))
+                return;
 
             const GunInstance& gun = (ws.current == WeaponSlot::QUATERNARY)  ? ws.quaternary
                                      : (ws.current == WeaponSlot::TERTIARY)  ? ws.tertiary
@@ -1349,7 +1351,8 @@ SDL_AppResult Game::iterate()
     // Build weapon viewmodel
     {
         WeaponViewmodel vm;
-        if (currentWeaponModelIdx >= 0) {
+        const auto localDeadView = registry.view<LocalPlayer, RespawnTimer>();
+        if (currentWeaponModelIdx >= 0 && localDeadView.begin() == localDeadView.end()) {
             vm.modelIndex = currentWeaponModelIdx;
             vm.visible = true;
 

--- a/src/ecs/systems/HitboxSystem.cpp
+++ b/src/ecs/systems/HitboxSystem.cpp
@@ -7,6 +7,7 @@
 #include "ecs/components/Hitbox.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/Position.hpp"
+#include "ecs/components/RespawnTimer.hpp"
 
 #include <cmath>
 #include <glm/ext/matrix_transform.hpp>
@@ -17,7 +18,11 @@ namespace systems
 
 void updateHitboxes(Registry& registry, const HitboxRig& hitboxRig, float rigScale, float rigMeshMinY)
 {
-    auto view = registry.view<Position, JointMatrices>();
+    // Remove stale hitboxes from dead/respawning entities (handles client side where handleDeath doesn't run).
+    for (auto entity : registry.view<RespawnTimer>())
+        registry.remove<HitboxInstance>(entity);
+
+    auto view = registry.view<Position, JointMatrices>(entt::exclude<RespawnTimer>);
     view.each([&](entt::entity entity, const Position& pos, const JointMatrices& joints) {
         auto& instance = registry.get_or_emplace<HitboxInstance>(entity);
         instance.capsules.resize(hitboxRig.definitions.size());

--- a/src/ecs/systems/PlayerStatusSystem.cpp
+++ b/src/ecs/systems/PlayerStatusSystem.cpp
@@ -107,6 +107,7 @@ inline void handleDeath(entt::entity& player,
         registry.get_or_emplace<PlayerState>(player).IsDead = true;
         registry.get_or_emplace<Velocity>(player) = Velocity{};
         registry.patch<Renderable>(player, [](Renderable& rend) { rend.visible = false; });
+        registry.remove<HitboxInstance>(player);
         registry.emplace_or_replace<RespawnTimer>(player, RespawnTimer{.timeRemaining = 5.0f});
         registry.patch<PlayerMatchStats>(player, [&](PlayerMatchStats& stats) { stats.deaths++; });
 


### PR DESCRIPTION
Before, a hitbox remained when a player was killed. Bullets would still interact with this hitbox. Guns would also remain floating on a player's death. Both fixed by checking for instance of RespawnTimer.