### PR TITLE
Externalize map loading func from client and server. They now just call the same function.

### DIFF
--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -6,6 +6,7 @@
 #include "SDL3/SDL_init.h"
 #include "animation/CharacterAnimator.hpp"
 #include "ecs/AssetCatalog.hpp"
+#include "ecs/MapConfig.hpp"
 #include "ecs/components/AnimatedCharacter.hpp"
 #include "ecs/components/BeamState.hpp"
 #include "ecs/components/ClientId.hpp"
@@ -176,68 +177,22 @@ bool Game::init()
     // ── Load map ──────────────────────────────────────────────────────────
     // Scale: the map was authored in meters; the game uses Quake units (inches).
     // 1 m = 39.3701 in.
+    //
+    // Map filename and load-mode toggles live in ecs/MapConfig.hpp so the
+    // client and server load the exact same primitives (a prerequisite for
+    // prediction parity).  To switch maps, edit `kMapAsset` in AssetCatalog.hpp.
+    // To change *how* the map is loaded, edit the constants in MapConfig.hpp.
     {
-        // Toggle: does this map use SEPARATED collision and visual meshes?
-        //   false → "prototype mode": every mesh in the GLB is both visual *and*
-        //           collision (used for blockout maps like map1.glb).
-        //   true  → "separated mode": collision-only meshes are tagged in Blender
-        //           (e.g. "COL_*" prefix) and excluded from the visual model.
-        //           Used for production maps where collision is hand-authored
-        //           independently from rendering geometry.
-        static constexpr bool k_separatedCollisionMap = false;
-
-        // Pattern that identifies collision-only nodes when in separated mode.
-        // The Blender export convention here is a "COL_" prefix; nodes whose
-        // names contain this substring (case-insensitive) are treated as
-        // collision-only and stripped from the visual mesh list.
-        static constexpr const char* k_collisionPattern = "COL_";
-
-        // In separated mode, should the loader auto-fit each collision mesh
-        // to a primitive (AABB / cylinder / sphere / brush) — or load the raw
-        // Blender geometry as-is (triangle mesh)?
-        //   true  (default) → auto-detect: convex shapes become cheap primitives
-        //                     or brushes; only truly non-convex meshes fall
-        //                     back to triMesh.  Smoother collision overall.
-        //   false           → trust the artist: every collision mesh stays a
-        //                     triMesh, vertex-for-vertex, exactly as authored.
-        static constexpr bool k_guessShapesProcessed = true;
-
-        const char* const mapFilename =
-            k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : kMapAsset.filename;
-
-        const char* base = SDL_GetBasePath();
-        const std::string mapPath = std::string(base ? base : "") + "assets/" + mapFilename;
-
-        // 1) Extract collision geometry.
-        physics::MapLoadOptions opts;
-        opts.scale = kMapAsset.loadScale;
-        opts.allMeshesAreCollision = !k_separatedCollisionMap;
-        // In separated mode, recognise collision-prefixed nodes; in prototype
-        // mode, the field is unused (every mesh is collision by definition).
-        if (k_separatedCollisionMap)
-            opts.collisionCollection = k_collisionPattern;
-        opts.guessShapesProcessed = k_guessShapesProcessed;
-        opts.addFloorPlane = false; // Map geometry provides its own floor.
-
-        if (physics::loadMapCollision(mapPath, mapCollision_, opts)) {
-            SDL_Log("[client] map collision loaded: %zu planes, %zu boxes, %zu brushes, %zu cylinders, %zu spheres, "
-                    "%zu trimeshes",
-                    mapCollision_.planes.size(),
-                    mapCollision_.boxes.size(),
-                    mapCollision_.brushes.size(),
-                    mapCollision_.cylinders.size(),
-                    mapCollision_.spheres.size(),
-                    mapCollision_.triMeshes.size());
-        } else {
-            SDL_Log("[client] WARNING: map collision load failed — falling back to testWorld()");
-        }
+        // 1) Extract collision geometry (shared with server).
+        gamemap::loadConfiguredMap(mapCollision_, "client");
 
         // 2) Load visual model for rendering (scene-pass so it draws as static world geometry).
         // In separated mode, exclude collision-only nodes so they aren't rendered.
-        const std::string visualExclude = k_separatedCollisionMap ? std::string(k_collisionPattern) : std::string();
+        const std::string visualExclude =
+            gamemap::k_separatedCollisionMap ? std::string(gamemap::k_collisionPattern) : std::string();
         const int mapId = addAssetDefinition(assets_, kMapAsset);
         const int mapModelIdx = renderer.loadSceneModel(
-            mapFilename, kMapAsset.loadTranslation, kMapAsset.loadScale, kMapAsset.flipUVs, visualExclude);
+            kMapAsset.filename, kMapAsset.loadTranslation, kMapAsset.loadScale, kMapAsset.flipUVs, visualExclude);
         assets_.setModelIndex(mapId, mapModelIdx);
         if (mapModelIdx >= 0) {
             renderer.setModelScenePass(mapModelIdx, true);

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -184,7 +184,7 @@ bool Game::init()
         //           (e.g. "COL_*" prefix) and excluded from the visual model.
         //           Used for production maps where collision is hand-authored
         //           independently from rendering geometry.
-        static constexpr bool k_separatedCollisionMap = true;
+        static constexpr bool k_separatedCollisionMap = false;
 
         // Pattern that identifies collision-only nodes when in separated mode.
         // The Blender export convention here is a "COL_" prefix; nodes whose

--- a/src/ecs/MapConfig.hpp
+++ b/src/ecs/MapConfig.hpp
@@ -1,0 +1,125 @@
+/// @file MapConfig.hpp
+/// @brief Single source of truth for which map is loaded and how, shared by client and server.
+///
+/// **Why this exists.** The server is authoritative for movement and the client predicts;
+/// for prediction to agree with the server, both sides must extract *exactly* the same
+/// collision primitives from the *exact* same map file. Previously this code was duplicated
+/// in `client/game/Game.cpp` and `server/game/ServerGame.cpp` and the two could silently drift.
+/// Now both call `gamemap::loadConfiguredMap()` and read the same constants from this header.
+///
+/// **What lives here.**
+///   1. The "how to load it" toggles (`k_separatedCollisionMap`, `k_guessShapesProcessed`).
+///   2. The collision-pattern substring used in separated mode (`k_collisionPattern`).
+///   3. Helpers to build `MapLoadOptions` and resolve the absolute map path.
+///   4. `loadConfiguredMap()` — fills a `MapCollisionData` using the configured options.
+///
+/// **What does NOT live here.** The map *filename* itself. That stays in `AssetCatalog.hpp`
+/// (`kMapAsset.filename`) so there is one and only one source of truth for which file is
+/// loaded. Flipping the toggles below changes *how* the map is processed, never *which*
+/// map. To switch to a different map, edit `kMapAsset` in `AssetCatalog.hpp`.
+
+#pragma once
+
+#include "ecs/AssetCatalog.hpp"
+#include "ecs/physics/MapLoader.hpp"
+
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_log.h>
+
+#include <string>
+
+namespace gamemap
+{
+
+/// @brief Does this map use SEPARATED collision and visual meshes?
+///
+///   false → "prototype mode": every mesh in the GLB is both visual *and*
+///           collision. Used for blockout maps like map1.glb.
+///   true  → "separated mode": collision-only nodes are tagged in Blender
+///           with the prefix `kCollisionPattern` and excluded from the visual
+///           model. Used for production maps where collision is hand-authored
+///           independently from rendering geometry.
+///
+/// IMPORTANT: this flag controls *how* the map is processed, not *which* map
+/// is loaded. The map filename comes solely from `kMapAsset` in `AssetCatalog.hpp`.
+inline constexpr bool k_separatedCollisionMap = false;
+
+/// @brief Substring that identifies collision-only nodes in separated mode.
+/// Matched case-insensitively against Assimp node names.
+inline constexpr const char* k_collisionPattern = "COL_";
+
+/// @brief Should collision meshes be auto-fit to primitive shapes, or kept
+/// as raw triMeshes (the exact artist-authored Blender geometry)?
+///
+///   true  (default) → run the auto-detection pipeline (AABB → cylinder →
+///                     sphere → convex brush → triMesh). Convex meshes
+///                     become cheap primitives or brushes; only truly
+///                     non-convex meshes fall back to triMesh.
+///   false           → trust the artist: every collision mesh stays a
+///                     triMesh, vertex-for-vertex.
+///
+/// Has no effect in prototype mode (`k_separatedCollisionMap = false`):
+/// every mesh is collision there, and forcing all of them to triMesh would
+/// be prohibitively expensive.
+inline constexpr bool k_guessShapesProcessed = true;
+
+/// @brief Build the `MapLoadOptions` used by both client and server.
+///
+/// Centralised so the two sides cannot drift. The client also reads
+/// `k_separatedCollisionMap` / `k_collisionPattern` directly when deciding
+/// which visual meshes to exclude from the renderer.
+[[nodiscard]] inline physics::MapLoadOptions makeLoadOptions()
+{
+    physics::MapLoadOptions opts;
+    opts.scale = kMapAsset.loadScale;
+    opts.allMeshesAreCollision = !k_separatedCollisionMap;
+    if (k_separatedCollisionMap)
+        opts.collisionCollection = k_collisionPattern;
+    opts.guessShapesProcessed = k_guessShapesProcessed;
+    opts.addFloorPlane = false; // Map geometry provides its own floor.
+    return opts;
+}
+
+/// @brief Resolve the absolute path of the configured map file.
+///
+/// Reads the filename from `kMapAsset` (in `AssetCatalog.hpp`) — never
+/// affected by the load-mode toggles above.
+[[nodiscard]] inline std::string mapAbsolutePath()
+{
+    const char* const base = SDL_GetBasePath();
+    return std::string(base ? base : "") + "assets/" + kMapAsset.filename;
+}
+
+/// @brief Load the configured map's collision into `out`.
+///
+/// Both client and server call this so they end up with identical primitives
+/// (a prerequisite for prediction parity). Logs success/failure with `tag`
+/// so each side keeps its `[client]` / `[server]` prefix.
+///
+/// @param out  Filled with extracted collision primitives on success.
+/// @param tag  Short side identifier used in log output ("client" / "server").
+/// @return Whatever `physics::loadMapCollision` returns.
+inline bool loadConfiguredMap(physics::MapCollisionData& out, const char* tag)
+{
+    const std::string path = mapAbsolutePath();
+    const physics::MapLoadOptions opts = makeLoadOptions();
+
+    if (physics::loadMapCollision(path, out, opts)) {
+        SDL_Log("[%s] map collision loaded (%s): %zu planes, %zu boxes, %zu brushes, %zu cylinders, %zu spheres, "
+                "%zu trimeshes",
+                tag,
+                kMapAsset.filename,
+                out.planes.size(),
+                out.boxes.size(),
+                out.brushes.size(),
+                out.cylinders.size(),
+                out.spheres.size(),
+                out.triMeshes.size());
+        return true;
+    }
+
+    SDL_Log("[%s] WARNING: map collision load failed (%s) — falling back to testWorld()", tag, kMapAsset.filename);
+    return false;
+}
+
+} // namespace gamemap

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -5,6 +5,7 @@
 
 #include "client/animation/CharacterAnimator.hpp"
 #include "ecs/AssetCatalog.hpp"
+#include "ecs/MapConfig.hpp"
 #include "ecs/components/BeamState.hpp"
 #include "ecs/components/CollisionShape.hpp"
 #include "ecs/components/Health.hpp"
@@ -55,53 +56,19 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz, int snapshotHz, con
     registry.clear();
 
     // ── Load map collision ──────────────────────────────────────────────
+    // Map filename and load-mode toggles live in ecs/MapConfig.hpp so the
+    // client and server load the exact same primitives (a prerequisite for
+    // prediction parity).  To switch maps, edit `kMapAsset` in AssetCatalog.hpp.
+    // To change *how* the map is loaded, edit the constants in MapConfig.hpp.
     {
-        // Toggle: does this map use SEPARATED collision and visual meshes?
-        // Must match the client (Game.cpp) for prediction parity — both sides
-        // need to extract the exact same collision primitives from the GLB.
-        //   false → "prototype mode": every mesh in the GLB is collision.
-        //   true  → "separated mode": only nodes whose name contains the
-        //           collision pattern (e.g. "COL_") are extracted as collision.
-        static constexpr bool k_separatedCollisionMap = false;
-        static constexpr const char* k_collisionPattern = "COL_";
-
-        // Should collision meshes be auto-fit to primitive shapes, or kept
-        // as raw triMeshes (the exact artist-authored Blender geometry)?
-        // Must match the client value in Game.cpp for prediction parity.
-        static constexpr bool k_guessShapesProcessed = true;
-
-        const char* const mapFilename =
-            k_separatedCollisionMap ? "maps/map1_script_collisions.glb" : kMapAsset.filename;
-
-        const char* base = SDL_GetBasePath();
-        const std::string mapPath = std::string(base ? base : "") + "assets/" + mapFilename;
-
-        physics::MapLoadOptions opts;
-        opts.scale = kMapAsset.loadScale;
-        opts.allMeshesAreCollision = !k_separatedCollisionMap;
-        if (k_separatedCollisionMap)
-            opts.collisionCollection = k_collisionPattern;
-        opts.guessShapesProcessed = k_guessShapesProcessed;
-        opts.addFloorPlane = false; // Map geometry provides its own floor.
-
-        if (physics::loadMapCollision(mapPath, mapCollision_, opts)) {
-            SDL_Log("[server] map collision loaded: %zu planes, %zu boxes, %zu brushes, %zu cylinders, %zu spheres, "
-                    "%zu trimeshes",
-                    mapCollision_.planes.size(),
-                    mapCollision_.boxes.size(),
-                    mapCollision_.brushes.size(),
-                    mapCollision_.cylinders.size(),
-                    mapCollision_.spheres.size(),
-                    mapCollision_.triMeshes.size());
-        } else {
-            SDL_Log("[server] WARNING: map collision load failed — falling back to testWorld()");
-        }
+        gamemap::loadConfiguredMap(mapCollision_, "server");
 
         // Load prop collision — must match client for prediction parity.
         // Props with `decomposeCollision = true` (pallet, bottle) are non-convex,
         // so V-HACD turns each sub-mesh into a few `WorldBrush`es instead of a
         // `WorldTriMesh`.  Server pays a one-shot startup cost but runtime
         // collision is much smoother (no per-triangle jitter).
+        const char* const base = SDL_GetBasePath();
         const std::string assetsDir = std::string(base ? base : "") + "assets/";
         for (const AssetDefinition& def : kPropAssets)
             physics::loadPropCollision(

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -62,7 +62,7 @@ bool ServerGame::init(const char* addr, Uint16 port, int hz, int snapshotHz, con
         //   false → "prototype mode": every mesh in the GLB is collision.
         //   true  → "separated mode": only nodes whose name contains the
         //           collision pattern (e.g. "COL_") are extracted as collision.
-        static constexpr bool k_separatedCollisionMap = true;
+        static constexpr bool k_separatedCollisionMap = false;
         static constexpr const char* k_collisionPattern = "COL_";
 
         // Should collision meshes be auto-fit to primitive shapes, or kept


### PR DESCRIPTION
Should simplify handling and changing maps, testing, anything else. And guaranteed to behave same way.