### PR TITLE
T3code/map collisions loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1349,6 +1349,24 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/assets/animations")
     )
 endif()
 
+# Copy prop GLBs (top-level files in assets/) next to the server binary so
+# MapLoader::loadPropCollision can find them.  ServerGame.cpp loads bottle_a /
+# metallic_pallet_factory_store as collision-only props for prediction parity
+# with the client.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/assets")
+    file(GLOB _server_prop_glbs "${CMAKE_CURRENT_SOURCE_DIR}/assets/*.glb")
+    if(_server_prop_glbs)
+        add_custom_command(TARGET server POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:server>/assets"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${_server_prop_glbs}
+                    "$<TARGET_FILE_DIR:server>/assets/"
+            COMMENT "Copying prop GLBs to server binary directory"
+            VERBATIM
+        )
+    endif()
+endif()
+
 # ===========================================================================
 # Clientbot executable — headless network-only load-test bot.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,21 @@ FetchContent_MakeAvailable(minimp3)
 add_library(minimp3 INTERFACE)
 target_include_directories(minimp3 SYSTEM INTERFACE ${minimp3_SOURCE_DIR})
 
+# V-HACD — Volumetric Hierarchical Approximate Convex Decomposition.
+# Header-only library used by MapLoader to split non-convex collision meshes
+# into a small set of convex hulls (WorldBrushes), avoiding triMesh-edge
+# jitter on curved surfaces.  Implementation lives in
+# src/ecs/physics/VHACDImpl.cpp via the ENABLE_VHACD_IMPLEMENTATION define.
+FetchContent_Declare(
+    vhacd
+    GIT_REPOSITORY https://github.com/kmammou/v-hacd.git
+    GIT_TAG        v4.1.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(vhacd)
+add_library(vhacd INTERFACE)
+target_include_directories(vhacd SYSTEM INTERFACE ${vhacd_SOURCE_DIR}/include)
+
 # ozz-animation — runtime skeletal animation (CPU skinning, sampling, blending).
 # We only need the runtime + offline builders; disable all extras.
 set(ozz_build_tests     OFF CACHE BOOL "" FORCE)
@@ -701,6 +716,7 @@ add_executable(group2
         src/ecs/physics/MapLoader.cpp
         src/ecs/physics/TriMeshCollision.hpp
         src/ecs/physics/TriMeshCollision.cpp
+        src/ecs/physics/VHACDImpl.cpp
         src/ecs/physics/WallDetection.hpp
         src/ecs/physics/WallDetection.cpp
         src/ecs/physics/TitanfallConstants.hpp
@@ -824,6 +840,7 @@ target_link_libraries(group2 PRIVATE
     glm::glm
     SDL3_net::SDL3_net
     EnTT::EnTT
+    vhacd
     imgui_lib
     assimp
     stb_image
@@ -1011,6 +1028,7 @@ add_executable(client
         src/ecs/physics/MapLoader.cpp
         src/ecs/physics/TriMeshCollision.hpp
         src/ecs/physics/TriMeshCollision.cpp
+        src/ecs/physics/VHACDImpl.cpp
         src/ecs/physics/WallDetection.hpp
         src/ecs/physics/WallDetection.cpp
         src/ecs/physics/TitanfallConstants.hpp
@@ -1117,6 +1135,7 @@ target_link_libraries(client PRIVATE
     glm::glm
     SDL3_net::SDL3_net
     EnTT::EnTT
+    vhacd
     imgui_lib
     assimp
     stb_image
@@ -1188,6 +1207,7 @@ add_executable(server
         src/ecs/physics/MapLoader.cpp
         src/ecs/physics/TriMeshCollision.hpp
         src/ecs/physics/TriMeshCollision.cpp
+        src/ecs/physics/VHACDImpl.cpp
         src/ecs/physics/WallDetection.hpp
         src/ecs/physics/WallDetection.cpp
         src/ecs/physics/TitanfallConstants.hpp
@@ -1265,6 +1285,7 @@ target_link_libraries(server PRIVATE
     EnTT::EnTT
     glm::glm
     assimp
+    vhacd
     tomlplusplus::tomlplusplus
     ozz_animation_offline
     ozz_animation

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -249,7 +249,7 @@ bool Game::init()
             }
         };
 
-        loadProp("porsche", "free_1975_porsche_911_930_turbo.glb", glm::vec3(-200.0f, 1.3f, 400.0f), 40.0f, true);
+        // Porsche removed — its 75-mesh hierarchy floods the collision debug UI.
         loadProp("pallet", "metallic_pallet_factory_store.glb", glm::vec3(0.0f, 0.0f, 600.0f), 0.25f, true);
         loadProp("bottle", "bottle_a.glb", glm::vec3(100.0f, 0.0f, 400.0f), 20.0f);
 

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -158,31 +158,59 @@ bool Game::init()
     {
         static constexpr float k_metersToInches = 39.3701f;
 
-        const char* base = SDL_GetBasePath();
-        const std::string mapPath = std::string(base ? base : "") + "assets/maps/map1.glb";
+        // Toggle: does this map use SEPARATED collision and visual meshes?
+        //   false → "prototype mode": every mesh in the GLB is both visual *and*
+        //           collision (used for blockout maps like map1.glb).
+        //   true  → "separated mode": collision-only meshes are tagged in Blender
+        //           (e.g. "COL_*" prefix) and excluded from the visual model.
+        //           Used for production maps where collision is hand-authored
+        //           independently from rendering geometry.
+        static constexpr bool k_separatedCollisionMap = true;
 
-        // 1) Extract collision geometry (prototype mode: all meshes → collision).
+        // Pattern that identifies collision-only nodes when in separated mode.
+        // The Blender export convention here is a "COL_" prefix; nodes whose
+        // names contain this substring (case-insensitive) are treated as
+        // collision-only and stripped from the visual mesh list.
+        static constexpr const char* k_collisionPattern = "COL_";
+
+        const char* const mapFilename = k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : "maps/map1.glb";
+
+        const char* base = SDL_GetBasePath();
+        const std::string mapPath = std::string(base ? base : "") + "assets/" + mapFilename;
+
+        // 1) Extract collision geometry.
         physics::MapLoadOptions opts;
         opts.scale = k_metersToInches;
-        opts.allMeshesAreCollision = true; // Prototype map — every mesh is both visual and collision.
-        opts.addFloorPlane = false;        // Map geometry provides its own floor.
+        opts.allMeshesAreCollision = !k_separatedCollisionMap;
+        // In separated mode, recognise collision-prefixed nodes; in prototype
+        // mode, the field is unused (every mesh is collision by definition).
+        if (k_separatedCollisionMap)
+            opts.collisionCollection = k_collisionPattern;
+        opts.addFloorPlane = false; // Map geometry provides its own floor.
 
         if (physics::loadMapCollision(mapPath, mapCollision_, opts)) {
-            SDL_Log("[client] map collision loaded: %zu planes, %zu boxes, %zu brushes",
+            SDL_Log("[client] map collision loaded: %zu planes, %zu boxes, %zu brushes, %zu cylinders, %zu spheres, "
+                    "%zu trimeshes",
                     mapCollision_.planes.size(),
                     mapCollision_.boxes.size(),
-                    mapCollision_.brushes.size());
+                    mapCollision_.brushes.size(),
+                    mapCollision_.cylinders.size(),
+                    mapCollision_.spheres.size(),
+                    mapCollision_.triMeshes.size());
         } else {
             SDL_Log("[client] WARNING: map collision load failed — falling back to testWorld()");
         }
 
         // 2) Load visual model for rendering (scene-pass so it draws as static world geometry).
-        const int mapId = assets_.add("map1", "maps/map1.glb", AssetRole::Map);
-        const int mapModelIdx = renderer.loadSceneModel("maps/map1.glb", glm::vec3(0.0f), k_metersToInches);
+        // In separated mode, exclude collision-only nodes so they aren't rendered.
+        const std::string visualExclude = k_separatedCollisionMap ? std::string(k_collisionPattern) : std::string();
+        const int mapId = assets_.add("map1", mapFilename, AssetRole::Map);
+        const int mapModelIdx =
+            renderer.loadSceneModel(mapFilename, glm::vec3(0.0f), k_metersToInches, false, visualExclude);
         assets_.setModelIndex(mapId, mapModelIdx);
         if (mapModelIdx >= 0) {
             renderer.setModelScenePass(mapModelIdx, true);
-            SDL_Log("[client] map visual loaded (model index %d)", mapModelIdx);
+            SDL_Log("[client] map visual loaded (model index %d, exclude='%s')", mapModelIdx, visualExclude.c_str());
         } else {
             SDL_Log("[client] WARNING: map visual load failed — map will be invisible");
         }

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -176,11 +176,12 @@ bool Game::init()
         // In separated mode, should the loader auto-fit each collision mesh
         // to a primitive (AABB / cylinder / sphere / brush) — or load the raw
         // Blender geometry as-is (triangle mesh)?
-        //   false (default) → trust the artist: every collision mesh becomes a
+        //   true  (default) → auto-detect: convex shapes become cheap primitives
+        //                     or brushes; only truly non-convex meshes fall
+        //                     back to triMesh.  Smoother collision overall.
+        //   false           → trust the artist: every collision mesh stays a
         //                     triMesh, vertex-for-vertex, exactly as authored.
-        //   true            → run the auto-detection pipeline (cheaper at
-        //                     runtime, but the loader picks the primitive).
-        static constexpr bool k_guessShapesProcessed = false;
+        static constexpr bool k_guessShapesProcessed = true;
 
         const char* const mapFilename = k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : "maps/map1.glb";
 

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -235,7 +235,16 @@ bool Game::init()
         const std::string basePath = base ? base : "";
 
         // Helper: load a prop with render + collision in one call.
-        auto loadProp = [&](const char* name, const char* filename, glm::vec3 pos, float scale, bool flipUVs = false) {
+        // `decomposeProp = true` runs V-HACD on each non-convex sub-mesh so
+        // organic/detailed shapes (a bottle, a metallic pallet) end up as a
+        // handful of `WorldBrush`es instead of a giant triangle mesh.  Costs
+        // a few seconds of load time per prop but kills triMesh edge-jitter.
+        auto loadProp = [&](const char* name,
+                            const char* filename,
+                            glm::vec3 pos,
+                            float scale,
+                            bool flipUVs = false,
+                            bool decomposeProp = false) {
             const int id = assets_.add(name, filename, AssetRole::Prop);
             const int modelIdx = renderer.loadSceneModel(filename, pos, scale, flipUVs);
             assets_.setModelIndex(id, modelIdx);
@@ -245,14 +254,26 @@ bool Game::init()
 
             // Load collision at the same position/scale.
             const std::string fullPath = basePath + "assets/" + filename;
-            if (physics::loadPropCollision(fullPath, mapCollision_, pos, scale)) {
+            if (physics::loadPropCollision(fullPath, mapCollision_, pos, scale, decomposeProp)) {
                 assets_.setHasCollision(id);
             }
         };
 
         // Porsche removed — its 75-mesh hierarchy floods the collision debug UI.
-        loadProp("pallet", "metallic_pallet_factory_store.glb", glm::vec3(0.0f, 0.0f, 600.0f), 0.25f, true);
-        loadProp("bottle", "bottle_a.glb", glm::vec3(100.0f, 0.0f, 400.0f), 20.0f);
+        // Pallet + bottle are organic/non-convex; decompose them via V-HACD so
+        // collision stays smooth even when the player slides along curved parts.
+        loadProp("pallet",
+                 "metallic_pallet_factory_store.glb",
+                 glm::vec3(0.0f, 0.0f, 600.0f),
+                 0.25f,
+                 /*flipUVs=*/true,
+                 /*decomposeProp=*/true);
+        loadProp("bottle",
+                 "bottle_a.glb",
+                 glm::vec3(100.0f, 0.0f, 400.0f),
+                 20.0f,
+                 /*flipUVs=*/false,
+                 /*decomposeProp=*/true);
 
         // Update the active world with the new collision data (map + all props).
         physics::setActiveWorld(mapCollision_.geometry());

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -173,6 +173,15 @@ bool Game::init()
         // collision-only and stripped from the visual mesh list.
         static constexpr const char* k_collisionPattern = "COL_";
 
+        // In separated mode, should the loader auto-fit each collision mesh
+        // to a primitive (AABB / cylinder / sphere / brush) — or load the raw
+        // Blender geometry as-is (triangle mesh)?
+        //   false (default) → trust the artist: every collision mesh becomes a
+        //                     triMesh, vertex-for-vertex, exactly as authored.
+        //   true            → run the auto-detection pipeline (cheaper at
+        //                     runtime, but the loader picks the primitive).
+        static constexpr bool k_guessShapesProcessed = false;
+
         const char* const mapFilename = k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : "maps/map1.glb";
 
         const char* base = SDL_GetBasePath();
@@ -186,6 +195,7 @@ bool Game::init()
         // mode, the field is unused (every mesh is collision by definition).
         if (k_separatedCollisionMap)
             opts.collisionCollection = k_collisionPattern;
+        opts.guessShapesProcessed = k_guessShapesProcessed;
         opts.addFloorPlane = false; // Map geometry provides its own floor.
 
         if (physics::loadMapCollision(mapPath, mapCollision_, opts)) {

--- a/src/client/renderer-new/Renderer.hpp
+++ b/src/client/renderer-new/Renderer.hpp
@@ -52,7 +52,11 @@ public:
     [[nodiscard]] const Camera& getCamera() const override { return legacyCameraStub_; }
 
     void setParticleSystem(ParticleSystem* /*ps*/) override {}
-    int loadSceneModel(const char* /*filename*/, glm::vec3 /*pos*/, float /*scale*/, bool /*flipUVs*/) override
+    int loadSceneModel(const char* /*filename*/,
+                       glm::vec3 /*pos*/,
+                       float /*scale*/,
+                       bool /*flipUVs*/,
+                       const std::string& /*excludeNodesContaining*/ = "") override
     {
         return -1;
     }

--- a/src/client/renderer/HybridRenderer.cpp
+++ b/src/client/renderer/HybridRenderer.cpp
@@ -193,11 +193,12 @@ void HybridRenderer::setParticleSystem(ParticleSystem* ps)
         legacy_.setParticleSystem(ps);
 }
 
-int HybridRenderer::loadSceneModel(const char* filename, glm::vec3 pos, float scale, bool flipUVs)
+int HybridRenderer::loadSceneModel(
+    const char* filename, glm::vec3 pos, float scale, bool flipUVs, const std::string& excludeNodesContaining)
 {
     if (next_.supports(RendererFeature::LoadSceneModel))
-        return next_.loadSceneModel(filename, pos, scale, flipUVs);
-    return legacy_.loadSceneModel(filename, pos, scale, flipUVs);
+        return next_.loadSceneModel(filename, pos, scale, flipUVs, excludeNodesContaining);
+    return legacy_.loadSceneModel(filename, pos, scale, flipUVs, excludeNodesContaining);
 }
 
 int HybridRenderer::uploadSceneModel(const LoadedModel& model)

--- a/src/client/renderer/HybridRenderer.hpp
+++ b/src/client/renderer/HybridRenderer.hpp
@@ -30,7 +30,11 @@ public:
     [[nodiscard]] const Camera& getCamera() const override;
 
     void setParticleSystem(ParticleSystem* ps) override;
-    int loadSceneModel(const char* filename, glm::vec3 pos, float scale, bool flipUVs = false) override;
+    int loadSceneModel(const char* filename,
+                       glm::vec3 pos,
+                       float scale,
+                       bool flipUVs = false,
+                       const std::string& excludeNodesContaining = "") override;
     int uploadSceneModel(const LoadedModel& model) override;
     bool setVSync(bool enabled) override;
     void

--- a/src/client/renderer/IRenderer.hpp
+++ b/src/client/renderer/IRenderer.hpp
@@ -67,7 +67,15 @@ public:
     [[nodiscard]] virtual const Camera& getCamera() const = 0;
 
     virtual void setParticleSystem(ParticleSystem* ps) = 0;
-    virtual int loadSceneModel(const char* filename, glm::vec3 pos, float scale, bool flipUVs) = 0;
+    /// @brief Load a model and return its index in the renderer's models list.
+    /// @param excludeNodesContaining  Optional case-insensitive substring; any
+    ///        node whose name contains it (and its descendants) is skipped.
+    ///        Used to drop collision-only meshes from a map's visual model.
+    virtual int loadSceneModel(const char* filename,
+                               glm::vec3 pos,
+                               float scale,
+                               bool flipUVs,
+                               const std::string& excludeNodesContaining = "") = 0;
     virtual int uploadSceneModel(const LoadedModel& model) = 0;
     virtual bool setVSync(bool enabled) = 0;
     virtual void

--- a/src/client/renderer/ModelLoader.cpp
+++ b/src/client/renderer/ModelLoader.cpp
@@ -5,6 +5,9 @@
 
 #include <SDL3/SDL_log.h>
 
+#include <algorithm>
+#include <cctype>
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -234,6 +237,20 @@ glm::mat4 aiToGlm(const aiMatrix4x4& m)
     return glm::transpose(glm::make_mat4(&m.a1));
 }
 
+/// @brief Case-insensitive substring search.  Returns false when needle is empty
+///        (the "no-filter" convention used by the exclude-pattern API).
+bool nodeNameContainsCI(const std::string& haystack, const std::string& needle)
+{
+    if (needle.empty())
+        return false;
+    auto toLower = [](std::string s) {
+        std::transform(
+            s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    };
+    return toLower(haystack).find(toLower(needle)) != std::string::npos;
+}
+
 // Recursive scene-graph traversal
 //
 // Key rules:
@@ -252,12 +269,23 @@ glm::mat4 aiToGlm(const aiMatrix4x4& m)
 /// @param parentTransform Accumulated parent world transform.
 /// @param outModel Output model receiving meshes and textures.
 /// @param embTexToDataIdx Mapping from Assimp texture index to textures[] index.
+/// @param excludePattern Skip the entire subtree whenever this node's name
+///        contains `excludePattern` (case-insensitive).  Empty disables filtering.
 void processNode(const aiNode* node,
                  const aiScene* scene,
                  const glm::mat4& parentTransform,
                  LoadedModel& outModel,
-                 std::vector<int>& embTexToDataIdx)
+                 std::vector<int>& embTexToDataIdx,
+                 const std::string& excludePattern)
 {
+    // Drop collision-only nodes (and their entire subtrees) from the visual model.
+    // For maps with separated collision/visual meshes (e.g. "COL_*" prefixed nodes
+    // from Blender), this prevents the collision geometry from being rendered.
+    if (nodeNameContainsCI(std::string(node->mName.C_Str()), excludePattern)) {
+        SDL_Log("ModelLoader: skipping excluded node '%s' (matches '%s')", node->mName.C_Str(), excludePattern.c_str());
+        return;
+    }
+
     const glm::mat4 worldTransform = parentTransform * aiToGlm(node->mTransformation);
 
     // Normal matrix: inverse-transpose of the upper-left 3×3.
@@ -363,12 +391,12 @@ void processNode(const aiNode* node,
 
     // Recurse into children.
     for (unsigned int c = 0; c < node->mNumChildren; ++c)
-        processNode(node->mChildren[c], scene, worldTransform, outModel, embTexToDataIdx);
+        processNode(node->mChildren[c], scene, worldTransform, outModel, embTexToDataIdx, excludePattern);
 }
 
 } // namespace
 
-bool loadModel(const std::string& path, LoadedModel& outModel, bool flipUVs)
+bool loadModel(const std::string& path, LoadedModel& outModel, bool flipUVs, const std::string& excludeNodesContaining)
 {
     Assimp::Importer importer;
 
@@ -398,7 +426,7 @@ bool loadModel(const std::string& path, LoadedModel& outModel, bool flipUVs)
 
     std::vector<int> embTexToDataIdx(scene->mNumTextures, -1);
 
-    processNode(scene->mRootNode, scene, glm::mat4(1.0f), outModel, embTexToDataIdx);
+    processNode(scene->mRootNode, scene, glm::mat4(1.0f), outModel, embTexToDataIdx, excludeNodesContaining);
 
     // Log material summary for all meshes (debugging aid).
     for (size_t m = 0; m < outModel.meshes.size(); ++m) {

--- a/src/client/renderer/ModelLoader.hpp
+++ b/src/client/renderer/ModelLoader.hpp
@@ -88,5 +88,13 @@ struct LoadedModel
 /// @param outModel    Filled on success.
 /// @param flipUVs     Flip V texture coordinates (V = 1 − V).  Set true for
 ///                    models from tools that use V=0 at bottom (Blender, OBJ).
+/// @param excludeNodesContaining  Skip any node (and its descendants) whose
+///                    name contains this substring (case-insensitive).  Used
+///                    to omit collision-only meshes from a map's visual model
+///                    (e.g. "COL_" to skip Blender collision-prefixed nodes).
+///                    Empty string disables filtering.
 /// @return True on success; false on failure (error logged via SDL_Log).
-bool loadModel(const std::string& path, LoadedModel& outModel, bool flipUVs = false);
+bool loadModel(const std::string& path,
+               LoadedModel& outModel,
+               bool flipUVs = false,
+               const std::string& excludeNodesContaining = "");

--- a/src/client/renderer/Renderer.cpp
+++ b/src/client/renderer/Renderer.cpp
@@ -3182,14 +3182,15 @@ void Renderer::downloadAndSaveCapture(const Uint32 w, const Uint32 h)
 
 // Misc
 
-int Renderer::loadSceneModel(const char* filename, glm::vec3 pos, float scale, bool flipUVs)
+int Renderer::loadSceneModel(
+    const char* filename, glm::vec3 pos, float scale, bool flipUVs, const std::string& excludeNodesContaining)
 {
     const char* const k_base = SDL_GetBasePath();
     char path[512];
     SDL_snprintf(path, sizeof(path), "%sassets/%s", k_base ? k_base : "", filename);
 
     LoadedModel loaded;
-    if (!loadModel(path, loaded, flipUVs)) {
+    if (!loadModel(path, loaded, flipUVs, excludeNodesContaining)) {
         SDL_Log("Renderer::loadSceneModel: failed to load '%s'", filename);
         return -1;
     }

--- a/src/client/renderer/Renderer.hpp
+++ b/src/client/renderer/Renderer.hpp
@@ -114,7 +114,11 @@ public:
     }
 
     /// @brief Load a model and return its index in the models[] vector, or -1 on failure.
-    int loadSceneModel(const char* filename, glm::vec3 pos, float scale, bool flipUVs = false) override;
+    int loadSceneModel(const char* filename,
+                       glm::vec3 pos,
+                       float scale,
+                       bool flipUVs = false,
+                       const std::string& excludeNodesContaining = "") override;
 
     /// @brief Upload a pre-built LoadedModel (e.g. from CharacterRig::templateLoadedModel()) and return its index.
     int uploadSceneModel(const LoadedModel& model) override;

--- a/src/ecs/physics/MapLoader.cpp
+++ b/src/ecs/physics/MapLoader.cpp
@@ -545,6 +545,33 @@ bool buildBrushFromHull(const VHACD::IVHACD::ConvexHull& hull, WorldBrush& outBr
     if (static_cast<int>(uniquePlanes.size()) < 4 || static_cast<int>(uniquePlanes.size()) > WorldBrush::k_maxPlanes)
         return false;
 
+    // SANITY CHECK: every hull vertex must satisfy `dot(n, v) - dist <= 0` for
+    // every plane (with a small tolerance for face vertices that lie *on* the
+    // plane).  If any vertex sits outside its own brush by more than the
+    // tolerance, the brush is malformed (wrong winding, bad dedup, bad face
+    // normal) and bullets/players will fly straight through it because the
+    // sweep tests against half-spaces that don't actually enclose the hull.
+    // Reject the brush so the caller can fall through to triMesh.
+    const float k_validateTolerance = meshDiag * 0.01f; // 1% of mesh diagonal
+    for (const auto& v : verts) {
+        for (const auto& plane : uniquePlanes) {
+            const float d = glm::dot(plane.normal, v) - plane.distance;
+            if (d > k_validateTolerance) {
+                SDL_Log("MapLoader: rejecting V-HACD hull — vertex (%.2f,%.2f,%.2f) is %.3f outside plane "
+                        "(normal=%.2f,%.2f,%.2f dist=%.2f) — malformed convex region",
+                        static_cast<double>(v.x),
+                        static_cast<double>(v.y),
+                        static_cast<double>(v.z),
+                        static_cast<double>(d),
+                        static_cast<double>(plane.normal.x),
+                        static_cast<double>(plane.normal.y),
+                        static_cast<double>(plane.normal.z),
+                        static_cast<double>(plane.distance));
+                return false;
+            }
+        }
+    }
+
     outBrush.planeCount = static_cast<int>(uniquePlanes.size());
     for (int i = 0; i < outBrush.planeCount; ++i) {
         outBrush.planes[i].normal = uniquePlanes[static_cast<size_t>(i)].normal;
@@ -1055,7 +1082,8 @@ bool loadMapCollision(const std::string& path, MapCollisionData& out, const MapL
     return true;
 }
 
-bool loadPropCollision(const std::string& path, MapCollisionData& out, glm::vec3 position, float scale)
+bool loadPropCollision(
+    const std::string& path, MapCollisionData& out, glm::vec3 position, float scale, bool decomposeNonConvex)
 {
     Assimp::Importer importer;
 
@@ -1083,35 +1111,28 @@ bool loadPropCollision(const std::string& path, MapCollisionData& out, glm::vec3
     // We can't use extractCollision directly because it computes the transform
     // from the node hierarchy.  Instead, use a simple recursive walk that
     // multiplies our prop transform with each node's accumulated transform.
+    // decomposeNonConvex is captured by the walker so non-convex sub-meshes
+    // either go through V-HACD (smoother runtime collision, slower load) or
+    // fall back to triMesh (instant load, jittery on curved contacts).
     struct Walker
     {
-        static void
-        walk(const aiNode* node, const aiScene* scene, const glm::mat4& parentTransform, MapCollisionData& out)
+        bool decompose;
+        void walk(const aiNode* node, const aiScene* scene, const glm::mat4& parentTransform, MapCollisionData& out)
         {
             const glm::mat4 world = parentTransform * aiToGlm(node->mTransformation);
 
             for (unsigned int mi = 0; mi < node->mNumMeshes; ++mi) {
                 const aiMesh* mesh = scene->mMeshes[node->mMeshes[mi]];
                 // Scale = 1.0 because the scale is already baked into the transform.
-                // decomposeNonConvex = false: props are loaded one-shot per call
-                // and a typical prop GLB has many meshes, V-HACD on each at
-                // load time would slow startup unacceptably.  Props use the
-                // existing primitive auto-detection + triMesh fallback.
-                extractMeshCollision(mesh,
-                                     world,
-                                     1.0f,
-                                     "",
-                                     node->mName.C_Str(),
-                                     /*decomposeNonConvex=*/false,
-                                     out);
+                extractMeshCollision(mesh, world, 1.0f, "", node->mName.C_Str(), decompose, out);
             }
 
             for (unsigned int c = 0; c < node->mNumChildren; ++c)
                 walk(node->mChildren[c], scene, world, out);
         }
     };
-
-    Walker::walk(scene->mRootNode, scene, propTransform, out);
+    Walker walker{decomposeNonConvex};
+    walker.walk(scene->mRootNode, scene, propTransform, out);
 
     const auto newBoxes = out.boxes.size() - prevBoxes;
     const auto newCyls = out.cylinders.size() - prevCyls;

--- a/src/ecs/physics/MapLoader.cpp
+++ b/src/ecs/physics/MapLoader.cpp
@@ -72,8 +72,34 @@ bool isUnderCollectionNode(const aiNode* node, const std::string& collectionName
 
 /// @brief Determine the collision sub-collection type from ancestor node names.
 /// Returns: "boxes", "brushes", "cylinders", "spheres", "meshes", or "" (auto).
+///
+/// Two Blender authoring conventions are supported:
+///   1. **Sub-collection (plural):** wrap collision objects in a child collection
+///      named "Boxes", "Cylinders", "Spheres", "Brushes", or "Meshes".  The
+///      collection becomes a parent node in the GLB; we walk ancestors here.
+///   2. **Object name (singular):** name the collision object after its shape
+///      (the Blender default for primitive adds — "Cylinder", "Sphere", etc.).
+///      Useful when collision is tagged by name prefix (e.g. "COL_Cylinder")
+///      instead of nested sub-collections.
+///
+/// The node's own name is checked first because it is the more specific signal:
+/// users who deliberately group meshes under a sub-collection are typically
+/// fine with auto-detection for the individual meshes, but a mesh actually
+/// named "Cylinder" almost always *is* the Blender cylinder primitive (which
+/// auto-detection mis-fits as a sphere when the cylinder is rotated off-Y).
 std::string getCollectionType(const aiNode* node)
 {
+    // 1) Check the node's own name for Blender-style shape keywords.  Only
+    //    "cylinder" needs help today: the auto AABB / fitSphere paths already
+    //    handle "Cube"/"Plane"/"Sphere"/"Icosphere" correctly, but a rotated
+    //    cylinder has equidistant rim vertices and slips into fitSphere.
+    {
+        const std::string ownName(node->mName.C_Str());
+        if (containsCI(ownName, "cylinder"))
+            return "cylinders";
+    }
+
+    // 2) Walk ancestors looking for sub-collection names (plural).
     const aiNode* cur = node->mParent;
     while (cur != nullptr) {
         std::string name(cur->mName.C_Str());

--- a/src/ecs/physics/MapLoader.cpp
+++ b/src/ecs/physics/MapLoader.cpp
@@ -10,6 +10,20 @@
 
 #include <SDL3/SDL_log.h>
 
+// V-HACD (header-only).  Implementation is compiled in VHACDImpl.cpp via
+// `#define ENABLE_VHACD_IMPLEMENTATION` — this site only needs the API.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#endif
+#include <VHACD.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
@@ -350,14 +364,48 @@ struct FacePlane
     float distance;
 };
 
-/// @brief Extract unique face planes from mesh triangles and build a WorldBrush.
-/// Returns true if the mesh is convex and fits within WorldBrush::k_maxPlanes.
+/// @brief Try to fit a convex hull (`WorldBrush`) to the mesh.
+///
+/// Returns true if **and only if** the mesh is genuinely convex *and* its
+/// unique face planes fit within `WorldBrush::k_maxPlanes`.
+///
+/// "Genuinely convex" means: for every triangle face, all of the mesh's other
+/// vertices lie on or behind that face's plane (using the outward-facing
+/// normal).  An L-shape, U-shape, hollow tube, or anything with a concave
+/// region will fail this test even if its unique-plane count happens to fit
+/// in `k_maxPlanes` — those meshes are silently mis-represented if you build
+/// a brush from them, because the brush is the *convex hull* of the planes,
+/// not the actual concave shape.
+///
+/// Outward orientation is auto-detected from the mesh centroid: whichever side
+/// of each face the centroid is on is treated as the interior.  This means
+/// inverted-winding meshes are handled correctly without a manual flip.
 bool extractConvexBrush(const aiMesh* mesh, const glm::mat4& world, float scale, WorldBrush& outBrush)
 {
-    if (!mesh->HasPositions() || !mesh->HasNormals() || mesh->mNumFaces == 0)
+    if (!mesh->HasPositions() || mesh->mNumFaces == 0)
         return false;
 
-    // Collect unique face planes (by normal direction).
+    // World-space vertex cache — we'll project every vertex against every
+    // face plane below, so do the transform once.
+    const std::vector<glm::vec3> verts = getWorldVertices(mesh, world, scale);
+    if (verts.size() < 4)
+        return false; // a closed convex volume needs at least a tetrahedron
+
+    // Mesh extent — used to scale a relative tolerance for "on the plane".
+    glm::vec3 bmin, bmax;
+    computeAABB(verts, bmin, bmax);
+    const glm::vec3 centroid = (bmin + bmax) * 0.5f;
+    const glm::vec3 ext = bmax - bmin;
+    const float meshDiag = glm::length(ext);
+    if (meshDiag < 1e-6f)
+        return false; // degenerate (zero-extent mesh)
+
+    // 0.1% of the mesh diagonal — generous enough to absorb numerical noise
+    // and Blender's typical export precision, tight enough to flag real
+    // concavities.  For a 200-unit cube that's 0.2 units, well below any
+    // "real" feature size.
+    const float tolerance = meshDiag * 0.001f;
+
     std::vector<FacePlane> uniquePlanes;
 
     for (unsigned int fi = 0; fi < mesh->mNumFaces; ++fi) {
@@ -365,33 +413,40 @@ bool extractConvexBrush(const aiMesh* mesh, const glm::mat4& world, float scale,
         if (face.mNumIndices < 3)
             continue;
 
-        // Compute face normal from the first triangle of this face.
-        const glm::vec4 lp0(mesh->mVertices[face.mIndices[0]].x,
-                            mesh->mVertices[face.mIndices[0]].y,
-                            mesh->mVertices[face.mIndices[0]].z,
-                            1.0f);
-        const glm::vec4 lp1(mesh->mVertices[face.mIndices[1]].x,
-                            mesh->mVertices[face.mIndices[1]].y,
-                            mesh->mVertices[face.mIndices[1]].z,
-                            1.0f);
-        const glm::vec4 lp2(mesh->mVertices[face.mIndices[2]].x,
-                            mesh->mVertices[face.mIndices[2]].y,
-                            mesh->mVertices[face.mIndices[2]].z,
-                            1.0f);
-
-        const glm::vec3 wp0 = glm::vec3(world * lp0) * scale;
-        const glm::vec3 wp1 = glm::vec3(world * lp1) * scale;
-        const glm::vec3 wp2 = glm::vec3(world * lp2) * scale;
+        const glm::vec3& wp0 = verts[face.mIndices[0]];
+        const glm::vec3& wp1 = verts[face.mIndices[1]];
+        const glm::vec3& wp2 = verts[face.mIndices[2]];
 
         glm::vec3 faceN = glm::cross(wp1 - wp0, wp2 - wp0);
         const float len = glm::length(faceN);
         if (len < 1e-8f)
-            continue;
+            continue; // sliver / degenerate triangle — skip
         faceN /= len;
+        float dist = glm::dot(faceN, wp0);
 
-        const float dist = glm::dot(faceN, wp0);
+        // Pick the outward orientation: the centroid should be on the *inside*
+        // (negative side) of each face plane for a convex closed mesh.  If the
+        // raw cross-product points the wrong way (inward winding), flip both
+        // normal and distance so the plane is consistently outward.
+        const float centroidSide = glm::dot(faceN, centroid) - dist;
+        if (centroidSide > tolerance) {
+            faceN = -faceN;
+            dist = -dist;
+        }
 
-        // Check if this normal direction already exists (within angular tolerance).
+        // Convexity verification: every vertex in the mesh must be on or
+        // behind this plane.  A single vertex on the *outside* (positive side
+        // beyond tolerance) means the mesh has a concavity here — treating it
+        // as a brush would silently give the player the wrong collision (the
+        // player would collide with the convex hull instead of the real
+        // surface).  Bail out so the caller falls through to triMesh.
+        for (const auto& v : verts) {
+            const float d = glm::dot(faceN, v) - dist;
+            if (d > tolerance)
+                return false;
+        }
+
+        // Deduplicate by normal direction (parallel coplanar tris share a plane).
         bool duplicate = false;
         for (const auto& existing : uniquePlanes) {
             if (glm::dot(faceN, existing.normal) > 0.999f) {
@@ -399,13 +454,12 @@ bool extractConvexBrush(const aiMesh* mesh, const glm::mat4& world, float scale,
                 break;
             }
         }
-
         if (!duplicate)
             uniquePlanes.push_back({faceN, dist});
     }
 
-    // A closed convex volume needs at least 4 planes (tetrahedron).
-    // Fewer planes produce infinite half-spaces that break collision.
+    // A closed convex volume needs at least 4 planes (tetrahedron); fewer means
+    // an unbounded half-space.  And it must fit within the brush's plane budget.
     if (static_cast<int>(uniquePlanes.size()) < 4 || static_cast<int>(uniquePlanes.size()) > WorldBrush::k_maxPlanes)
         return false;
 
@@ -417,6 +471,212 @@ bool extractConvexBrush(const aiMesh* mesh, const glm::mat4& world, float scale,
     }
 
     return true;
+}
+
+// Convex decomposition (V-HACD)
+
+/// @brief Convert one V-HACD output hull to a `WorldBrush`.
+///
+/// V-HACD hands us each hull as a triangle mesh (vertices + indices in double
+/// precision).  We extract its unique face planes (deduplicating coplanar
+/// triangles), auto-detect the outward orientation from the centroid, and
+/// pack them into a brush.  Returns false if the hull is degenerate or its
+/// plane count exceeds the brush budget.
+bool buildBrushFromHull(const VHACD::IVHACD::ConvexHull& hull, WorldBrush& outBrush)
+{
+    if (hull.m_points.empty() || hull.m_triangles.empty())
+        return false;
+
+    // Convert hull vertices from V-HACD's double-precision to glm::vec3.
+    std::vector<glm::vec3> verts;
+    verts.reserve(hull.m_points.size());
+    for (const auto& p : hull.m_points)
+        verts.emplace_back(static_cast<float>(p.mX), static_cast<float>(p.mY), static_cast<float>(p.mZ));
+
+    // Centroid + tolerance for outward-orientation detection (mirrors the
+    // logic in extractConvexBrush so we keep behaviour consistent).
+    glm::vec3 bmin(1e30f), bmax(-1e30f);
+    for (const auto& v : verts) {
+        bmin = glm::min(bmin, v);
+        bmax = glm::max(bmax, v);
+    }
+    const glm::vec3 centroid = (bmin + bmax) * 0.5f;
+    const float meshDiag = glm::length(bmax - bmin);
+    if (meshDiag < 1e-6f)
+        return false;
+    const float tolerance = meshDiag * 0.001f;
+
+    std::vector<FacePlane> uniquePlanes;
+    uniquePlanes.reserve(hull.m_triangles.size());
+
+    for (const auto& tri : hull.m_triangles) {
+        if (tri.mI0 >= verts.size() || tri.mI1 >= verts.size() || tri.mI2 >= verts.size())
+            continue;
+
+        const glm::vec3& v0 = verts[tri.mI0];
+        const glm::vec3& v1 = verts[tri.mI1];
+        const glm::vec3& v2 = verts[tri.mI2];
+
+        glm::vec3 n = glm::cross(v1 - v0, v2 - v0);
+        const float len = glm::length(n);
+        if (len < 1e-8f)
+            continue; // sliver
+        n /= len;
+        float dist = glm::dot(n, v0);
+
+        // Outward orientation: centroid should be on the inside (negative side).
+        if (glm::dot(n, centroid) - dist > tolerance) {
+            n = -n;
+            dist = -dist;
+        }
+
+        // Deduplicate by normal direction (coplanar tris share a plane).
+        bool dup = false;
+        for (const auto& existing : uniquePlanes) {
+            if (glm::dot(n, existing.normal) > 0.999f) {
+                dup = true;
+                break;
+            }
+        }
+        if (!dup)
+            uniquePlanes.push_back({n, dist});
+    }
+
+    if (static_cast<int>(uniquePlanes.size()) < 4 || static_cast<int>(uniquePlanes.size()) > WorldBrush::k_maxPlanes)
+        return false;
+
+    outBrush.planeCount = static_cast<int>(uniquePlanes.size());
+    for (int i = 0; i < outBrush.planeCount; ++i) {
+        outBrush.planes[i].normal = uniquePlanes[static_cast<size_t>(i)].normal;
+        outBrush.planes[i].distance = uniquePlanes[static_cast<size_t>(i)].distance;
+    }
+    return true;
+}
+
+/// @brief Run V-HACD convex decomposition on a non-convex mesh and append the
+///        resulting hulls to `out.brushes`.
+///
+/// Tries V-HACD's three fill modes in order:
+///   1. `FLOOD_FILL`     — closed solid meshes (default).  Voxelises the
+///                         interior via flood-fill from outside.  Best
+///                         quality for watertight solids.
+///   2. `RAYCAST_FILL`   — meshes with small holes.  Determines inside vs
+///                         outside by raycasting around each voxel.  More
+///                         robust than flood-fill against leaks.
+///   3. `SURFACE_ONLY`   — hollow shells (e.g. a tube wall, a curved
+///                         walkable corridor).  Treats the mesh as a thin
+///                         skin and produces hulls along the surface only,
+///                         so the cavity stays empty and walkable.
+///
+/// We accept the *first* mode that produces ≥1 successfully-converted hull —
+/// the modes are ordered "most likely correct for solid meshes" first so
+/// that solid non-convex shapes (chairs, L-blocks) don't accidentally get
+/// the surface-only treatment.
+///
+/// @return Number of brushes appended to `out.brushes`. Zero on failure
+/// (caller should fall through to triMesh).
+size_t decomposeIntoBrushes(
+    const aiMesh* mesh, const glm::mat4& world, float scale, const char* nodeName, MapCollisionData& out)
+{
+    if (!mesh->HasPositions() || mesh->mNumFaces == 0)
+        return 0;
+
+    // Build float vertex array (world-space) and uint32 index array.
+    const std::vector<glm::vec3> wverts = getWorldVertices(mesh, world, scale);
+    if (wverts.size() < 4)
+        return 0;
+
+    std::vector<float> points;
+    points.reserve(wverts.size() * 3);
+    for (const auto& v : wverts) {
+        points.push_back(v.x);
+        points.push_back(v.y);
+        points.push_back(v.z);
+    }
+
+    std::vector<uint32_t> indices;
+    indices.reserve(mesh->mNumFaces * 3);
+    for (unsigned int fi = 0; fi < mesh->mNumFaces; ++fi) {
+        const aiFace& face = mesh->mFaces[fi];
+        if (face.mNumIndices != 3)
+            continue;
+        indices.push_back(face.mIndices[0]);
+        indices.push_back(face.mIndices[1]);
+        indices.push_back(face.mIndices[2]);
+    }
+    if (indices.size() < 9)
+        return 0;
+
+    // Try each fill mode until one yields hulls.
+    //
+    // FLOOD_FILL is tried first because it's the most efficient for the common
+    // case (closed solid mesh, e.g. a chair, an L-shaped block): it voxelises
+    // the volume, flood-fills "outside" from the bounds, and decomposes the
+    // remaining "inside" into a small number of compact hulls.
+    //
+    // RAYCAST_FILL is a fallback for meshes with small holes that defeat the
+    // flood-fill (it decides inside-vs-outside per voxel via raycasts).
+    //
+    // SURFACE_ONLY is the last resort for thin-shell meshes that have no
+    // enclosed volume (e.g. a single-layer bezier tube the artist intended to
+    // be walkable from inside).  It decomposes only the surface skin so the
+    // cavity stays empty.  If you have a hollow-walkable mesh that's getting
+    // its cavity filled by FLOOD_FILL, give the wall thickness in Blender
+    // (Solidify modifier) — or move SURFACE_ONLY to the front of this list.
+    static constexpr struct
+    {
+        VHACD::FillMode mode;
+        const char* name;
+    } k_fillModes[] = {
+        {VHACD::FillMode::FLOOD_FILL, "flood-fill"},
+        {VHACD::FillMode::RAYCAST_FILL, "raycast-fill"},
+        {VHACD::FillMode::SURFACE_ONLY, "surface-only"},
+    };
+
+    for (const auto& mode : k_fillModes) {
+        VHACD::IVHACD::Parameters params;
+        params.m_maxConvexHulls = 32;      // total hull budget per mesh
+        params.m_resolution = 100000;      // voxel grid (default 400000 is slower)
+        params.m_maxNumVerticesPerCH = 32; // bounds plane count per hull (after dedup)
+        params.m_asyncACD = false;         // synchronous: we're at load-time
+        params.m_fillMode = mode.mode;
+
+        VHACD::IVHACD* iface = VHACD::CreateVHACD();
+        const bool computed = iface->Compute(points.data(),
+                                             static_cast<uint32_t>(points.size() / 3),
+                                             indices.data(),
+                                             static_cast<uint32_t>(indices.size() / 3),
+                                             params);
+
+        const uint32_t hullCount = computed ? iface->GetNConvexHulls() : 0u;
+        if (hullCount == 0) {
+            iface->Release();
+            continue; // try next fill mode
+        }
+
+        size_t addedBrushes = 0;
+        for (uint32_t i = 0; i < hullCount; ++i) {
+            VHACD::IVHACD::ConvexHull hull;
+            if (!iface->GetConvexHull(i, hull))
+                continue;
+
+            WorldBrush brush{};
+            if (buildBrushFromHull(hull, brush)) {
+                out.brushes.push_back(brush);
+                ++addedBrushes;
+            }
+        }
+        iface->Release();
+
+        if (addedBrushes > 0) {
+            SDL_Log(
+                "MapLoader: V-HACD decomposed '%s' into %zu brush(es) [mode=%s]", nodeName, addedBrushes, mode.name);
+            return addedBrushes;
+        }
+    }
+
+    SDL_Log("MapLoader: V-HACD failed for '%s' (all fill modes produced 0 hulls); falling back to triMesh", nodeName);
+    return 0;
 }
 
 // Triangle mesh construction
@@ -457,11 +717,15 @@ bool shouldSkipNode(const char* nodeName)
 }
 
 /// @brief Determine the best collision primitive for a mesh and add it to `out`.
+/// @param decomposeNonConvex  If true and the mesh fails the single-hull
+///        convex-brush check, run V-HACD convex decomposition before falling
+///        back to triMesh.
 void extractMeshCollision(const aiMesh* mesh,
                           const glm::mat4& world,
                           float scale,
                           const std::string& forceType,
                           const char* nodeName,
+                          bool decomposeNonConvex,
                           MapCollisionData& out)
 {
     if (!mesh->HasPositions() || mesh->mNumVertices == 0)
@@ -618,7 +882,8 @@ void extractMeshCollision(const aiMesh* mesh,
         }
     }
 
-    // 4. Try convex brush
+    // 4. Try a single convex brush (for genuinely-convex meshes that fit in
+    //    one hull within k_maxPlanes — cheapest collision shape after AABB).
     {
         WorldBrush brush{};
         if (extractConvexBrush(mesh, world, scale, brush)) {
@@ -626,6 +891,14 @@ void extractMeshCollision(const aiMesh* mesh,
             SDL_Log("MapLoader: Brush (auto) %d planes '%s'", brush.planeCount, nodeName);
             return;
         }
+    }
+
+    // 4.5. Try V-HACD convex decomposition: split the non-convex mesh into a
+    //     handful of convex brushes.  Smoother runtime collision than triMesh
+    //     (no per-triangle MTV jitter on curved surfaces) and the cost is paid
+    //     only once at load time.
+    if (decomposeNonConvex && decomposeIntoBrushes(mesh, world, scale, nodeName, out) > 0) {
+        return;
     }
 
     // 5. TriMesh (for complex geometry that doesn't fit simpler primitives)
@@ -666,6 +939,7 @@ void extractCollision(const aiNode* node,
                       const std::string& collectionName,
                       bool allAreCollision,
                       bool guessShapesProcessed,
+                      bool decomposeNonConvex,
                       float scale,
                       MapCollisionData& out)
 {
@@ -689,14 +963,27 @@ void extractCollision(const aiNode* node,
             forceType = guessShapesProcessed ? getCollectionType(node) : std::string("meshes");
         }
 
+        // V-HACD only fires in separated + shape-guessing mode and only on
+        // meshes that fall through to auto-detection (no forced type).  In
+        // prototype mode every mesh is collision (often hundreds), and forced
+        // triMesh / brush requests should be honoured exactly.
+        const bool tryDecompose = decomposeNonConvex && !allAreCollision && guessShapesProcessed && forceType.empty();
+
         for (unsigned int mi = 0; mi < node->mNumMeshes; ++mi) {
             const aiMesh* mesh = scene->mMeshes[node->mMeshes[mi]];
-            extractMeshCollision(mesh, world, scale, forceType, node->mName.C_Str(), out);
+            extractMeshCollision(mesh, world, scale, forceType, node->mName.C_Str(), tryDecompose, out);
         }
     }
 
     for (unsigned int c = 0; c < node->mNumChildren; ++c)
-        extractCollision(node->mChildren[c], scene, collectionName, allAreCollision, guessShapesProcessed, scale, out);
+        extractCollision(node->mChildren[c],
+                         scene,
+                         collectionName,
+                         allAreCollision,
+                         guessShapesProcessed,
+                         decomposeNonConvex,
+                         scale,
+                         out);
 }
 
 } // namespace
@@ -729,6 +1016,7 @@ bool loadMapCollision(const std::string& path, MapCollisionData& out, const MapL
                      opts.collisionCollection,
                      opts.allMeshesAreCollision,
                      opts.guessShapesProcessed,
+                     opts.decomposeNonConvex,
                      opts.scale,
                      out);
 
@@ -805,7 +1093,17 @@ bool loadPropCollision(const std::string& path, MapCollisionData& out, glm::vec3
             for (unsigned int mi = 0; mi < node->mNumMeshes; ++mi) {
                 const aiMesh* mesh = scene->mMeshes[node->mMeshes[mi]];
                 // Scale = 1.0 because the scale is already baked into the transform.
-                extractMeshCollision(mesh, world, 1.0f, "", node->mName.C_Str(), out);
+                // decomposeNonConvex = false: props are loaded one-shot per call
+                // and a typical prop GLB has many meshes, V-HACD on each at
+                // load time would slow startup unacceptably.  Props use the
+                // existing primitive auto-detection + triMesh fallback.
+                extractMeshCollision(mesh,
+                                     world,
+                                     1.0f,
+                                     "",
+                                     node->mName.C_Str(),
+                                     /*decomposeNonConvex=*/false,
+                                     out);
             }
 
             for (unsigned int c = 0; c < node->mNumChildren; ++c)

--- a/src/ecs/physics/MapLoader.cpp
+++ b/src/ecs/physics/MapLoader.cpp
@@ -665,6 +665,7 @@ void extractCollision(const aiNode* node,
                       const aiScene* scene,
                       const std::string& collectionName,
                       bool allAreCollision,
+                      bool guessShapesProcessed,
                       float scale,
                       MapCollisionData& out)
 {
@@ -673,7 +674,20 @@ void extractCollision(const aiNode* node,
 
     if (isCollision) {
         const glm::mat4 world = accumulatedTransform(node);
-        const std::string forceType = allAreCollision ? "" : getCollectionType(node);
+
+        // Pick the shape strategy:
+        //   - Prototype mode (allAreCollision): no forcing — let auto-detection
+        //     pick the best primitive for every mesh.
+        //   - Separated mode WITHOUT shape-guessing (default): force every
+        //     collision mesh to a raw triangle mesh, preserving the exact
+        //     geometry the artist authored in Blender.
+        //   - Separated mode WITH shape-guessing: respect sub-collection
+        //     naming ("Boxes/", "Cylinders/") and Blender primitive names,
+        //     falling back to auto-detection.
+        std::string forceType;
+        if (!allAreCollision) {
+            forceType = guessShapesProcessed ? getCollectionType(node) : std::string("meshes");
+        }
 
         for (unsigned int mi = 0; mi < node->mNumMeshes; ++mi) {
             const aiMesh* mesh = scene->mMeshes[node->mMeshes[mi]];
@@ -682,7 +696,7 @@ void extractCollision(const aiNode* node,
     }
 
     for (unsigned int c = 0; c < node->mNumChildren; ++c)
-        extractCollision(node->mChildren[c], scene, collectionName, allAreCollision, scale, out);
+        extractCollision(node->mChildren[c], scene, collectionName, allAreCollision, guessShapesProcessed, scale, out);
 }
 
 } // namespace
@@ -710,9 +724,16 @@ bool loadMapCollision(const std::string& path, MapCollisionData& out, const MapL
     out.spheres.clear();
     out.triMeshes.clear();
 
-    extractCollision(scene->mRootNode, scene, opts.collisionCollection, opts.allMeshesAreCollision, opts.scale, out);
+    extractCollision(scene->mRootNode,
+                     scene,
+                     opts.collisionCollection,
+                     opts.allMeshesAreCollision,
+                     opts.guessShapesProcessed,
+                     opts.scale,
+                     out);
 
-    const size_t total = out.boxes.size() + out.brushes.size() + out.cylinders.size() + out.spheres.size();
+    const size_t total =
+        out.boxes.size() + out.brushes.size() + out.cylinders.size() + out.spheres.size() + out.triMeshes.size();
     if (total == 0) {
         SDL_Log("MapLoader: WARNING — no collision geometry extracted from '%s'", path.c_str());
     }
@@ -726,6 +747,8 @@ bool loadMapCollision(const std::string& path, MapCollisionData& out, const MapL
             lowestY = std::min(lowestY, c.base.y);
         for (const auto& s : out.spheres)
             lowestY = std::min(lowestY, s.center.y - s.radius);
+        for (const auto& tm : out.triMeshes)
+            lowestY = std::min(lowestY, tm.boundsMin.y);
 
         out.planes.push_back(Plane{.normal = {0.0f, 1.0f, 0.0f}, .distance = lowestY});
         SDL_Log("MapLoader: added floor plane at y=%.1f", static_cast<double>(lowestY));

--- a/src/ecs/physics/MapLoader.hpp
+++ b/src/ecs/physics/MapLoader.hpp
@@ -82,6 +82,29 @@ struct MapLoadOptions
     /// found across all collision geometry.  Prevents players from falling
     /// through the world even if the map mesh has tiny cracks.
     bool addFloorPlane = false;
+
+    /// In separated mode (`allMeshesAreCollision = false`), should the loader
+    /// auto-detect/guess each collision mesh's best-fitting primitive
+    /// (AABB / cylinder / sphere / convex brush), or load it raw?
+    ///
+    ///   false (default) — preserve exactly what Blender's collision section
+    ///                     contains: every collision mesh becomes a triangle
+    ///                     mesh, vertex-for-vertex.  Sub-collection name
+    ///                     overrides ("Boxes/", "Cylinders/", …) and Blender
+    ///                     primitive-name hints ("Cylinder") are ignored.
+    ///                     Use this when the artist has authored exact
+    ///                     collision hulls and the loader must not second-
+    ///                     guess them.
+    ///   true            — run the existing auto-detection pipeline
+    ///                     (AABB → cylinder → sphere → brush → triMesh) plus
+    ///                     sub-collection / name forcing.  Cheaper at runtime
+    ///                     for simple shapes, but the loader picks the
+    ///                     primitive — not the artist.
+    ///
+    /// Has no effect in prototype mode (`allMeshesAreCollision = true`):
+    /// every mesh is collision there, and forcing all of them to triMesh
+    /// would be prohibitively expensive.
+    bool guessShapesProcessed = false;
 };
 
 /// API

--- a/src/ecs/physics/MapLoader.hpp
+++ b/src/ecs/physics/MapLoader.hpp
@@ -87,7 +87,14 @@ struct MapLoadOptions
     /// auto-detect/guess each collision mesh's best-fitting primitive
     /// (AABB / cylinder / sphere / convex brush), or load it raw?
     ///
-    ///   false (default) — preserve exactly what Blender's collision section
+    ///   true (default)  — run the auto-detection pipeline
+    ///                     (AABB → cylinder → sphere → convex brush → triMesh)
+    ///                     plus sub-collection / name forcing.  Convex shapes
+    ///                     end up as cheap primitives or brushes; only truly
+    ///                     non-convex meshes fall back to triMesh.  Convex
+    ///                     primitives are dramatically cheaper at runtime and
+    ///                     don't suffer triMesh edge-jitter on contact.
+    ///   false           — preserve exactly what Blender's collision section
     ///                     contains: every collision mesh becomes a triangle
     ///                     mesh, vertex-for-vertex.  Sub-collection name
     ///                     overrides ("Boxes/", "Cylinders/", …) and Blender
@@ -95,16 +102,33 @@ struct MapLoadOptions
     ///                     Use this when the artist has authored exact
     ///                     collision hulls and the loader must not second-
     ///                     guess them.
-    ///   true            — run the existing auto-detection pipeline
-    ///                     (AABB → cylinder → sphere → brush → triMesh) plus
-    ///                     sub-collection / name forcing.  Cheaper at runtime
-    ///                     for simple shapes, but the loader picks the
-    ///                     primitive — not the artist.
     ///
     /// Has no effect in prototype mode (`allMeshesAreCollision = true`):
     /// every mesh is collision there, and forcing all of them to triMesh
     /// would be prohibitively expensive.
-    bool guessShapesProcessed = false;
+    bool guessShapesProcessed = true;
+
+    /// In separated mode with shape-guessing on, when a collision mesh is
+    /// non-convex (so it can't be a single `WorldBrush`), should the loader
+    /// run V-HACD convex decomposition to split it into multiple brushes?
+    ///
+    ///   true  (default) — non-convex meshes go through V-HACD; the resulting
+    ///                     hulls are appended as `WorldBrush`es.  Smoother
+    ///                     collision than triMesh (no per-triangle MTV
+    ///                     jitter) and cheaper at runtime.  Costs a few
+    ///                     hundred milliseconds to a few seconds at *load*
+    ///                     time per non-convex mesh, depending on size.
+    ///   false           — skip decomposition; non-convex meshes fall through
+    ///                     to `WorldTriMesh`.
+    ///
+    /// V-HACD tries `FLOOD_FILL` first (closed solid meshes), falling back
+    /// to `RAYCAST_FILL` and finally `SURFACE_ONLY` (hollow shells like a
+    /// tube without thickness) — so it works for both solid non-convex
+    /// objects and walkable hollow shells.
+    ///
+    /// Has no effect when `guessShapesProcessed = false` or when
+    /// `allMeshesAreCollision = true`.
+    bool decomposeNonConvex = true;
 };
 
 /// API

--- a/src/ecs/physics/MapLoader.hpp
+++ b/src/ecs/physics/MapLoader.hpp
@@ -160,7 +160,16 @@ bool loadMapCollision(const std::string& path, MapCollisionData& out, const MapL
 /// @param out      Existing collision data to append to.
 /// @param position World-space position of the prop.
 /// @param scale    Uniform scale factor.
+/// @param decomposeNonConvex
+///                 When true, non-convex meshes inside the prop are run through
+///                 V-HACD convex decomposition (each becomes a small set of
+///                 `WorldBrush`es) instead of falling back to `WorldTriMesh`.
+///                 Smoother runtime collision on irregular shapes (a bottle, a
+///                 bent metal pallet) at the cost of seconds-per-mesh load time.
+///                 Default false because a prop GLB can hold dozens of sub-
+///                 meshes and decomposing every one of them blows up startup.
 /// @return True on success.
-bool loadPropCollision(const std::string& path, MapCollisionData& out, glm::vec3 position, float scale);
+bool loadPropCollision(
+    const std::string& path, MapCollisionData& out, glm::vec3 position, float scale, bool decomposeNonConvex = false);
 
 } // namespace physics

--- a/src/ecs/physics/Raycast.hpp
+++ b/src/ecs/physics/Raycast.hpp
@@ -293,6 +293,79 @@ inline bool raycastTriMesh(glm::vec3 origin,
     return anyHit;
 }
 
+/// @brief Ray vs convex brush intersection (generalised slab method).
+///
+/// A `WorldBrush` is the intersection of half-spaces defined by planes with
+/// **outward** normals; the solid interior satisfies `dot(n, p) <= distance`
+/// for every plane.  A ray hits the brush at the *latest* plane it enters
+/// from outside, provided that t doesn't exceed the *earliest* plane it
+/// exits.  Mirrors the logic in `sweepAABBvsBrush` but for a point-ray
+/// instead of a swept AABB.
+inline bool raycastBrush(glm::vec3 origin,
+                         glm::vec3 direction,
+                         const WorldBrush& brush,
+                         float maxDistance,
+                         float& outDistance,
+                         glm::vec3& outNormal)
+{
+    float tEntry = 0.0f;
+    float tExit = maxDistance;
+    glm::vec3 entryNormal{0.0f, 1.0f, 0.0f};
+    bool startsOutside = false;
+
+    for (int i = 0; i < brush.planeCount; ++i) {
+        const Plane& plane = brush.planes[i];
+
+        // Signed distance from origin to plane (outward normal):
+        //   > 0 → outside (free space)
+        //   < 0 → inside  (solid)
+        const float dist = glm::dot(plane.normal, origin) - plane.distance;
+        const float denom = glm::dot(plane.normal, direction);
+
+        if (dist > 0.0f)
+            startsOutside = true;
+
+        if (std::abs(denom) < k_parallelEpsilon) {
+            // Ray parallel to this plane: if origin is outside, the ray is
+            // entirely outside this plane's solid half-space → can't be in
+            // the brush at any t.  If inside, this plane doesn't constrain
+            // the [tEntry, tExit] interval.
+            if (dist > 0.0f)
+                return false;
+            continue;
+        }
+
+        // t at which the ray crosses the plane.
+        const float t = -dist / denom;
+
+        if (denom < 0.0f) {
+            // Ray heading from outside (dist > 0) toward inside (dist < 0):
+            // entering this plane's solid half-space.  Track the latest
+            // entry across all planes.
+            if (t > tEntry) {
+                tEntry = t;
+                entryNormal = plane.normal;
+            }
+        } else {
+            // Ray heading from inside toward outside: exiting.  Track the
+            // earliest exit.
+            if (t < tExit)
+                tExit = t;
+        }
+    }
+
+    // Origin must be outside the brush; depenetration handles the inside case.
+    if (!startsOutside)
+        return false;
+    // Need a non-empty intersection window of [tEntry, tExit] within [0, maxDistance].
+    if (tEntry >= tExit || tEntry < 0.0f || tEntry >= maxDistance)
+        return false;
+
+    outDistance = tEntry;
+    outNormal = entryNormal;
+    return true;
+}
+
 /// @brief Raycast against all static world geometry (planes + boxes + cylinders + spheres).
 inline HitscanHit raycastWorld(glm::vec3 origin, glm::vec3 direction, const WorldGeometry& world)
 {
@@ -323,6 +396,18 @@ inline HitscanHit raycastWorld(glm::vec3 origin, glm::vec3 direction, const Worl
             continue;
         }
 
+        bestHit.hit = true;
+        bestHit.distance = distance;
+        bestHit.point = origin + direction * distance;
+        bestHit.normal = normal;
+        bestHit.surface = SurfaceType::Concrete;
+    }
+
+    for (const WorldBrush& brush : world.brushes) {
+        float distance = bestHit.distance;
+        glm::vec3 normal{0.0f};
+        if (!raycastBrush(origin, direction, brush, bestHit.distance, distance, normal))
+            continue;
         bestHit.hit = true;
         bestHit.distance = distance;
         bestHit.point = origin + direction * distance;

--- a/src/ecs/physics/SweptCollision.hpp
+++ b/src/ecs/physics/SweptCollision.hpp
@@ -38,9 +38,17 @@ struct WorldAABB
 ///
 /// The solid interior is the intersection of all half-spaces: `dot(normal, p) < distance`.
 /// Normals point outward (into free space), same as the Plane convention.
+///
+/// `k_maxPlanes` is sized to fit the typical output of V-HACD convex
+/// decomposition: each output hull has up to ~64 vertices (the V-HACD
+/// `m_maxNumVerticesPerCH` parameter we pass), and a triangulated convex
+/// polytope's face-plane count is bounded by ~2V-4 for V vertices but in
+/// practice (after coplanar-triangle deduplication) much lower.  64 planes
+/// is comfortable headroom and keeps each `WorldBrush` at 1KB — well within
+/// L1 cache for the per-frame collision loop.
 struct WorldBrush
 {
-    static constexpr int k_maxPlanes = 8;
+    static constexpr int k_maxPlanes = 64;
     Plane planes[k_maxPlanes];
     int planeCount{0};
 };

--- a/src/ecs/physics/TriMeshCollision.cpp
+++ b/src/ecs/physics/TriMeshCollision.cpp
@@ -427,58 +427,97 @@ void depenetrateAABBvsTriMesh(
         pos.z + halfExtents.z < mesh.boundsMin.z || pos.z - halfExtents.z > mesh.boundsMax.z)
         return;
 
-    // BVH traversal: for each leaf whose AABB overlaps the entity, run per-
-    // triangle SAT MTV.  pos and vel are mutated in-place — subsequent triangle
-    // tests see the already-pushed position so the entity converges out of the
-    // mesh in one pass for typical (curved-but-not-self-intersecting) shapes.
-    int stack[64];
-    int stackPtr = 0;
-    stack[0] = 0;
+    // Iterative aggregated depenetration to reduce jitter on curved surfaces.
+    //
+    // The naïve approach — apply each overlapping triangle's MTV one at a time —
+    // jitters when the entity straddles many triangles at once on a curved
+    // surface (e.g. inside a tube): each push moves the entity into a slightly
+    // different overlap with the *next* triangle, so the net motion oscillates.
+    //
+    // Instead, in each pass we:
+    //   1. Find every overlapping triangle (BVH-walk) at the *same* position.
+    //   2. Sum their normalised MTV directions (a Quake-style "average normal"
+    //      across all simultaneous contacts).
+    //   3. Push once along that averaged direction by the deepest single MTV
+    //      magnitude (plus the pushback bias).
+    //
+    // For a curved mesh, the averaged direction points smoothly out of the
+    // surface (e.g. radially outward from a tube's axis) instead of fighting
+    // between adjacent triangle normals.  For a corner where two faces meet,
+    // it points roughly diagonally and a few iterations clear the residual
+    // overlap on each face.  k_maxPasses caps the work even for pathological
+    // self-intersecting meshes.
+    constexpr int k_maxPasses = 4;
 
-    while (stackPtr >= 0) {
-        const int nodeIdx = stack[stackPtr--];
-        const BVHNode& node = mesh.bvhNodes[static_cast<size_t>(nodeIdx)];
+    for (int pass = 0; pass < k_maxPasses; ++pass) {
+        glm::vec3 sumDir(0.0f);
+        float maxDepth = 0.0f;
+        int overlapCount = 0;
 
-        // Cull this node by Minkowski-expanded AABB overlap test.
-        const glm::vec3 expMin = node.boundsMin - halfExtents;
-        const glm::vec3 expMax = node.boundsMax + halfExtents;
-        if (pos.x < expMin.x || pos.x > expMax.x || pos.y < expMin.y || pos.y > expMax.y || pos.z < expMin.z ||
-            pos.z > expMax.z)
-            continue;
+        int stack[64];
+        int stackPtr = 0;
+        stack[0] = 0;
 
-        if (node.count > 0) {
-            // Leaf — depenetrate against each triangle individually.
-            for (int i = node.leftFirst; i < node.leftFirst + node.count; ++i) {
-                const uint32_t ti = mesh.triIndices[static_cast<size_t>(i)];
-                const glm::vec3& v0 = mesh.vertices[mesh.indices[ti * 3 + 0]];
-                const glm::vec3& v1 = mesh.vertices[mesh.indices[ti * 3 + 1]];
-                const glm::vec3& v2 = mesh.vertices[mesh.indices[ti * 3 + 2]];
+        while (stackPtr >= 0) {
+            const int nodeIdx = stack[stackPtr--];
+            const BVHNode& node = mesh.bvhNodes[static_cast<size_t>(nodeIdx)];
 
-                glm::vec3 mtv;
-                if (!aabbVsTriMTV(pos, halfExtents, v0, v1, v2, mtv))
-                    continue;
+            // Cull this node by Minkowski-expanded AABB overlap test.
+            const glm::vec3 expMin = node.boundsMin - halfExtents;
+            const glm::vec3 expMax = node.boundsMax + halfExtents;
+            if (pos.x < expMin.x || pos.x > expMax.x || pos.y < expMin.y || pos.y > expMax.y || pos.z < expMin.z ||
+                pos.z > expMax.z)
+                continue;
 
-                const float depth = glm::length(mtv);
-                if (depth < 1e-6f)
-                    continue; // numerical floor — already touching
+            if (node.count > 0) {
+                // Leaf — accumulate MTV contributions from every overlapping triangle.
+                for (int i = node.leftFirst; i < node.leftFirst + node.count; ++i) {
+                    const uint32_t ti = mesh.triIndices[static_cast<size_t>(i)];
+                    const glm::vec3& v0 = mesh.vertices[mesh.indices[ti * 3 + 0]];
+                    const glm::vec3& v1 = mesh.vertices[mesh.indices[ti * 3 + 1]];
+                    const glm::vec3& v2 = mesh.vertices[mesh.indices[ti * 3 + 2]];
 
-                const glm::vec3 pushDir = mtv / depth;
+                    glm::vec3 mtv;
+                    if (!aabbVsTriMTV(pos, halfExtents, v0, v1, v2, mtv))
+                        continue;
 
-                // Push out by (depth + pushback) so we sit just off the surface.
-                pos += pushDir * (depth + pushback);
+                    const float depth = glm::length(mtv);
+                    if (depth < 1e-6f)
+                        continue;          // numerical floor — already touching
 
-                // Cancel velocity component flowing INTO the surface (vel · pushDir < 0
-                // means motion was opposite to the push, i.e. into the triangle).  This
-                // lets the entity slide along the contact instead of re-penetrating
-                // next frame.
-                const float into = glm::dot(vel, pushDir);
-                if (into < 0.0f)
-                    vel -= pushDir * into;
+                    sumDir += mtv / depth; // unit direction; sum smooths across adjacent tris
+                    maxDepth = std::max(maxDepth, depth);
+                    ++overlapCount;
+                }
+            } else {
+                stack[++stackPtr] = node.leftFirst;
+                stack[++stackPtr] = node.leftFirst + 1;
             }
-        } else {
-            stack[++stackPtr] = node.leftFirst;
-            stack[++stackPtr] = node.leftFirst + 1;
         }
+
+        if (overlapCount == 0)
+            return; // fully separated — done
+
+        const float dirLen = glm::length(sumDir);
+        if (dirLen < 1e-6f)
+            return; // contributions cancel out (rare; happens only if entity is
+                    // perfectly centred inside a closed mesh and all radial pushes
+                    // cancel — no useful direction to push, give up gracefully)
+
+        const glm::vec3 dir = sumDir / dirLen;
+
+        // Push along the averaged direction by enough to clear the deepest single
+        // overlap (plus the pushback bias).  Other simultaneous overlaps may not
+        // be fully cleared if their MTV directions diverge significantly from the
+        // average — those get caught by the next pass.
+        pos += dir * (maxDepth + pushback);
+
+        // Cancel velocity component flowing INTO the contact.  Using the averaged
+        // direction means the entity slides along the *average* surface normal,
+        // which is the smoothest behaviour on curved meshes.
+        const float into = glm::dot(vel, dir);
+        if (into < 0.0f)
+            vel -= dir * into;
     }
 }
 

--- a/src/ecs/physics/TriMeshCollision.cpp
+++ b/src/ecs/physics/TriMeshCollision.cpp
@@ -190,6 +190,98 @@ bool staticAABBvsTriSAT(glm::vec3 center, glm::vec3 he, glm::vec3 v0, glm::vec3 
     return true; // no separating axis found — overlapping
 }
 
+/// @brief Compute the minimum-translation-vector (MTV) that separates a static
+///        AABB from a single triangle, using the same 13 SAT axes as
+///        `staticAABBvsTriSAT`.  Returns true if they overlap; on overlap,
+///        `outMtv` is the smallest vector that — when added to the AABB centre
+///        — makes the shapes disjoint.
+///
+/// All cross-product axes are normalised before measuring overlap, so the
+/// returned depth is in world units across every axis (the boolean SAT test
+/// in `staticAABBvsTriSAT` skips this normalisation because it only needs to
+/// compare signs).
+bool aabbVsTriMTV(glm::vec3 center, glm::vec3 he, glm::vec3 v0, glm::vec3 v1, glm::vec3 v2, glm::vec3& outMtv)
+{
+    // Translate triangle so AABB centre is at origin (mirrors staticAABBvsTriSAT).
+    const glm::vec3 a = v0 - center;
+    const glm::vec3 b = v1 - center;
+    const glm::vec3 c = v2 - center;
+
+    const glm::vec3 edges[3] = {b - a, c - b, a - c};
+
+    glm::vec3 bestAxis(0.0f);
+    float bestDepth = 1e30f;
+
+    // For one SAT axis: project AABB ([-r, r] in axis-local coords) and triangle
+    // ([triMin, triMax]) and update the best-MTV running tally.  Returns false
+    // if the axis is a separating axis (no overlap → no need to test others).
+    auto considerAxis = [&](const glm::vec3& axis, float triMin, float triMax, float r) -> bool {
+        if (triMax < -r || triMin > r)
+            return false; // separating axis — shapes are disjoint
+
+        // Two ways to push the AABB out of the overlap on this axis:
+        //   push +axis by (triMax + r): AABB.min ends up at triMax (touching from -side)
+        //   push -axis by (r - triMin): AABB.max ends up at triMin (touching from +side)
+        // Pick whichever is smaller; that's the axis-local MTV contribution.
+        const float pushPlus = triMax + r;
+        const float pushMinus = r - triMin;
+
+        const float depth = std::min(pushPlus, pushMinus);
+        const glm::vec3 dir = (pushPlus < pushMinus) ? axis : -axis;
+
+        if (depth < bestDepth) {
+            bestDepth = depth;
+            bestAxis = dir;
+        }
+        return true;
+    };
+
+    // 1. AABB face normals — already unit length.
+    for (int axIdx = 0; axIdx < 3; ++axIdx) {
+        glm::vec3 ax(0.0f);
+        ax[axIdx] = 1.0f;
+        const float triMin = std::min({a[axIdx], b[axIdx], c[axIdx]});
+        const float triMax = std::max({a[axIdx], b[axIdx], c[axIdx]});
+        if (!considerAxis(ax, triMin, triMax, he[axIdx]))
+            return false;
+    }
+
+    // 2. Triangle face normal — normalise so depth is in world units.
+    glm::vec3 triN = glm::cross(edges[0], edges[1]);
+    const float triNLen = glm::length(triN);
+    if (triNLen > 1e-8f) {
+        triN /= triNLen;
+        const float r = he.x * std::abs(triN.x) + he.y * std::abs(triN.y) + he.z * std::abs(triN.z);
+        const float s = glm::dot(triN, a); // all 3 vertices are coplanar → single value
+        if (!considerAxis(triN, s, s, r))
+            return false;
+    }
+
+    // 3. Cross-product axes (3 AABB edges × 3 triangle edges = 9 axes).
+    const glm::vec3 aabbAxes[3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            glm::vec3 ax = glm::cross(aabbAxes[i], edges[j]);
+            const float axLen = glm::length(ax);
+            if (axLen < 1e-5f)
+                continue; // edges parallel — degenerate axis, skip
+            ax /= axLen;
+
+            const float r = he.x * std::abs(ax.x) + he.y * std::abs(ax.y) + he.z * std::abs(ax.z);
+            const float p0 = glm::dot(ax, a);
+            const float p1 = glm::dot(ax, b);
+            const float p2 = glm::dot(ax, c);
+            const float triMin = std::min({p0, p1, p2});
+            const float triMax = std::max({p0, p1, p2});
+            if (!considerAxis(ax, triMin, triMax, r))
+                return false;
+        }
+    }
+
+    outMtv = bestAxis * bestDepth;
+    return true;
+}
+
 /// @brief Swept AABB vs a single triangle.
 HitResult
 sweepAABBvsTriangle(glm::vec3 halfExtents, glm::vec3 start, glm::vec3 end, glm::vec3 v0, glm::vec3 v1, glm::vec3 v2)
@@ -321,6 +413,73 @@ HitResult sweepAABBvsTriMesh(glm::vec3 halfExtents, glm::vec3 start, glm::vec3 e
     }
 
     return best;
+}
+
+void depenetrateAABBvsTriMesh(
+    glm::vec3& pos, glm::vec3& vel, glm::vec3 halfExtents, const WorldTriMesh& mesh, float pushback)
+{
+    if (mesh.bvhNodes.empty())
+        return;
+
+    // Quick reject: AABB must overlap the whole-mesh bounds (Minkowski-expanded).
+    if (pos.x + halfExtents.x < mesh.boundsMin.x || pos.x - halfExtents.x > mesh.boundsMax.x ||
+        pos.y + halfExtents.y < mesh.boundsMin.y || pos.y - halfExtents.y > mesh.boundsMax.y ||
+        pos.z + halfExtents.z < mesh.boundsMin.z || pos.z - halfExtents.z > mesh.boundsMax.z)
+        return;
+
+    // BVH traversal: for each leaf whose AABB overlaps the entity, run per-
+    // triangle SAT MTV.  pos and vel are mutated in-place — subsequent triangle
+    // tests see the already-pushed position so the entity converges out of the
+    // mesh in one pass for typical (curved-but-not-self-intersecting) shapes.
+    int stack[64];
+    int stackPtr = 0;
+    stack[0] = 0;
+
+    while (stackPtr >= 0) {
+        const int nodeIdx = stack[stackPtr--];
+        const BVHNode& node = mesh.bvhNodes[static_cast<size_t>(nodeIdx)];
+
+        // Cull this node by Minkowski-expanded AABB overlap test.
+        const glm::vec3 expMin = node.boundsMin - halfExtents;
+        const glm::vec3 expMax = node.boundsMax + halfExtents;
+        if (pos.x < expMin.x || pos.x > expMax.x || pos.y < expMin.y || pos.y > expMax.y || pos.z < expMin.z ||
+            pos.z > expMax.z)
+            continue;
+
+        if (node.count > 0) {
+            // Leaf — depenetrate against each triangle individually.
+            for (int i = node.leftFirst; i < node.leftFirst + node.count; ++i) {
+                const uint32_t ti = mesh.triIndices[static_cast<size_t>(i)];
+                const glm::vec3& v0 = mesh.vertices[mesh.indices[ti * 3 + 0]];
+                const glm::vec3& v1 = mesh.vertices[mesh.indices[ti * 3 + 1]];
+                const glm::vec3& v2 = mesh.vertices[mesh.indices[ti * 3 + 2]];
+
+                glm::vec3 mtv;
+                if (!aabbVsTriMTV(pos, halfExtents, v0, v1, v2, mtv))
+                    continue;
+
+                const float depth = glm::length(mtv);
+                if (depth < 1e-6f)
+                    continue; // numerical floor — already touching
+
+                const glm::vec3 pushDir = mtv / depth;
+
+                // Push out by (depth + pushback) so we sit just off the surface.
+                pos += pushDir * (depth + pushback);
+
+                // Cancel velocity component flowing INTO the surface (vel · pushDir < 0
+                // means motion was opposite to the push, i.e. into the triangle).  This
+                // lets the entity slide along the contact instead of re-penetrating
+                // next frame.
+                const float into = glm::dot(vel, pushDir);
+                if (into < 0.0f)
+                    vel -= pushDir * into;
+            }
+        } else {
+            stack[++stackPtr] = node.leftFirst;
+            stack[++stackPtr] = node.leftFirst + 1;
+        }
+    }
 }
 
 } // namespace physics

--- a/src/ecs/physics/TriMeshCollision.hpp
+++ b/src/ecs/physics/TriMeshCollision.hpp
@@ -21,4 +21,27 @@ void buildTriMeshBVH(WorldTriMesh& mesh);
 /// @brief Sweep an AABB against a triangle mesh using BVH-accelerated SAT tests.
 HitResult sweepAABBvsTriMesh(glm::vec3 halfExtents, glm::vec3 start, glm::vec3 end, const WorldTriMesh& mesh);
 
+/// @brief Push an AABB out of a triangle mesh using per-triangle SAT MTV.
+///
+/// For each triangle the AABB overlaps (BVH-accelerated leaf search), computes
+/// the minimum-translation-vector that separates the AABB from the triangle and
+/// applies it.  More accurate than depenetrating against leaf-AABB proxies:
+/// curved surfaces (cylinders, spheres) feel curved instead of cubical.
+///
+/// Velocity is updated to cancel the component flowing into the surface, so the
+/// entity slides along the contact rather than re-penetrating next frame.
+///
+/// Trade-off: at sharp triangle edges where adjacent face normals fight, the
+/// per-triangle pushes can briefly disagree.  In practice this is rare and the
+/// pushback bias keeps the entity off the surface.
+///
+/// @param pos          AABB centre — modified in place to push out of overlaps.
+/// @param vel          Velocity — modified in place to cancel inward motion.
+/// @param halfExtents  AABB half-extents.
+/// @param mesh         Triangle mesh to depenetrate from.
+/// @param pushback     Tiny extra distance added to each push to avoid hairline
+///                     contact (matches Quake's DIST_EPSILON of 1/32 unit).
+void depenetrateAABBvsTriMesh(
+    glm::vec3& pos, glm::vec3& vel, glm::vec3 halfExtents, const WorldTriMesh& mesh, float pushback = 0.03125f);
+
 } // namespace physics

--- a/src/ecs/physics/VHACDImpl.cpp
+++ b/src/ecs/physics/VHACDImpl.cpp
@@ -1,0 +1,43 @@
+/// @file VHACDImpl.cpp
+/// @brief Single translation unit that compiles the V-HACD implementation.
+///
+/// V-HACD is a header-only library (`VHACD.h`).  Its header gates the actual
+/// algorithm behind the `ENABLE_VHACD_IMPLEMENTATION` macro — exactly like
+/// `stb_image` and `dr_libs` style single-headers.  Defining the macro in
+/// *one* compilation unit (this file) compiles the implementation; every
+/// other site just `#include <VHACD.h>` for the public API.
+
+// V-HACD uses a few constructs that fire warnings under our strict warning
+// configuration (-Wconversion, -Wshadow, etc.).  Suppress them around the
+// implementation include so we don't need to fix upstream code.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wcast-align"
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244 4305 4267 4456 4458 4459 4505 4189 4100)
+#endif
+
+#define ENABLE_VHACD_IMPLEMENTATION 1
+#include <VHACD.h>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/src/ecs/systems/CollisionSystem.cpp
+++ b/src/ecs/systems/CollisionSystem.cpp
@@ -210,51 +210,17 @@ depenetrateSphere(glm::vec3& pos, glm::vec3& vel, const glm::vec3& halfExtents, 
 
 /// @brief Push the entity out of a triangle mesh it currently overlaps.
 ///
-/// Instead of depenetrating against individual triangles (which jitters at
-/// edges where adjacent normals fight), this uses the BVH leaf AABBs as
-/// proxy collision volumes.  Each leaf AABB is a tight box around 1-4
-/// triangles.  AABB depenetration has stable, consistent face normals —
-/// the same algorithm that works perfectly for WorldAABB.
-///
-/// The swept collision still uses precise per-triangle tests, so sliding and
-/// surface normals are accurate.  This depenetration is only a safety net.
+/// Delegates to `physics::depenetrateAABBvsTriMesh`, which uses per-triangle
+/// SAT MTV — accurate enough that curved surfaces (cylinders, spheres) feel
+/// curved instead of cubical.  Trade-off: at sharp triangle edges where
+/// adjacent normals fight, per-triangle pushes can briefly disagree.  In
+/// practice the pushback bias keeps the entity off the surface and the swept
+/// collision (which still does precise per-triangle hits) is the primary path
+/// for normal motion; this depenetration is only a safety net.
 static void
 depenetrateTriMesh(glm::vec3& pos, glm::vec3& vel, const glm::vec3& halfExtents, const physics::WorldTriMesh& mesh)
 {
-    // Quick reject: AABB overlap with mesh bounds.
-    if (pos.x + halfExtents.x < mesh.boundsMin.x || pos.x - halfExtents.x > mesh.boundsMax.x ||
-        pos.y + halfExtents.y < mesh.boundsMin.y || pos.y - halfExtents.y > mesh.boundsMax.y ||
-        pos.z + halfExtents.z < mesh.boundsMin.z || pos.z - halfExtents.z > mesh.boundsMax.z)
-        return;
-
-    // BVH traversal: find leaf nodes whose AABBs overlap the entity and
-    // depenetrate against each leaf AABB using the standard box push-out.
-    int stack[64];
-    int stackPtr = 0;
-    stack[0] = 0;
-
-    while (stackPtr >= 0) {
-        const int nodeIdx = stack[stackPtr--];
-        const auto& node = mesh.bvhNodes[static_cast<size_t>(nodeIdx)];
-
-        // Expand node bounds by entity halfExtents (Minkowski sum).
-        const glm::vec3 expMin = node.boundsMin - halfExtents;
-        const glm::vec3 expMax = node.boundsMax + halfExtents;
-
-        // Not overlapping this node?
-        if (pos.x < expMin.x || pos.x > expMax.x || pos.y < expMin.y || pos.y > expMax.y || pos.z < expMin.z ||
-            pos.z > expMax.z)
-            continue;
-
-        if (node.count > 0) {
-            // Leaf node — depenetrate against its AABB (same logic as depenetrateBox).
-            const physics::WorldAABB leafBox{node.boundsMin, node.boundsMax};
-            depenetrateBox(pos, vel, halfExtents, leafBox);
-        } else {
-            stack[++stackPtr] = node.leftFirst;
-            stack[++stackPtr] = node.leftFirst + 1;
-        }
-    }
+    physics::depenetrateAABBvsTriMesh(pos, vel, halfExtents, mesh, k_pushback);
 }
 
 /// @brief Run all depenetration passes (planes, boxes, brushes, cylinders, spheres).

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -51,6 +51,11 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz)
         static constexpr bool k_separatedCollisionMap = true;
         static constexpr const char* k_collisionPattern = "COL_";
 
+        // Should collision meshes be auto-fit to primitive shapes, or kept
+        // as raw triMeshes (the exact artist-authored Blender geometry)?
+        // Must match the client value in Game.cpp for prediction parity.
+        static constexpr bool k_guessShapesProcessed = false;
+
         const char* const mapFilename = k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : "maps/map1.glb";
 
         const char* base = SDL_GetBasePath();
@@ -61,6 +66,7 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz)
         opts.allMeshesAreCollision = !k_separatedCollisionMap;
         if (k_separatedCollisionMap)
             opts.collisionCollection = k_collisionPattern;
+        opts.guessShapesProcessed = k_guessShapesProcessed;
         opts.addFloorPlane = false; // Map geometry provides its own floor.
 
         if (physics::loadMapCollision(mapPath, mapCollision_, opts)) {

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -84,10 +84,22 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz)
 
         // Load prop collision — must match client for prediction parity.
         // Porsche removed — its 75-mesh hierarchy floods the collision debug UI.
+        // `decomposeNonConvex = true`: pallet + bottle are non-convex, so
+        // V-HACD turns each non-convex sub-mesh into a few `WorldBrush`es
+        // instead of a `WorldTriMesh`.  Server pays a one-shot startup cost
+        // but runtime collision is much smoother (no per-triangle jitter).
+        // Must mirror the client setting in Game.cpp for prediction parity.
         const std::string assetsDir = std::string(base ? base : "") + "assets/";
-        physics::loadPropCollision(
-            assetsDir + "metallic_pallet_factory_store.glb", mapCollision_, glm::vec3(0.0f, 0.0f, 600.0f), 0.25f);
-        physics::loadPropCollision(assetsDir + "bottle_a.glb", mapCollision_, glm::vec3(100.0f, 0.0f, 400.0f), 20.0f);
+        physics::loadPropCollision(assetsDir + "metallic_pallet_factory_store.glb",
+                                   mapCollision_,
+                                   glm::vec3(0.0f, 0.0f, 600.0f),
+                                   0.25f,
+                                   /*decomposeNonConvex=*/true);
+        physics::loadPropCollision(assetsDir + "bottle_a.glb",
+                                   mapCollision_,
+                                   glm::vec3(100.0f, 0.0f, 400.0f),
+                                   20.0f,
+                                   /*decomposeNonConvex=*/true);
 
         // Set active world with map + all props.
         physics::setActiveWorld(mapCollision_.geometry());

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -83,9 +83,8 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz)
         }
 
         // Load prop collision — must match client for prediction parity.
+        // Porsche removed — its 75-mesh hierarchy floods the collision debug UI.
         const std::string assetsDir = std::string(base ? base : "") + "assets/";
-        physics::loadPropCollision(
-            assetsDir + "free_1975_porsche_911_930_turbo.glb", mapCollision_, glm::vec3(-200.0f, 1.3f, 400.0f), 40.0f);
         physics::loadPropCollision(
             assetsDir + "metallic_pallet_factory_store.glb", mapCollision_, glm::vec3(0.0f, 0.0f, 600.0f), 0.25f);
         physics::loadPropCollision(assetsDir + "bottle_a.glb", mapCollision_, glm::vec3(100.0f, 0.0f, 400.0f), 20.0f);

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -54,7 +54,7 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz)
         // Should collision meshes be auto-fit to primitive shapes, or kept
         // as raw triMeshes (the exact artist-authored Blender geometry)?
         // Must match the client value in Game.cpp for prediction parity.
-        static constexpr bool k_guessShapesProcessed = false;
+        static constexpr bool k_guessShapesProcessed = true;
 
         const char* const mapFilename = k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : "maps/map1.glb";
 

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -42,19 +42,36 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz)
     {
         static constexpr float k_metersToInches = 39.3701f;
 
+        // Toggle: does this map use SEPARATED collision and visual meshes?
+        // Must match the client (Game.cpp) for prediction parity — both sides
+        // need to extract the exact same collision primitives from the GLB.
+        //   false → "prototype mode": every mesh in the GLB is collision.
+        //   true  → "separated mode": only nodes whose name contains the
+        //           collision pattern (e.g. "COL_") are extracted as collision.
+        static constexpr bool k_separatedCollisionMap = true;
+        static constexpr const char* k_collisionPattern = "COL_";
+
+        const char* const mapFilename = k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : "maps/map1.glb";
+
         const char* base = SDL_GetBasePath();
-        const std::string mapPath = std::string(base ? base : "") + "assets/maps/map1.glb";
+        const std::string mapPath = std::string(base ? base : "") + "assets/" + mapFilename;
 
         physics::MapLoadOptions opts;
         opts.scale = k_metersToInches;
-        opts.allMeshesAreCollision = true; // Prototype map — every mesh is collision.
-        opts.addFloorPlane = false;        // Map geometry provides its own floor.
+        opts.allMeshesAreCollision = !k_separatedCollisionMap;
+        if (k_separatedCollisionMap)
+            opts.collisionCollection = k_collisionPattern;
+        opts.addFloorPlane = false; // Map geometry provides its own floor.
 
         if (physics::loadMapCollision(mapPath, mapCollision_, opts)) {
-            SDL_Log("[server] map collision loaded: %zu planes, %zu boxes, %zu brushes",
+            SDL_Log("[server] map collision loaded: %zu planes, %zu boxes, %zu brushes, %zu cylinders, %zu spheres, "
+                    "%zu trimeshes",
                     mapCollision_.planes.size(),
                     mapCollision_.boxes.size(),
-                    mapCollision_.brushes.size());
+                    mapCollision_.brushes.size(),
+                    mapCollision_.cylinders.size(),
+                    mapCollision_.spheres.size(),
+                    mapCollision_.triMeshes.size());
         } else {
             SDL_Log("[server] WARNING: map collision load failed — falling back to testWorld()");
         }


### PR DESCRIPTION
This pull request introduces several significant improvements across the codebase, focusing on collision handling, player state management, and build system enhancements. The most notable changes are the integration of the V-HACD library for improved collision mesh decomposition, a refactor of player state components for better separation of concerns, and the addition of a new `clientbot` executable for server load testing. Additionally, the map loading logic is updated to support separated collision and visual meshes, and various code and build adjustments are made to support these changes.

**Collision handling improvements:**

* Integrated the V-HACD (Volumetric Hierarchical Approximate Convex Decomposition) library as a header-only dependency, enabling MapLoader to split non-convex collision meshes into convex hulls for more stable physics. Updated build targets to include the new library and its implementation file `VHACDImpl.cpp`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR309-R323) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR719) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1031) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1210) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR843) [[6]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1138) [[7]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1288)

**Player state refactor:**

* Refactored player state into multiple components: `PlayerVisState`, `PlayerSimState`, and `PlayerStateEnums`, replacing the monolithic `PlayerState` component. Updated all references in code and build scripts to use the new components. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL682-R699) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL990-R1011) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1172-R1197) [[4]](diffhunk://#diff-1306689d3aa223121a9f95b8720d2fc6504f8b18e558b9c478ff137eee23863cL71-R71) [[5]](diffhunk://#diff-9b44ffee28d09f42022e3005a5291c63832d3f1b247ea4bd7c3b7b72083b9eccL18-R18) [[6]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83L11-R11) [[7]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83L374-R375) [[8]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83L477-R483) [[9]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83L545-R545) [[10]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83L607-R607) [[11]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83L617-R617) [[12]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L19-R19)

**Build system and tooling:**

* Added a new `clientbot` executable for headless, network-only server load testing. This tool spawns multiple TCP client connections without requiring a GPU or animation/physics, allowing for stress testing beyond the GPU context limit. The build system is updated to include this target and its dependencies.

**Map loading and collision/visual separation:**

* Updated map loading logic to support "separated mode", where collision and visual meshes are handled independently. Collision-only meshes are identified by a naming convention (e.g., "COL_" prefix), and new options allow for auto-fitting collision meshes to primitives or using raw geometry. Visual mesh loading now excludes collision-only nodes as needed. [[1]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4R161-R224) [[2]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L214-R253)

**Minor code and build cleanups:**

* Removed the "porsche" prop from the map due to its complexity in collision debugging. Updated various code comments and fixed header references to match the new component structure. [[1]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L214-R253) [[2]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L830-L831)

Let me know if you'd like a walkthrough of any of these changes in more detail!