### PR TITLE
fix: background suspend fast-forward and bullet holes on player hits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,17 @@ endif()
 # off across the board.  PCH already provides the bulk of the rebuild-speed
 # win that split-dwarf was helping with.
 
+# Clang validates PCH freshness by checking system header mtime.  Package
+# manager updates (apt upgrade, brew upgrade) bump mtimes without changing
+# content, causing spurious "precompiled header has been modified" errors.
+# -fno-pch-timestamp stops baking file timestamps into the PCH so mtime
+# changes alone never invalidate it.  Applied only to our own targets (not
+# FetchContent deps) via target_compile_options below — search for
+# "PCH_NO_TIMESTAMP_TARGETS".
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(PCH_NO_TIMESTAMP_FLAG "-Xclang;-fno-pch-timestamp" CACHE INTERNAL "")
+endif()
+
 # ---- Dependencies ----
 
 # SDL3 — window, input, GPU pipeline (Vulkan/Metal/DX12) + OpenGL context
@@ -833,6 +844,10 @@ target_precompile_headers(group2 PRIVATE
     <entt/entt.hpp>
     <SDL3/SDL.h>
 )
+# PCH_NO_TIMESTAMP_TARGETS — see note near top of file.
+if(PCH_NO_TIMESTAMP_FLAG)
+    target_compile_options(group2 PRIVATE ${PCH_NO_TIMESTAMP_FLAG})
+endif()
 
 # Copy assets (models, textures, …) next to the binary so the renderer can
 # find them via SDL_GetBasePath().  Tolerate missing dir (e.g. CI without LFS).
@@ -1112,6 +1127,10 @@ target_precompile_headers(client PRIVATE
     <entt/entt.hpp>
     <SDL3/SDL.h>
 )
+# PCH_NO_TIMESTAMP_TARGETS — see note near top of file.
+if(PCH_NO_TIMESTAMP_FLAG)
+    target_compile_options(client PRIVATE ${PCH_NO_TIMESTAMP_FLAG})
+endif()
 
 # Copy assets next to the binary (same as group2).
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/assets")
@@ -1248,6 +1267,10 @@ target_precompile_headers(server PRIVATE
     <entt/entt.hpp>
     <SDL3/SDL.h>
 )
+# PCH_NO_TIMESTAMP_TARGETS — see note near top of file.
+if(PCH_NO_TIMESTAMP_FLAG)
+    target_compile_options(server PRIVATE ${PCH_NO_TIMESTAMP_FLAG})
+endif()
 
 # Copy config.toml next to the server binary when it changes.
 add_custom_command(

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -109,49 +109,58 @@ void DebugUI::newFrame()
     ImGui::NewFrame();
 }
 
-void DebugUI::toggleAllPanels(std::initializer_list<bool*> externalPanels)
+void DebugUI::toggleDebugMenu()
 {
-    // All window-visibility flags owned by DebugUI in one place — keep this
-    // list in sync with the private members in DebugUI.hpp when adding new
-    // top-level panels. Panels owned by other systems (e.g. Game's Animation
-    // Tester) are passed in via externalPanels.
-    bool* const ownedPanels[] = {
-        &showInspector,
-        &showMovementChart,
-        &showBhopAnalyzer,
-        &showParticleWindow_,
-        &showRenderToggles,
-        &showLightingControls,
-        &showSkybox,
-        &showNetworkStats,
-        &showHitboxWindow,
-        &showCollisionWindow,
-    };
+    showDebugMenu = !showDebugMenu;
+}
 
-    // If anything is currently visible (owned or external), hide everything;
-    // otherwise show everything.
-    bool anyVisible = false;
-    for (bool* p : ownedPanels) {
-        if (*p) {
-            anyVisible = true;
-            break;
+void DebugUI::buildDebugMenu(std::initializer_list<ExternalPanel> externalPanels)
+{
+    if (!showDebugMenu)
+        return;
+
+    ImGui::SetNextWindowPos({10.0f, 10.0f}, ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize({260.0f, 0.0f}, ImGuiCond_FirstUseEver);
+    constexpr ImGuiWindowFlags k_flags =
+        ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize;
+    if (!ImGui::Begin("Debug Menu (F2)", &showDebugMenu, k_flags)) {
+        ImGui::End();
+        return;
+    }
+
+    ImGui::TextDisabled("F2: toggle this menu  |  F3: toggle cursor");
+    ImGui::Separator();
+
+    // DebugUI-owned panels
+    ImGui::SeparatorText("Inspector");
+    ImGui::Checkbox("ECS Inspector", &showInspector);
+    ImGui::Checkbox("Movement Chart", &showMovementChart);
+    ImGui::Checkbox("Bhop Analyzer", &showBhopAnalyzer);
+
+    ImGui::SeparatorText("Rendering");
+    ImGui::Checkbox("Render Toggles", &showRenderToggles);
+    ImGui::Checkbox("Lighting Controls", &showLightingControls);
+    ImGui::Checkbox("Skybox Selector", &showSkybox);
+
+    ImGui::SeparatorText("Gameplay");
+    ImGui::Checkbox("Network Stats", &showNetworkStats);
+    ImGui::Checkbox("Weapon HUD", &showWeaponHud);
+    ImGui::Checkbox("Particle System", &showParticleWindow_);
+
+    ImGui::SeparatorText("Physics");
+    ImGui::Checkbox("Hitbox Debug", &showHitboxWindow);
+    ImGui::Checkbox("Collision Debug", &showCollisionWindow);
+
+    // External panels (owned by Game)
+    if (externalPanels.size() > 0) {
+        ImGui::SeparatorText("Game");
+        for (const auto& panel : externalPanels) {
+            if (panel.visible)
+                ImGui::Checkbox(panel.name, panel.visible);
         }
     }
-    if (!anyVisible) {
-        for (bool* p : externalPanels) {
-            if (p && *p) {
-                anyVisible = true;
-                break;
-            }
-        }
-    }
-    const bool newState = !anyVisible;
-    for (bool* p : ownedPanels)
-        *p = newState;
-    for (bool* p : externalPanels) {
-        if (p)
-            *p = newState;
-    }
+
+    ImGui::End();
 }
 
 void DebugUI::buildUI(const Registry& registry,
@@ -201,7 +210,8 @@ void DebugUI::buildUI(const Registry& registry,
     if (showBhopAnalyzer)
         buildBhopAnalyzer(registry);
 
-    buildWeaponUI(registry);
+    if (showWeaponHud)
+        buildWeaponUI(registry);
 }
 
 // Contents of the ECS Inspector window, factored out so the Begin/End wrapping
@@ -221,7 +231,7 @@ void DebugUI::buildInspectorContents(const Registry& registry,
                                      const float fps5pLow)
 {
     // Key bindings reminder
-    ImGui::TextDisabled("ESC: toggle mouse  |  Q: quit  |  F2: toggle all panels");
+    ImGui::TextDisabled("F2: debug menu  |  F3: toggle cursor  |  ESC: toggle cursor");
     ImGui::Separator();
 
     // Settings

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -140,18 +140,27 @@ public:
     /// @brief Finalise the ImGui frame. Call after all ImGui draw calls, before Renderer::drawFrame().
     void render();
 
-    /// @brief Toggle every debug panel on/off at once.
+    /// @brief Toggle the unified debug menu on/off.
     ///
-    /// If any panel is currently visible, all panels are hidden. If all panels are
-    /// hidden, all panels become visible. Intended to be bound to a hotkey so the
-    /// user can clear the overlay for clean gameplay/screenshots and bring it
-    /// back with the same press.
-    /// @param externalPanels  Visibility flags for panels owned outside DebugUI
-    ///                        (e.g. the Animation Tester lives on Game). They
-    ///                        participate in both the "any visible?" check and
-    ///                        the bulk show/hide so the hotkey behavior stays
-    ///                        consistent across all debug windows.
-    void toggleAllPanels(std::initializer_list<bool*> externalPanels = {});
+    /// When visible, the debug menu shows one checkbox per debug panel. Individual
+    /// panels are only drawn when their checkbox is checked.
+    void toggleDebugMenu();
+
+    /// @brief Build the unified debug menu window.
+    ///
+    /// Renders a single ImGui window with a checkbox per debug panel (both
+    /// DebugUI-owned and external panels passed by Game). Only call when
+    /// `showDebugMenu` is true.
+    ///
+    /// @param externalPanels  Named toggle pairs for panels owned outside DebugUI.
+    struct ExternalPanel
+    {
+        const char* name; ///< Display name shown as checkbox label.
+        bool* visible;    ///< Pointer to the visibility flag.
+    };
+    void buildDebugMenu(std::initializer_list<ExternalPanel> externalPanels);
+
+    bool showDebugMenu = false;      ///< Master toggle for the unified debug menu window.
 
     bool pendingAmmoRefill_ = false; ///< Set by Weapon HUD button, consumed by Game::iterate().
 
@@ -162,6 +171,7 @@ private:
     bool showLightingControls = false; ///< Show the Lighting Controls window.
     bool showSkybox = false;           ///< Show the Skybox window.
     bool showNetworkStats = false;     ///< Show the Network Stats window.
+    bool showWeaponHud = false;        ///< Show the Weapon HUD debug window (disabled by default).
 
     /// Per-component visibility toggles — persistent across frames.
     bool showPosition = true;       ///< Show Position component row.

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -520,15 +520,22 @@ SDL_AppResult Game::event(SDL_Event* event)
             //     break;
             // }
 
-        // F2 — toggle all ImGui debug panels at once. Hides them all if any
-        // are visible, shows them all if everything is hidden. Handy for clean
-        // gameplay / screenshots without losing the ability to bring the
-        // overlay back with a single press.
+        // F2 — toggle the unified debug menu. Individual panels are toggled
+        // from checkboxes inside the menu, not all-at-once.
         case SDLK_F2:
-            // Animation Tester is owned by Game (animUI_), not DebugUI, so
-            // pass its visibility flag in so F2 toggles every panel uniformly.
-            debugUI.toggleAllPanels(
-                {&animUI_.show, &showViewmodelUI, &showTPWeaponUI_, &showDynLightUI_, &showHudDebug_});
+            debugUI.toggleDebugMenu();
+            // Auto-release cursor when opening the debug menu so the user can
+            // interact with ImGui widgets immediately.
+            if (debugUI.showDebugMenu && mouseCaptured) {
+                mouseCaptured = false;
+                SDL_SetWindowRelativeMouseMode(window, false);
+            }
+            break;
+
+        // F3 — toggle mouse capture on/off independently.
+        case SDLK_F3:
+            mouseCaptured = !mouseCaptured;
+            SDL_SetWindowRelativeMouseMode(window, mouseCaptured);
             break;
 
         // Particle system test keys
@@ -606,9 +613,14 @@ SDL_AppResult Game::event(SDL_Event* event)
     }
 
     // Re-capture mouse on window click while uncaptured (standard FPS behaviour).
+    // Suppress recapture when ImGui wants the mouse (hovering over a debug
+    // window) or when the debug menu is open — let the user interact freely.
     if (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN && !mouseCaptured) {
-        mouseCaptured = true;
-        SDL_SetWindowRelativeMouseMode(window, true);
+        const ImGuiIO& io = ImGui::GetIO();
+        if (!io.WantCaptureMouse && !debugUI.showDebugMenu) {
+            mouseCaptured = true;
+            SDL_SetWindowRelativeMouseMode(window, true);
+        }
     }
 
     return SDL_APP_CONTINUE;
@@ -696,9 +708,29 @@ SDL_AppResult Game::iterate()
     const Uint64 k_now = SDL_GetPerformanceCounter();
 
     float frameTime = static_cast<float>(k_now - prevTime) / static_cast<float>(k_perfFreq);
-    frameTime = std::min(frameTime, 0.25f); // cap to avoid spiral-of-death
-    prevTime = k_now;
-    accumulator += frameTime;
+
+    // If the game was suspended (backgrounded / minimized), the raw delta can
+    // be enormous.  Rather than trying to catch up through potentially seconds
+    // of physics ticks (and replaying every buffered TCP message visually), we
+    // detect the gap and skip straight to the present.  The next client.poll()
+    // will still drain the TCP buffer so entity state snaps to current.
+    static constexpr float k_suspendThreshold = 0.5f; // half-second gap = clearly suspended
+    if (frameTime > k_suspendThreshold) {
+        SDL_Log("[client] detected suspend (gap %.2fs) — resetting accumulator", static_cast<double>(frameTime));
+        prevTime = k_now;
+        accumulator = k_physicsDt; // run exactly one tick to apply latest state
+        // Drain the network now so we snap to the current server state
+        // without fast-forwarding through every intermediate update.
+        client.poll(registry);
+        refreshRemotePlayerRenderables();
+        refreshRemoteProjectileRenderables();
+        refreshRemoteRespawnRenderables();
+        // Fall through to render the current frame normally.
+    } else {
+        frameTime = std::min(frameTime, 0.25f); // cap to avoid spiral-of-death
+        prevTime = k_now;
+        accumulator += frameTime;
+    }
 
     static int iterCount = 0;
     if (false && ++iterCount <= 3)
@@ -1586,6 +1618,16 @@ SDL_AppResult Game::iterate()
 
     // 10. Render
     debugUI.newFrame();
+
+    // Unified debug menu — one window with toggles for every debug panel.
+    debugUI.buildDebugMenu({
+        {"HUD Tweaker", &showHudDebug_},
+        {"Viewmodel Tweaker", &showViewmodelUI},
+        {"3P Weapon Tweaker", &showTPWeaponUI_},
+        {"Dynamic Lighting", &showDynLightUI_},
+        {"Animation Tester", &animUI_.show},
+    });
+
     debugUI.buildUI(registry,
                     tickCount,
                     mouseSensitivity,
@@ -1771,42 +1813,8 @@ SDL_AppResult Game::iterate()
                         static_cast<double>(recoilPitch_),
                         static_cast<double>(recoilPushBack_),
                         static_cast<double>(recoilRoll_));
-
-            ImGui::SeparatorText("Crosshair");
-            ImGui::Checkbox("Show Crosshair", &showCrosshair_);
-            ImGui::DragFloat("CH Size", &crosshairSize_, 0.5f, 1.0f, 30.0f);
-            ImGui::DragFloat("CH Gap", &crosshairGap_, 0.5f, 0.0f, 20.0f);
-            ImGui::DragFloat("CH Thickness", &crosshairThickness_, 0.5f, 0.5f, 5.0f);
-            ImGui::ColorEdit4("CH Color", &crosshairColor_.x);
-            ImGui::Checkbox("CH Dot", &crosshairDot_);
         }
         ImGui::End();
-    }
-
-    // Draw screen crosshair via ImGui foreground draw list
-    if (showCrosshair_ && mouseCaptured) {
-        int winW = 0, winH = 0;
-        SDL_GetWindowSizeInPixels(window, &winW, &winH);
-        const float cx = static_cast<float>(winW) * 0.5f;
-        const float cy = static_cast<float>(winH) * 0.5f;
-
-        const ImU32 col = ImGui::ColorConvertFloat4ToU32(
-            ImVec4(crosshairColor_.r, crosshairColor_.g, crosshairColor_.b, crosshairColor_.a));
-        ImDrawList* dl = ImGui::GetForegroundDrawList();
-
-        const float g = crosshairGap_;
-        const float s = crosshairSize_;
-        const float t = crosshairThickness_;
-
-        // Four lines: top, bottom, left, right
-        dl->AddLine(ImVec2(cx, cy - g - s), ImVec2(cx, cy - g), col, t); // up
-        dl->AddLine(ImVec2(cx, cy + g), ImVec2(cx, cy + g + s), col, t); // down
-        dl->AddLine(ImVec2(cx - g - s, cy), ImVec2(cx - g, cy), col, t); // left
-        dl->AddLine(ImVec2(cx + g, cy), ImVec2(cx + g + s, cy), col, t); // right
-
-        // Optional center dot
-        if (crosshairDot_)
-            dl->AddCircleFilled(ImVec2(cx, cy), t * 0.6f, col);
     }
 
     // Kill feed — tick timers and drop expired entries.

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -183,14 +183,6 @@ private:
     // Local weapon fire cooldown (mirrors server's per-weapon cooldown for VFX)
     float localFireCooldown_ = 0.0f; ///< Countdown timer; fire VFX only when <= 0.
 
-    // Crosshair settings (ImGui-adjustable)
-    float crosshairSize_ = 6.0f;                           ///< Half-length of each crosshair line (pixels).
-    float crosshairThickness_ = 2.0f;                      ///< Line thickness (pixels).
-    float crosshairGap_ = 3.0f;                            ///< Gap from center to start of each line (pixels).
-    glm::vec4 crosshairColor_ = {0.0f, 1.0f, 0.0f, 0.85f}; ///< RGBA (default: green).
-    bool crosshairDot_ = true;                             ///< Draw center dot.
-    bool showCrosshair_ = true;                            ///< Master toggle.
-
     // Scroll-wheel weapon switching
     int pendingScrollSwitch_ = 0; ///< +1 = next slot, -1 = prev slot, consumed each frame.
 

--- a/src/client/particles/ParticleSystem.cpp
+++ b/src/client/particles/ParticleSystem.cpp
@@ -128,7 +128,9 @@ void ParticleSystem::spawnHitscanBeam(glm::vec3 origin, glm::vec3 hitPos, Weapon
 void ParticleSystem::spawnImpactEffect(glm::vec3 pos, glm::vec3 normal, SurfaceType surf, WeaponType wt)
 {
     impact_.spawn(pos, normal, surf, frameDt_);
-    spawnBulletHole(pos, normal, wt);
+    // Don't leave bullet-hole decals on players — only on world surfaces.
+    if (surf != SurfaceType::Flesh)
+        spawnBulletHole(pos, normal, wt);
 }
 
 void ParticleSystem::spawnBulletHole(glm::vec3 pos, glm::vec3 normal, WeaponType wt)


### PR DESCRIPTION
- Detect window suspend (>0.5s frame gap) and reset the physics accumulator instead of catching up through seconds of buffered TCP state updates; entities snap to current server position on resume
- Skip bullet-hole decals on SurfaceType::Flesh so player hits only spawn blood sparks, not persistent wall decals
- Refactor DebugUI from toggle-all to a unified debug menu (F2) with per-panel checkboxes; F3 now toggles mouse capture independently
- Suppress mouse recapture when ImGui wants the cursor or debug menu is open
- Remove ImGui crosshair (migrated to HUD system)
- Disable ImGui weapon HUD by default (behind debug menu toggle)
- Add -fno-pch-timestamp for Clang to avoid spurious PCH invalidation from package-manager header mtime bumps