### PR TITLE
Chore/debug vis

### DIFF
--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -12,6 +12,7 @@
 #include "ecs/components/PlayerVisState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/PreviousPosition.hpp"
+#include "ecs/components/RespawnPoint.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/WeaponConfig.hpp"
 #include "ecs/components/WeaponSpawner.hpp"
@@ -154,6 +155,7 @@ void DebugUI::buildDebugMenu(std::initializer_list<ExternalPanel> externalPanels
     ImGui::Checkbox("Hitbox Debug", &showHitboxWindow);
     ImGui::Checkbox("Collision Debug", &showCollisionWindow);
     ImGui::Checkbox("Weapon Spawners", &showWeaponSpawnerWindow);
+    ImGui::Checkbox("Spawn Points", &showSpawnPointWindow);
     ImGui::Checkbox("Shot Debug (sv_showimpacts)", &showShotDebugWindow);
 
     // External panels (owned by Game)
@@ -2076,6 +2078,110 @@ void DebugUI::buildWeaponSpawnerUI(const Registry& registry,
             }
             dl->AddText({sp.x + k_crossLen + 4.0f, sp.y - 6.0f}, markerColor, typeName);
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildSpawnPointUI
+// ─────────────────────────────────────────────────────────────────────────────
+void DebugUI::buildSpawnPointUI(const Registry& registry,
+                                const glm::mat4& viewProj,
+                                float screenWidth,
+                                float screenHeight)
+{
+    // ── ImGui window (only when showSpawnPointWindow is true) ──
+    if (showSpawnPointWindow) {
+        if (ImGui::Begin("Spawn Point Debug", &showSpawnPointWindow)) {
+            ImGui::Checkbox("Draw Spawn Markers", &drawSpawnPointOverlay);
+            ImGui::Separator();
+
+            // Count spawn points.
+            int totalSpawns = 0;
+            int availableSpawns = 0;
+            auto spawnView = registry.view<RespawnPoint, Position>();
+            for (auto e : spawnView) {
+                ++totalSpawns;
+                if (spawnView.get<RespawnPoint>(e).available)
+                    ++availableSpawns;
+            }
+            ImGui::Text("Spawn Points: %d  |  Available: %d  |  On Cooldown: %d",
+                        totalSpawns,
+                        availableSpawns,
+                        totalSpawns - availableSpawns);
+            ImGui::Separator();
+
+            // Per-spawn-point details.
+            int idx = 0;
+            for (auto e : spawnView) {
+                const auto& sp = spawnView.get<RespawnPoint>(e);
+                const auto& pos = spawnView.get<Position>(e);
+
+                char label[64];
+                std::snprintf(label, sizeof(label), "Spawn #%d", idx);
+                if (ImGui::TreeNode(label)) {
+                    ImGui::Text("Position: (%.0f, %.0f, %.0f)", pos.value.x, pos.value.y, pos.value.z);
+                    if (sp.available) {
+                        ImGui::TextColored(ImVec4(0.2f, 1.0f, 0.2f, 1.0f), "Available");
+                    } else {
+                        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.2f, 1.0f), "Cooldown: %.1fs", sp.cooldown);
+                    }
+                    ImGui::TreePop();
+                }
+                ++idx;
+            }
+        }
+        ImGui::End();
+    }
+
+    // ── Marker overlay (independent of window visibility) ──
+    if (!drawSpawnPointOverlay)
+        return;
+
+    ImDrawList* dl = ImGui::GetForegroundDrawList();
+
+    auto spawnView = registry.view<RespawnPoint, Position>();
+    int idx = 0;
+    for (auto e : spawnView) {
+        const auto& sp = spawnView.get<RespawnPoint>(e);
+        const auto& pos = spawnView.get<Position>(e);
+
+        // Green = available, orange = on cooldown.
+        const ImU32 markerColor = sp.available ? IM_COL32(50, 255, 50, 220) : IM_COL32(255, 140, 30, 200);
+
+        // Draw a diamond marker at the spawn position.
+        ImVec2 center;
+        if (worldToScreen(pos.value, viewProj, screenWidth, screenHeight, center)) {
+            constexpr float k_size = 12.0f;
+            // Diamond shape (rotated square)
+            dl->AddQuadFilled({center.x, center.y - k_size},
+                              {center.x + k_size, center.y},
+                              {center.x, center.y + k_size},
+                              {center.x - k_size, center.y},
+                              markerColor);
+            // Outline
+            dl->AddQuad({center.x, center.y - k_size},
+                        {center.x + k_size, center.y},
+                        {center.x, center.y + k_size},
+                        {center.x - k_size, center.y},
+                        IM_COL32(255, 255, 255, 200),
+                        2.0f);
+
+            // Label with spawn index and status.
+            char text[48];
+            if (sp.available) {
+                std::snprintf(text, sizeof(text), "Spawn #%d", idx);
+            } else {
+                std::snprintf(text, sizeof(text), "Spawn #%d (%.1fs)", idx, sp.cooldown);
+            }
+            dl->AddText({center.x + k_size + 4.0f, center.y - 6.0f}, IM_COL32(255, 255, 255, 220), text);
+        }
+
+        // Draw a vertical "pole" line from the ground (y=0) up to the spawn height
+        // so the spawn is easy to spot in 3D space.
+        const glm::vec3 groundPoint = {pos.value.x, 0.0f, pos.value.z};
+        drawWorldLine(dl, groundPoint, pos.value, viewProj, screenWidth, screenHeight, markerColor, 1.5f);
+
+        ++idx;
     }
 }
 

--- a/src/client/debug/DebugUI.cpp
+++ b/src/client/debug/DebugUI.cpp
@@ -14,6 +14,7 @@
 #include "ecs/components/PreviousPosition.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/WeaponConfig.hpp"
+#include "ecs/components/WeaponSpawner.hpp"
 #include "ecs/components/WeaponState.hpp"
 #include "ecs/physics/Movement.hpp"
 #include "ecs/physics/PhysicsConstants.hpp"
@@ -152,6 +153,7 @@ void DebugUI::buildDebugMenu(std::initializer_list<ExternalPanel> externalPanels
     ImGui::SeparatorText("Physics");
     ImGui::Checkbox("Hitbox Debug", &showHitboxWindow);
     ImGui::Checkbox("Collision Debug", &showCollisionWindow);
+    ImGui::Checkbox("Weapon Spawners", &showWeaponSpawnerWindow);
     ImGui::Checkbox("Shot Debug (sv_showimpacts)", &showShotDebugWindow);
 
     // External panels (owned by Game)
@@ -1927,6 +1929,153 @@ void DebugUI::buildCollisionUI(const physics::WorldGeometry& world,
         const ImU32 triColor = IM_COL32(200, 50, 255, 220);
         for (const auto& tm : world.triMeshes)
             drawTriMeshWireframe(dl, tm, viewProj, screenWidth, screenHeight, triColor);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildWeaponSpawnerUI
+// ─────────────────────────────────────────────────────────────────────────────
+void DebugUI::buildWeaponSpawnerUI(const Registry& registry,
+                                   const glm::mat4& viewProj,
+                                   float screenWidth,
+                                   float screenHeight)
+{
+    // ── ImGui window (only when showWeaponSpawnerWindow is true) ──
+    if (showWeaponSpawnerWindow) {
+        if (ImGui::Begin("Weapon Spawner Debug", &showWeaponSpawnerWindow)) {
+            ImGui::Checkbox("Draw Spawner Boxes", &drawWeaponSpawnerOverlay);
+            ImGui::Separator();
+
+            // Count spawners.
+            int totalSpawners = 0;
+            int activeSpawners = 0;
+            auto spawnerView = registry.view<WeaponSpawner, Position, CollisionShape>();
+            for (auto e : spawnerView) {
+                ++totalSpawners;
+                if (spawnerView.get<WeaponSpawner>(e).hasWeapon)
+                    ++activeSpawners;
+            }
+            ImGui::Text("Spawners: %d  |  Active: %d  |  On Cooldown: %d",
+                        totalSpawners,
+                        activeSpawners,
+                        totalSpawners - activeSpawners);
+            ImGui::Separator();
+
+            // Per-spawner details.
+            int idx = 0;
+            for (auto e : spawnerView) {
+                const auto& spawner = spawnerView.get<WeaponSpawner>(e);
+                const auto& pos = spawnerView.get<Position>(e);
+                const auto& shape = spawnerView.get<CollisionShape>(e);
+
+                const char* typeName = "Unknown";
+                switch (spawner.type) {
+                case WeaponType::Rifle:
+                    typeName = "Rifle";
+                    break;
+                case WeaponType::Rocket:
+                    typeName = "Rocket";
+                    break;
+                case WeaponType::RailGun:
+                    typeName = "RailGun";
+                    break;
+                case WeaponType::EnergyGun:
+                    typeName = "EnergyGun";
+                    break;
+                }
+
+                char label[64];
+                std::snprintf(label, sizeof(label), "Spawner #%d (%s)", idx, typeName);
+                if (ImGui::TreeNode(label)) {
+                    ImGui::Text("Position: (%.0f, %.0f, %.0f)", pos.value.x, pos.value.y, pos.value.z);
+                    ImGui::Text("Box half-extents: (%.0f, %.0f, %.0f)",
+                                shape.halfExtents.x,
+                                shape.halfExtents.y,
+                                shape.halfExtents.z);
+                    ImGui::Text("Has weapon: %s", spawner.hasWeapon ? "YES" : "no");
+                    if (!spawner.hasWeapon)
+                        ImGui::Text("Cooldown: %.1fs", spawner.spawnCooldown);
+                    ImGui::TreePop();
+                }
+                ++idx;
+            }
+        }
+        ImGui::End();
+    }
+
+    // ── Wireframe overlay (independent of window visibility) ──
+    if (!drawWeaponSpawnerOverlay)
+        return;
+
+    ImDrawList* dl = ImGui::GetForegroundDrawList();
+
+    auto spawnerView = registry.view<WeaponSpawner, Position, CollisionShape>();
+    for (auto e : spawnerView) {
+        const auto& spawner = spawnerView.get<WeaponSpawner>(e);
+        const auto& pos = spawnerView.get<Position>(e);
+        const auto& shape = spawnerView.get<CollisionShape>(e);
+
+        // Green = weapon available, red/orange = on cooldown.
+        const ImU32 boxColor = spawner.hasWeapon ? IM_COL32(50, 255, 50, 200) : IM_COL32(255, 100, 50, 160);
+
+        // Draw AABB wireframe around the spawner's collision volume.
+        const glm::vec3 mn = pos.value - shape.halfExtents;
+        const glm::vec3 mx = pos.value + shape.halfExtents;
+        const glm::vec3 corners[8] = {
+            {mn.x, mn.y, mn.z},
+            {mx.x, mn.y, mn.z},
+            {mx.x, mn.y, mx.z},
+            {mn.x, mn.y, mx.z},
+            {mn.x, mx.y, mn.z},
+            {mx.x, mx.y, mn.z},
+            {mx.x, mx.y, mx.z},
+            {mn.x, mx.y, mx.z},
+        };
+        // 12 edges of the AABB.
+        static constexpr int edges[12][2] = {
+            {0, 1},
+            {1, 2},
+            {2, 3},
+            {3, 0}, // bottom
+            {4, 5},
+            {5, 6},
+            {6, 7},
+            {7, 4}, // top
+            {0, 4},
+            {1, 5},
+            {2, 6},
+            {3, 7}, // verticals
+        };
+        for (const auto& edge : edges)
+            drawWorldLine(dl, corners[edge[0]], corners[edge[1]], viewProj, screenWidth, screenHeight, boxColor, 2.0f);
+
+        // Draw a cross marker at the spawn position (center point).
+        ImVec2 sp;
+        if (worldToScreen(pos.value, viewProj, screenWidth, screenHeight, sp)) {
+            constexpr float k_crossLen = 10.0f;
+            const ImU32 markerColor = IM_COL32(255, 255, 0, 220);
+            dl->AddLine({sp.x - k_crossLen, sp.y}, {sp.x + k_crossLen, sp.y}, markerColor, 2.0f);
+            dl->AddLine({sp.x, sp.y - k_crossLen}, {sp.x, sp.y + k_crossLen}, markerColor, 2.0f);
+            dl->AddCircle(sp, k_crossLen, markerColor, 12, 1.5f);
+
+            // Label with weapon type name.
+            const char* typeName = "?";
+            switch (spawner.type) {
+            case WeaponType::Rifle:
+                typeName = "Rifle";
+                break;
+            case WeaponType::Rocket:
+                typeName = "Rocket";
+                break;
+            case WeaponType::RailGun:
+                typeName = "RailGun";
+                break;
+            case WeaponType::EnergyGun:
+                typeName = "EnergyGun";
+                break;
+            }
+            dl->AddText({sp.x + k_crossLen + 4.0f, sp.y - 6.0f}, markerColor, typeName);
+        }
     }
 }
 

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -168,6 +168,19 @@ public:
     bool showCollisionWindow = false;  ///< Show the Collision Debug ImGui window.
     bool drawCollisionOverlay = false; ///< Draw world collision wireframes (independent of window visibility).
 
+    /// @brief Draw the Weapon Spawner Debug window and (optionally) wireframe overlay
+    /// for all weapon spawner entities, showing their bounding boxes and spawn positions.
+    ///
+    /// @param registry     ECS registry (reads WeaponSpawner, Position, CollisionShape).
+    /// @param viewProj     Combined view-projection matrix for the current camera.
+    /// @param screenWidth  Viewport width in pixels.
+    /// @param screenHeight Viewport height in pixels.
+    void
+    buildWeaponSpawnerUI(const Registry& registry, const glm::mat4& viewProj, float screenWidth, float screenHeight);
+
+    bool showWeaponSpawnerWindow = false;  ///< Show the Weapon Spawner Debug ImGui window.
+    bool drawWeaponSpawnerOverlay = false; ///< Draw weapon spawner wireframes (independent of window visibility).
+
     // ── PR-20: Shot-debug visualizer (CSGO sv_showimpacts-style) ─────
     //
     // Holds a ring buffer of paired (client-side fire-time snapshot,

--- a/src/client/debug/DebugUI.hpp
+++ b/src/client/debug/DebugUI.hpp
@@ -181,6 +181,18 @@ public:
     bool showWeaponSpawnerWindow = false;  ///< Show the Weapon Spawner Debug ImGui window.
     bool drawWeaponSpawnerOverlay = false; ///< Draw weapon spawner wireframes (independent of window visibility).
 
+    /// @brief Draw the Spawn Point Debug window and (optionally) overlay markers
+    /// for all player respawn point entities, showing position and cooldown state.
+    ///
+    /// @param registry     ECS registry (reads RespawnPoint, Position).
+    /// @param viewProj     Combined view-projection matrix for the current camera.
+    /// @param screenWidth  Viewport width in pixels.
+    /// @param screenHeight Viewport height in pixels.
+    void buildSpawnPointUI(const Registry& registry, const glm::mat4& viewProj, float screenWidth, float screenHeight);
+
+    bool showSpawnPointWindow = false;  ///< Show the Spawn Point Debug ImGui window.
+    bool drawSpawnPointOverlay = false; ///< Draw spawn point markers (independent of window visibility).
+
     // ── PR-20: Shot-debug visualizer (CSGO sv_showimpacts-style) ─────
     //
     // Holds a ring buffer of paired (client-side fire-time snapshot,

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -1584,13 +1584,15 @@ SDL_AppResult Game::iterate()
         // Note: Player component is not synced to clients, so we raycast against
         // HitboxInstance directly (skipping the local player entity).
         if (isBeamNow) {
-            registry.view<LocalPlayer, BeamState, InputSnapshot, Position, CollisionShape>().each(
+            registry.view<LocalPlayer, BeamState, InputSnapshot, Position, CollisionShape, PlayerVisState>().each(
                 [&](entt::entity localE,
                     const BeamState&,
                     const InputSnapshot& inp,
                     const Position& pos,
-                    const CollisionShape& shape) {
-                    const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f, 0.0f};
+                    const CollisionShape& shape,
+                    const PlayerVisState& pvis) {
+                    const float beamEyeDir = pvis.gravityFlipped ? -1.0f : 1.0f;
+                    const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * beamEyeDir, 0.0f};
                     const float cp = std::cos(inp.pitch);
                     const glm::vec3 dir{std::sin(inp.yaw) * cp, -std::sin(inp.pitch), std::cos(inp.yaw) * cp};
 
@@ -2015,14 +2017,16 @@ SDL_AppResult Game::iterate()
                 firePulledThisFrame = true;
         });
         if (firePulledThisFrame) {
-            registry.view<LocalPlayer, InputSnapshot, Position, CollisionShape>().each(
+            registry.view<LocalPlayer, InputSnapshot, Position, CollisionShape, PlayerVisState>().each(
                 [&](entt::entity localEntity,
                     const InputSnapshot& snap,
                     const Position& pos,
-                    const CollisionShape& shape) {
+                    const CollisionShape& shape,
+                    const PlayerVisState& pvis) {
                     net::shotdebug::ShotDebugCapture cap;
                     cap.shotInputTick = snap.tick; // PR-24: post-physics value, matches wire
-                    cap.origin = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f, 0.0f};
+                    const float debugEyeDir = pvis.gravityFlipped ? -1.0f : 1.0f;
+                    cap.origin = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * debugEyeDir, 0.0f};
                     const float cp = std::cos(snap.pitch);
                     cap.direction = glm::normalize(
                         glm::vec3{std::sin(snap.yaw) * cp, -std::sin(snap.pitch), std::cos(snap.yaw) * cp});
@@ -3172,9 +3176,13 @@ SDL_AppResult Game::iterate()
             glm::vec3 eye{0.f};
             glm::vec3 viewFwd{0.f, 0.f, 1.f};
             bool haveLocal = false;
-            registry.view<LocalPlayer, Position, CollisionShape, InputSnapshot>().each(
-                [&](const Position& pos, const CollisionShape& shape, const InputSnapshot& input) {
-                    eye = pos.value + glm::vec3{0.f, shape.halfExtents.y * 0.77f, 0.f};
+            registry.view<LocalPlayer, Position, CollisionShape, InputSnapshot, PlayerVisState>().each(
+                [&](const Position& pos,
+                    const CollisionShape& shape,
+                    const InputSnapshot& input,
+                    const PlayerVisState& pvis) {
+                    const float pickupEyeDir = pvis.gravityFlipped ? -1.0f : 1.0f;
+                    eye = pos.value + glm::vec3{0.f, shape.halfExtents.y * 0.77f * pickupEyeDir, 0.f};
                     const float cp = std::cos(input.pitch);
                     viewFwd = glm::normalize(glm::vec3{
                         std::sin(input.yaw) * cp,

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -433,7 +433,8 @@ bool Game::init()
         glm::vec3 evtOrigin = evt.pos1;
         if (evt.source == localPlayer && evt.effectType == ParticleEffectType::HitscanBeam) {
             const glm::vec3 right = glm::normalize(glm::cross(cachedCamFwd_, glm::vec3{0, 1, 0}));
-            evtOrigin = cachedEye_ + right * 15.f - glm::vec3{0, 1, 0} * 8.f + cachedCamFwd_ * 5.f;
+            const float cs = cachedGravFlipped_ ? -1.0f : 1.0f;
+            evtOrigin = cachedEye_ + right * (cs * 15.f) - glm::vec3{0, 1, 0} * (cs * 8.f) + cachedCamFwd_ * 5.f;
         }
 
         switch (evt.effectType) {
@@ -803,7 +804,9 @@ SDL_AppResult Game::event(SDL_Event* event)
         case SDLK_T: {
             // Energy beam — hits floor or max range
             const glm::vec3 right = glm::normalize(glm::cross(cachedCamFwd_, glm::vec3{0, 1, 0}));
-            const glm::vec3 hip = cachedEye_ + right * 15.f - glm::vec3{0, 1, 0} * 8.f + cachedCamFwd_ * 5.f;
+            const float ts = cachedGravFlipped_ ? -1.0f : 1.0f;
+            const glm::vec3 hip =
+                cachedEye_ + right * (ts * 15.f) - glm::vec3{0, 1, 0} * (ts * 8.f) + cachedCamFwd_ * 5.f;
             float dist = 500.f;
             glm::vec3 hitN = -cachedCamFwd_;
             if (cachedCamFwd_.y < -0.001f) {
@@ -821,7 +824,9 @@ SDL_AppResult Game::event(SDL_Event* event)
         case SDLK_Y: {
             // Bullet tracer — hits floor or max range
             const glm::vec3 right = glm::normalize(glm::cross(cachedCamFwd_, glm::vec3{0, 1, 0}));
-            const glm::vec3 hip = cachedEye_ + right * 15.f - glm::vec3{0, 1, 0} * 8.f + cachedCamFwd_ * 5.f;
+            const float ds = cachedGravFlipped_ ? -1.0f : 1.0f;
+            const glm::vec3 hip =
+                cachedEye_ + right * (ds * 15.f) - glm::vec3{0, 1, 0} * (ds * 8.f) + cachedCamFwd_ * 5.f;
             float dist = 500.f;
             glm::vec3 hitN = -cachedCamFwd_;
             if (cachedCamFwd_.y < -0.001f) {
@@ -1509,7 +1514,13 @@ SDL_AppResult Game::iterate()
                 localFireCooldown_ = wpnCfg.fireCooldown;
 
                 const glm::vec3 right = glm::normalize(glm::cross(cachedCamFwd_, glm::vec3{0, 1, 0}));
-                const glm::vec3 hip = cachedEye_ + right * 15.f - glm::vec3{0, 1, 0} * 8.f + cachedCamFwd_ * 5.f;
+                // When gravity-flipped the 180° camera roll swaps screen-
+                // left/right and screen-up/down in world space.  Negate both
+                // offsets so the tracer still originates at screen bottom-right
+                // (where the viewmodel muzzle is).
+                const float hSign = localGravFlipped ? -1.0f : 1.0f;
+                const glm::vec3 hip =
+                    cachedEye_ + right * (hSign * 15.f) - glm::vec3{0, 1, 0} * (hSign * 8.f) + cachedCamFwd_ * 5.f;
 
                 // Raycast world geometry for tracer endpoint.  Impact effects
                 // (sparks / blood / bullet holes) are NOT spawned here — they
@@ -1692,7 +1703,8 @@ SDL_AppResult Game::iterate()
             const float cosPi = std::cos(renderPitch);
             const glm::vec3 fwd{std::sin(renderYaw) * cosPi, -std::sin(renderPitch), std::cos(renderYaw) * cosPi};
             const glm::vec3 right = glm::normalize(glm::cross(fwd, glm::vec3{0, 1, 0}));
-            const glm::vec3 hand = renderEye + right * 15.f - glm::vec3{0, 1, 0} * 8.f + fwd * 5.f;
+            const float gSign = pstate.gravityFlipped ? -1.0f : 1.0f;
+            const glm::vec3 hand = renderEye + right * (gSign * 15.f) - glm::vec3{0, 1, 0} * (gSign * 8.f) + fwd * 5.f;
             // particleSystem.spawnHitscanBeam(hand, pstate.grapplePoint, WeaponType::EnergyRifle);
         }
     });
@@ -1703,6 +1715,7 @@ SDL_AppResult Game::iterate()
         cachedCamFwd_ =
             glm::vec3{std::sin(renderYaw) * cosPitch, -std::sin(renderPitch), std::cos(renderYaw) * cosPitch};
         cachedEye_ = renderEye;
+        cachedGravFlipped_ = localGravFlipped;
     }
 
     // PR-19: unified pre-render interpolation pass.  Walks every

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -1243,8 +1243,16 @@ SDL_AppResult Game::iterate()
     // Movement keys run once per physics tick group (when inputSyncedWithPhysics
     // is true) so WASD movement calculations match the server.  When the
     // sync toggle is off, movement keys also run every frame.
+    // Dead input runs regardless of mouse capture — allows skip-respawn.
+    systems::runDeadInput(registry);
+
     if (mouseCaptured) {
-        systems::runMouseLook(registry, mouseSensitivity);
+        // Query local player's gravity flip state for mouse inversion.
+        bool localGravFlipped = false;
+        registry.view<PlayerVisState, LocalPlayer>().each(
+            [&](const PlayerVisState& vis) { localGravFlipped = vis.gravityFlipped; });
+
+        systems::runMouseLook(registry, mouseSensitivity, localGravFlipped);
         if (!inputSyncedWithPhysics)
             systems::runMovementKeys(registry);
         systems::runWeaponKeys(registry);
@@ -1254,7 +1262,7 @@ SDL_AppResult Game::iterate()
         // stomping the other.  Look additively composes (mouse delta + stick
         // delta) so the camera tracks whichever input is moving.  No-ops
         // cheaply when activeGamepad_ is nullptr.
-        systems::runGamepadLook(registry, activeGamepad_, gamepadLookSensitivity, frameTime);
+        systems::runGamepadLook(registry, activeGamepad_, gamepadLookSensitivity, frameTime, localGravFlipped);
         // AAA-style aim assist runs IMMEDIATELY after the look sampler so it
         // can refund part of the just-applied look delta (slowdown) and add
         // a rotational pull derived from the *change* in the target's
@@ -1437,10 +1445,14 @@ SDL_AppResult Game::iterate()
                 const PlayerVisState& pstate) {
                 const glm::vec3 interpPos = glm::mix(prev.value, pos.value, alpha);
                 const float eyeOffset = shape.halfExtents.y * 0.77f;
-                renderEye = interpPos + glm::vec3{0.0f, eyeOffset, 0.0f};
+                // When gravity is flipped, the player's head is at the bottom
+                // of the AABB (near the ceiling they walk on).
+                const float eyeDir = pstate.gravityFlipped ? -1.0f : 1.0f;
+                renderEye = interpPos + glm::vec3{0.0f, eyeOffset * eyeDir, 0.0f};
                 renderYaw = input.yaw;
                 renderPitch = input.pitch;
-                targetRoll = pstate.targetCameraTilt;
+                // Gravity flip adds 180° roll for the upside-down view.
+                targetRoll = pstate.targetCameraTilt + (pstate.gravityFlipped ? 180.0f : 0.0f);
             });
     } else {
         // Sequential mode: use post-tick state directly (no interpolation).
@@ -1450,10 +1462,11 @@ SDL_AppResult Game::iterate()
                 const CollisionShape& shape,
                 const PlayerVisState& pstate) {
                 const float eyeOffset = shape.halfExtents.y * 0.77f;
-                renderEye = pos.value + glm::vec3{0.0f, eyeOffset, 0.0f};
+                const float eyeDir = pstate.gravityFlipped ? -1.0f : 1.0f;
+                renderEye = pos.value + glm::vec3{0.0f, eyeOffset * eyeDir, 0.0f};
                 renderYaw = input.yaw;
                 renderPitch = input.pitch;
-                targetRoll = pstate.targetCameraTilt;
+                targetRoll = pstate.targetCameraTilt + (pstate.gravityFlipped ? 180.0f : 0.0f);
             });
     }
 
@@ -1786,6 +1799,11 @@ SDL_AppResult Game::iterate()
                 if (!ac.animator)
                     return;
                 const bool isLocal = registry.all_of<LocalPlayer>(e);
+
+                // Skip dead remote players — their mesh should not be visible.
+                if (!isLocal && ps.isDead)
+                    return;
+
                 const bool visible = isLocal || inFrustum(pos.value, charRadius);
                 if (!visible)
                     return;
@@ -2721,6 +2739,7 @@ SDL_AppResult Game::iterate()
             const glm::mat4 hbVP = hbProj * hbView;
             debugUI.buildHitboxUI(registry, clientHitboxRig_, hbVP, winWf, winHf);
             debugUI.buildCollisionUI(physics::activeWorld(), hbVP, winWf, winHf);
+            debugUI.buildWeaponSpawnerUI(registry, hbVP, winWf, winHf);
             // PR-20: CSGO sv_showimpacts-style shot debug.  Window
             // toggles + ring-buffer slider + per-shot summary table;
             // when `drawShotDebugOverlay` is checked we also render
@@ -2816,7 +2835,7 @@ SDL_AppResult Game::iterate()
                 killerName = killerBuf;
             }
 
-            char line1[64], line2[64];
+            char line1[64], line2[96], line3[48];
             std::snprintf(line1, sizeof(line1), "Killed by: %s", killerName);
             std::snprintf(line2,
                           sizeof(line2),
@@ -2824,6 +2843,7 @@ SDL_AppResult Game::iterate()
                           static_cast<double>(deathInfo.killerHealth.health),
                           static_cast<double>(deathInfo.killerHealth.armor),
                           std::ceil(static_cast<double>(respawnTimer.timeRemaining)));
+            std::snprintf(line3, sizeof(line3), "Press SPACE to skip");
 
             int winW = 0, winH = 0;
             SDL_GetWindowSizeInPixels(window, &winW, &winH);
@@ -2837,7 +2857,7 @@ SDL_AppResult Game::iterate()
             static constexpr float k_marginB = 16.0f;
             static constexpr float k_lineGap = 4.0f;
 
-            const float boxH = fs * 2.0f + k_lineGap + k_padY * 2.0f;
+            const float boxH = fs * 3.0f + k_lineGap * 2.0f + k_padY * 2.0f;
             const float boxW = static_cast<float>(winW) * 0.4f;
             const float x = (static_cast<float>(winW) - boxW) * 0.5f;
             const float y = static_cast<float>(winH) - boxH - k_marginB;
@@ -2845,10 +2865,12 @@ SDL_AppResult Game::iterate()
             const ImU32 bg = ImGui::ColorConvertFloat4ToU32(ImVec4(0.0f, 0.0f, 0.0f, 0.65f));
             const ImU32 fg = ImGui::ColorConvertFloat4ToU32(ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
             const ImU32 fg2 = ImGui::ColorConvertFloat4ToU32(ImVec4(0.85f, 0.85f, 0.85f, 0.85f));
+            const ImU32 fg3 = ImGui::ColorConvertFloat4ToU32(ImVec4(0.6f, 0.9f, 0.6f, 0.9f));
 
             dl->AddRectFilled(ImVec2(x, y), ImVec2(x + boxW, y + boxH), bg, 4.0f);
             dl->AddText(font, fs, ImVec2(x + k_padX, y + k_padY), fg, line1);
             dl->AddText(font, fs, ImVec2(x + k_padX, y + k_padY + fs + k_lineGap), fg2, line2);
+            dl->AddText(font, fs, ImVec2(x + k_padX, y + k_padY + fs * 2.0f + k_lineGap * 2.0f), fg3, line3);
         }
     }
 
@@ -3177,11 +3199,18 @@ SDL_AppResult Game::iterate()
     debugUI.render();
 
     // Smooth camera roll interpolation (degrees → radians).
+    // Uses shortest-path delta so that a 0→180° gravity flip rolls the
+    // correct direction instead of going the long way around.
     {
         const float k_targetRad = glm::radians(targetRoll);
-        const float k_speed = 10.0f; // interpolation speed (higher = snappier)
-        currentCameraRoll_ += (k_targetRad - currentCameraRoll_) * std::min(1.0f, k_speed * frameTime);
-        // Kill tiny residual to avoid permanent micro-tilt.
+        const float k_speed = 6.0f; // interpolation speed (lower = smoother gravity flip roll)
+        // Compute shortest-path delta, wrapping to [-π, π].
+        float delta = k_targetRad - currentCameraRoll_;
+        delta = std::remainder(delta, glm::two_pi<float>());
+        currentCameraRoll_ += delta * std::min(1.0f, k_speed * frameTime);
+        // Wrap current roll to [-π, π] to prevent drift.
+        currentCameraRoll_ = std::remainder(currentCameraRoll_, glm::two_pi<float>());
+        // Kill tiny residual to avoid permanent micro-tilt when near zero.
         if (std::abs(currentCameraRoll_) < 0.001f && std::abs(k_targetRad) < 0.001f)
             currentCameraRoll_ = 0.0f;
     }
@@ -3275,13 +3304,25 @@ void Game::refreshRemotePlayerRenderables()
         // while preventing the entity-render loop from drawing a duplicate.
         rend.modelIndex = -1;
         // Bottom-of-AABB reference: align model feet with the AABB bottom.
-        rend.translation = glm::vec3(0.0f, -shape.halfExtents.y - rigMeshMinY_ * kRigScale_, 0.0f);
+        // When gravity is flipped, the player walks on ceilings — the model
+        // is rotated 180° around Z so "feet" point upward; translate the model
+        // so the (now-inverted) feet align with the AABB top.
+        if (state.gravityFlipped)
+            rend.translation = glm::vec3(0.0f, shape.halfExtents.y + rigMeshMinY_ * kRigScale_, 0.0f);
+        else
+            rend.translation = glm::vec3(0.0f, -shape.halfExtents.y - rigMeshMinY_ * kRigScale_, 0.0f);
         rend.scale = glm::vec3(kRigScale_);
         // No importFix quaternion here: rig is loaded with
         // AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS=false which collapses the
         // FBX pre-rotation.  Add a rig-local fix here if the rig ends up
         // facing the wrong axis after a visual check.
-        rend.orientation = glm::angleAxis(input.yaw, glm::vec3{0, 1, 0});
+        // Gravity-flipped players get an additional 180° roll so they
+        // appear upside-down to normally-oriented observers.
+        glm::quat orient = glm::angleAxis(input.yaw, glm::vec3{0, 1, 0});
+        if (state.gravityFlipped) {
+            orient = orient * glm::angleAxis(glm::pi<float>(), glm::vec3{0, 0, 1});
+        }
+        rend.orientation = orient;
         rend.visible = !state.isDead;
     });
 }

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -1246,15 +1246,17 @@ SDL_AppResult Game::iterate()
     // Dead input runs regardless of mouse capture — allows skip-respawn.
     systems::runDeadInput(registry);
 
+    // Query local player's gravity flip state — used for mouse/stick
+    // inversion AND for swapping A-D / left-stick left-right.
+    bool localGravFlipped = false;
+    registry.view<PlayerVisState, LocalPlayer>().each(
+        [&](const PlayerVisState& vis) { localGravFlipped = vis.gravityFlipped; });
+
     if (mouseCaptured) {
-        // Query local player's gravity flip state for mouse inversion.
-        bool localGravFlipped = false;
-        registry.view<PlayerVisState, LocalPlayer>().each(
-            [&](const PlayerVisState& vis) { localGravFlipped = vis.gravityFlipped; });
 
         systems::runMouseLook(registry, mouseSensitivity, localGravFlipped);
         if (!inputSyncedWithPhysics)
-            systems::runMovementKeys(registry);
+            systems::runMovementKeys(registry, localGravFlipped);
         systems::runWeaponKeys(registry);
 
         // Gamepad samplers run AFTER kbm so they OR into the same flags —
@@ -1273,7 +1275,7 @@ SDL_AppResult Game::iterate()
         systems::runGamepadAimAssist(
             registry, activeGamepad_, aimAssistCfg_, aimAssistState_, gamepadLookSensitivity, frameTime);
         if (!inputSyncedWithPhysics)
-            systems::runGamepadMovement(registry, activeGamepad_);
+            systems::runGamepadMovement(registry, activeGamepad_, localGravFlipped);
         systems::runGamepadWeapon(registry, activeGamepad_);
 
         // Apply scroll-wheel weapon switch, constrained to primary/secondary.
@@ -1308,10 +1310,10 @@ SDL_AppResult Game::iterate()
     if (accumulator >= k_physicsDt) {
         // Movement keys: sample once for this whole group of ticks.
         if (inputSyncedWithPhysics && mouseCaptured) {
-            systems::runMovementKeys(registry);
+            systems::runMovementKeys(registry, localGravFlipped);
             // Gamepad movement is sampled on the same cadence and ORs into
             // the same flags so kbm + pad stay coherent under physics-sync.
-            systems::runGamepadMovement(registry, activeGamepad_);
+            systems::runGamepadMovement(registry, activeGamepad_, localGravFlipped);
         }
 
         // PR-24 (off-by-one + capsule staleness fix): the fire detection
@@ -2467,8 +2469,19 @@ SDL_AppResult Game::iterate()
             const float cosPitch = std::cos(renderPitch);
             const glm::vec3 forward{
                 std::sin(renderYaw) * cosPitch, -std::sin(renderPitch), std::cos(renderYaw) * cosPitch};
-            const glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0, 1, 0}));
-            const glm::vec3 up = glm::normalize(glm::cross(right, forward));
+            glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0, 1, 0}));
+            glm::vec3 up = glm::normalize(glm::cross(right, forward));
+
+            // Apply camera roll to the viewmodel basis so the weapon follows
+            // the 180° flip (or any tilt) instead of staying upright.
+            if (std::abs(currentCameraRoll_) > 0.001f) {
+                const float cosR = std::cos(currentCameraRoll_);
+                const float sinR = std::sin(currentCameraRoll_);
+                const glm::vec3 rolledRight = right * cosR + up * sinR;
+                const glm::vec3 rolledUp = up * cosR - right * sinR;
+                right = rolledRight;
+                up = rolledUp;
+            }
 
             // --- Weapon sway (CoD-style barrel lead) ---
             {
@@ -2740,6 +2753,7 @@ SDL_AppResult Game::iterate()
             debugUI.buildHitboxUI(registry, clientHitboxRig_, hbVP, winWf, winHf);
             debugUI.buildCollisionUI(physics::activeWorld(), hbVP, winWf, winHf);
             debugUI.buildWeaponSpawnerUI(registry, hbVP, winWf, winHf);
+            debugUI.buildSpawnPointUI(registry, hbVP, winWf, winHf);
             // PR-20: CSGO sv_showimpacts-style shot debug.  Window
             // toggles + ring-buffer slider + per-shot summary table;
             // when `drawShotDebugOverlay` is checked we also render

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -226,6 +226,7 @@ private:
     // Cached camera state — updated each iterate(), used by event() key shortcuts.
     glm::vec3 cachedEye_{0.f, 100.f, 0.f};
     glm::vec3 cachedCamFwd_{0.f, 0.f, 1.f};
+    bool cachedGravFlipped_{false}; ///< Local player gravity-flip state, updated each iterate().
     float currentCameraRoll_{0.0f}; ///< Smoothed camera roll angle (radians).
 
     // Map collision data — loaded from GLB, owns the vectors that back activeWorld().

--- a/src/client/systems/GamepadAimAssistSystem.hpp
+++ b/src/client/systems/GamepadAimAssistSystem.hpp
@@ -255,11 +255,16 @@ inline void runGamepadAimAssist(Registry& registry,
     glm::vec3 eye{0.0f};
     float curYaw = 0.0f, curPitch = 0.0f;
     bool foundLocal = false;
-    registry.view<LocalPlayer, Position, CollisionShape, InputSnapshot>().each(
-        [&](entt::entity e, const Position& pos, const CollisionShape& shape, const InputSnapshot& snap) {
+    registry.view<LocalPlayer, Position, CollisionShape, InputSnapshot, PlayerVisState>().each(
+        [&](entt::entity e,
+            const Position& pos,
+            const CollisionShape& shape,
+            const InputSnapshot& snap,
+            const PlayerVisState& pvis) {
             localEntity = e;
             const float eyeOffset = shape.halfExtents.y * 0.77f;
-            eye = pos.value + glm::vec3{0.0f, eyeOffset, 0.0f};
+            const float aaEyeDir = pvis.gravityFlipped ? -1.0f : 1.0f;
+            eye = pos.value + glm::vec3{0.0f, eyeOffset * aaEyeDir, 0.0f};
             curYaw = snap.yaw;
             curPitch = snap.pitch;
             foundLocal = true;

--- a/src/client/systems/InputSampleSystem.hpp
+++ b/src/client/systems/InputSampleSystem.hpp
@@ -74,8 +74,10 @@ inline bool prevFlipGravityKey = false;
 /// with physics (the default) so movement calculations match the server.
 /// Can also be called every iterate() when the sync toggle is off.
 ///
-/// @param registry  The ECS registry.
-inline void runMovementKeys(Registry& registry)
+/// @param registry        The ECS registry.
+/// @param gravityFlipped  When true, A/D are swapped so strafing feels
+///                        correct while the camera is rolled 180°.
+inline void runMovementKeys(Registry& registry, bool gravityFlipped = false)
 {
     const bool* const kKeys = SDL_GetKeyboardState(nullptr);
 
@@ -93,8 +95,11 @@ inline void runMovementKeys(Registry& registry)
     registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         snap.forward = kKeys[SDL_SCANCODE_W];
         snap.back = kKeys[SDL_SCANCODE_S];
-        snap.left = kKeys[SDL_SCANCODE_A];
-        snap.right = kKeys[SDL_SCANCODE_D];
+        // When gravity is flipped the camera is rolled 180°, which negates
+        // the screen-space right vector.  Swapping A/D compensates so
+        // pressing A still moves the player screen-left.
+        snap.left = gravityFlipped ? kKeys[SDL_SCANCODE_D] : kKeys[SDL_SCANCODE_A];
+        snap.right = gravityFlipped ? kKeys[SDL_SCANCODE_A] : kKeys[SDL_SCANCODE_D];
         snap.jump = kKeys[SDL_SCANCODE_SPACE];
         snap.crouch = kKeys[SDL_SCANCODE_LCTRL];
         snap.sprint = kKeys[SDL_SCANCODE_LSHIFT];
@@ -256,9 +261,11 @@ runGamepadLook(Registry& registry, SDL_Gamepad* gamepad, float lookSensitivity, 
 ///   L3 (LS click)  → sprint
 ///   LT             → grapple   (analog, threshold @ 0.5)
 ///
-/// @param registry  The ECS registry.
-/// @param gamepad   Open gamepad, or nullptr to no-op.
-inline void runGamepadMovement(Registry& registry, SDL_Gamepad* gamepad)
+/// @param registry        The ECS registry.
+/// @param gamepad          Open gamepad, or nullptr to no-op.
+/// @param gravityFlipped   When true, left/right stick are swapped to match
+///                         the 180° camera roll.
+inline void runGamepadMovement(Registry& registry, SDL_Gamepad* gamepad, bool gravityFlipped = false)
 {
     if (!gamepad)
         return;
@@ -272,8 +279,9 @@ inline void runGamepadMovement(Registry& registry, SDL_Gamepad* gamepad)
     constexpr float moveThresh = 0.3f;
     const bool padForward = ly < -moveThresh; // stick-up = -Y in SDL
     const bool padBack = ly > moveThresh;
-    const bool padLeft = lx < -moveThresh;
-    const bool padRight = lx > moveThresh;
+    // Swap left/right when gravity is flipped (same reasoning as keyboard).
+    const bool padLeft = gravityFlipped ? (lx > moveThresh) : (lx < -moveThresh);
+    const bool padRight = gravityFlipped ? (lx < -moveThresh) : (lx > moveThresh);
 
     const bool padJump = SDL_GetGamepadButton(gamepad, SDL_GAMEPAD_BUTTON_SOUTH);
     const bool padCrouch = SDL_GetGamepadButton(gamepad, SDL_GAMEPAD_BUTTON_EAST);

--- a/src/client/systems/InputSampleSystem.hpp
+++ b/src/client/systems/InputSampleSystem.hpp
@@ -6,6 +6,7 @@
 #include "ecs/components/Controllable.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LocalPlayer.hpp"
+#include "ecs/components/RespawnTimer.hpp"
 #include "ecs/registry/Registry.hpp"
 
 #include <SDL3/SDL.h>
@@ -30,11 +31,22 @@ namespace systems
 ///
 /// @param registry          The ECS registry.
 /// @param mouseSensitivity  Radians per pixel of mouse movement.
-inline void runMouseLook(Registry& registry, float mouseSensitivity)
+/// @param gravityFlipped    When true, both mouse axes are inverted so
+///                          controls feel natural while the camera is
+///                          rolled 180° for upside-down gravity.
+inline void runMouseLook(Registry& registry, float mouseSensitivity, bool gravityFlipped = false)
 {
     float mdx = 0.0f;
     float mdy = 0.0f;
     SDL_GetRelativeMouseState(&mdx, &mdy);
+
+    // When gravity is flipped the camera is rolled 180°, which swaps
+    // both screen-left/right and screen-up/down relative to world space.
+    // Negating both deltas keeps controls feeling natural.
+    if (gravityFlipped) {
+        mdx = -mdx;
+        mdy = -mdy;
+    }
 
     registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         // Negate: SDL mdx is positive when moving right, but positive yaw
@@ -51,6 +63,11 @@ inline void runMouseLook(Registry& registry, float mouseSensitivity)
     });
 }
 
+/// @brief Tracks previous-frame key state for edge detection.
+inline bool prevKillSelfKey = false;
+/// @brief Tracks previous-frame G key state for gravity flip edge detection.
+inline bool prevFlipGravityKey = false;
+
 /// @brief Sample keyboard state into the movement flags.
 ///
 /// Should be called **once per physics tick group** when input is synced
@@ -62,6 +79,17 @@ inline void runMovementKeys(Registry& registry)
 {
     const bool* const kKeys = SDL_GetKeyboardState(nullptr);
 
+    // Edge-detect K key: only fire killSelf on the rising edge (key-down),
+    // not while held.  Prevents respawn → immediate re-death loop.
+    const bool killKeyNow = kKeys[SDL_SCANCODE_K];
+    const bool killEdge = killKeyNow && !prevKillSelfKey;
+    prevKillSelfKey = killKeyNow;
+
+    // Edge-detect G key: gravity flip is a toggle, fire on rising edge only.
+    const bool flipKeyNow = kKeys[SDL_SCANCODE_G];
+    const bool flipEdge = flipKeyNow && !prevFlipGravityKey;
+    prevFlipGravityKey = flipKeyNow;
+
     registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         snap.forward = kKeys[SDL_SCANCODE_W];
         snap.back = kKeys[SDL_SCANCODE_S];
@@ -71,8 +99,24 @@ inline void runMovementKeys(Registry& registry)
         snap.crouch = kKeys[SDL_SCANCODE_LCTRL];
         snap.sprint = kKeys[SDL_SCANCODE_LSHIFT];
         snap.grapple = kKeys[SDL_SCANCODE_E];
-        snap.killSelf = kKeys[SDL_SCANCODE_K];
+        snap.killSelf = killEdge;
+        snap.flipGravity = flipEdge;
+        snap.skipRespawn = false; // Clear stale flag from previous death.
     });
+}
+
+/// @brief Sample skip-respawn input while the local player is dead.
+///
+/// Runs independently of Controllable — dead players can press Space to
+/// skip the remaining respawn timer and respawn immediately.
+///
+/// @param registry  The ECS registry.
+inline void runDeadInput(Registry& registry)
+{
+    const bool* const kKeys = SDL_GetKeyboardState(nullptr);
+
+    registry.view<InputSnapshot, LocalPlayer, RespawnTimer>().each(
+        [&](InputSnapshot& snap, const RespawnTimer& /*unused*/) { snap.skipRespawn = kKeys[SDL_SCANCODE_SPACE]; });
 }
 
 /// @brief Sample keyboard state into the weapon flags.
@@ -168,16 +212,23 @@ inline float normaliseAxis(Sint16 raw)
 /// @param gamepad           Open gamepad, or nullptr to no-op.
 /// @param lookSensitivity   Radians per second at full stick deflection.
 /// @param dt                Frame delta time in seconds.
-inline void runGamepadLook(Registry& registry, SDL_Gamepad* gamepad, float lookSensitivity, float dt)
+/// @param gravityFlipped    When true, both axes are inverted for 180° camera roll.
+inline void
+runGamepadLook(Registry& registry, SDL_Gamepad* gamepad, float lookSensitivity, float dt, bool gravityFlipped = false)
 {
     if (!gamepad)
         return;
 
-    const float rx = gamepad::normaliseAxis(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTX));
-    const float ry = gamepad::normaliseAxis(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTY));
+    float rx = gamepad::normaliseAxis(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTX));
+    float ry = gamepad::normaliseAxis(SDL_GetGamepadAxis(gamepad, SDL_GAMEPAD_AXIS_RIGHTY));
 
     if (rx == 0.0f && ry == 0.0f)
         return;
+
+    if (gravityFlipped) {
+        rx = -rx;
+        ry = -ry;
+    }
 
     registry.view<InputSnapshot, LocalPlayer, Controllable>().each([&](InputSnapshot& snap) {
         // Sign convention matches runMouseLook: stick-right (positive rx)

--- a/src/ecs/components/InputSnapshot.hpp
+++ b/src/ecs/components/InputSnapshot.hpp
@@ -32,7 +32,9 @@ struct InputSnapshot
     bool switchToPrimary{false};   ///< Switch to gun in primary slot.
     bool switchToSecondary{false}; ///< Switch to gun in secondary slot.
     bool refillAmmo{false};        ///< Debug: refill all weapons to full ammo.
-    bool killSelf{false};          ///< Debug: kill self
+    bool killSelf{false};          ///< Debug: kill self (rising-edge only).
+    bool skipRespawn{false};       ///< Skip respawn timer (space while dead).
+    bool flipGravity{false};       ///< Gravity flip toggle (G key, rising-edge only).
 
     float yaw{0.0f};               ///< Horizontal look angle in radians (accumulated from mouse X deltas).
     float pitch{0.0f};             ///< Vertical look angle in radians, clamped to [-89°, +89°] by InputSampleSystem.

--- a/src/ecs/components/PlayerSimState.hpp
+++ b/src/ecs/components/PlayerSimState.hpp
@@ -102,6 +102,10 @@ struct PlayerSimState
     glm::vec3 grapplePullDir{0.0f};    ///< Cached pull direction (toward anchor at fire time).
     bool grappleInputLastTick{false};  ///< Edge detection on the grapple key.
 
+    // ── Gravity flip ───────────────────────────────────────────────────────
+    bool flipGravityHeldLastTick{false}; ///< Edge detection on the gravity flip key.
+    float gravityFlipCooldown{0.0f};     ///< Remaining cooldown before next flip (s).
+
     // ── Grapple perch mode (hold jump while grappling → arc above hook) ─
     // No state needed: the trajectory is computed each tick purely from
     // current Position + replicated grapplePoint, so it stays in sync

--- a/src/ecs/components/PlayerVisState.hpp
+++ b/src/ecs/components/PlayerVisState.hpp
@@ -51,6 +51,7 @@ struct PlayerVisState
     bool exitingWall{false};     ///< Brief grace window after leaving a wall.
     bool exitingClimb{false};    ///< Brief grace window after leaving a climb.
     bool grappleActive{false};   ///< True while being pulled toward the grapple anchor.
+    bool gravityFlipped{false};  ///< True when the player's gravity is inverted (walking on ceilings).
 
     // Spatial state needed by client renderer/animator.
     glm::vec3 groundNormal{0.0f, 1.0f, 0.0f}; ///< Normal of the floor surface for foot orientation.

--- a/src/ecs/components/RespawnPoint.hpp
+++ b/src/ecs/components/RespawnPoint.hpp
@@ -1,9 +1,16 @@
 /// @file RespawnPoint.hpp
-/// @brief Respawn point information.
+/// @brief Player spawn point component with cooldown state.
 
 #pragma once
-#include "RespawnPoint.hpp"
 
-/// @brief ECS component: world weapon pickup point with respawn cooldown.
+/// @brief ECS component: player respawn point with cooldown state.
+///
+/// After a player spawns at this point, it enters a cooldown period during
+/// which other players prefer alternative spawn locations.  If all spawn
+/// points are on cooldown, the one with the lowest remaining cooldown is
+/// chosen.
 struct RespawnPoint
-{};
+{
+    float cooldown = 0.0f; ///< Seconds remaining before the point is preferred again.
+    bool available = true; ///< True when cooldown has elapsed (ready for use).
+};

--- a/src/ecs/physics/Movement.cpp
+++ b/src/ecs/physics/Movement.cpp
@@ -13,9 +13,10 @@
 namespace physics
 {
 
-glm::vec3 applyGravity(glm::vec3 vel, float dt)
+glm::vec3 applyGravity(glm::vec3 vel, float dt, bool flipped)
 {
-    vel.y -= k_gravity * dt;
+    const float dir = flipped ? 1.0f : -1.0f;
+    vel.y += dir * k_gravity * dt;
     return vel;
 }
 

--- a/src/ecs/physics/Movement.hpp
+++ b/src/ecs/physics/Movement.hpp
@@ -12,12 +12,16 @@
 namespace physics
 {
 
-/// @brief Apply gravity for one tick: subtracts `k_gravity * dt` from the Y component.
-/// @param vel  Current velocity.
-/// @param dt   Delta time in seconds.
-/// @return     New velocity with gravity applied.
-/// @note       Call every tick when the entity is airborne (not grounded).
-glm::vec3 applyGravity(glm::vec3 vel, float dt);
+/// @brief Apply gravity for one tick.
+///
+/// In normal mode subtracts `k_gravity * dt` from Y; when flipped, adds it.
+///
+/// @param vel     Current velocity.
+/// @param dt      Delta time in seconds.
+/// @param flipped True when the player's gravity is inverted.
+/// @return        New velocity with gravity applied.
+/// @note          Call every tick when the entity is airborne (not grounded).
+glm::vec3 applyGravity(glm::vec3 vel, float dt, bool flipped = false);
 
 /// @brief Apply Quake-style ground friction to horizontal (XZ) velocity.
 ///

--- a/src/ecs/physics/PhysicsConstants.hpp
+++ b/src/ecs/physics/PhysicsConstants.hpp
@@ -50,4 +50,7 @@ constexpr float k_overbounceFloor = 1.0f;  ///< Floor overbounce — exactly 1.0
 // Geometry
 constexpr float k_stepHeight = 18.0f; ///< Maximum obstacle height auto-stepped over without jumping (units).
 
+// Gravity flip
+constexpr float k_gravityFlipCooldown = 0.5f; ///< Minimum time between gravity flips (s).
+
 } // namespace physics

--- a/src/ecs/physics/TitanfallConstants.hpp
+++ b/src/ecs/physics/TitanfallConstants.hpp
@@ -26,11 +26,11 @@ constexpr float k_jumpSpeed = 330.0f;       ///< Upward velocity on ground jump 
 constexpr float k_doubleJumpSpeed = 270.0f; ///< Upward velocity on air jump (u/s).
 constexpr float k_slidehopJumpSpeed = 250.0f;    ///< Upward velocity when jumping during slide (u/s).
 constexpr float k_doubleJumpCooldown = 0.10f;    ///< Min time after first jump before double jump is allowed (s).
-constexpr float k_doubleJumpHorizBoost = 300.0f; ///< Horizontal velocity (u/s) toward WASD wishDir on double jump.
+constexpr float k_doubleJumpHorizBoost = 400.0f; ///< Horizontal velocity (u/s) toward WASD wishDir on double jump.
                                                  ///< Replaces horizontal velocity with wishDir * max(this, currentHs)
                                                  ///< so the second jump becomes an air dash. If no WASD held,
                                                  ///< horizontal momentum is preserved.
-constexpr float k_doubleJumpGroundedRefreshTime = 1.0f; ///< Continuous time grounded (s) needed to refresh DJ.
+constexpr float k_doubleJumpGroundedRefreshTime = 0.5f; ///< Continuous time grounded (s) needed to refresh DJ.
                                                         ///< DJ does NOT refresh from wall jump, climb, ledge,
                                                         ///< slidehop, or instant landing — only by being on the
                                                         ///< ground (OnFoot) for this long. Counters DJ-dash spam.

--- a/src/ecs/systems/CollisionSystem.cpp
+++ b/src/ecs/systems/CollisionSystem.cpp
@@ -351,6 +351,9 @@ void runCollision(Registry& registry, float dt, const physics::WorldGeometry& wo
             const bool k_wasGrounded = state.grounded;
             state.grounded = false;
 
+            // Gravity-flip direction: +1 normal (floors below), -1 flipped (ceilings as floors).
+            const float gravDir = state.gravityFlipped ? -1.0f : 1.0f;
+
             // Phase 0 — Depenetration
             depenetrate(pos.value, vel.value, shape.halfExtents, world);
 
@@ -369,7 +372,9 @@ void runCollision(Registry& registry, float dt, const physics::WorldGeometry& wo
                 pos.value += vel.value * k_hit.tFirst * remainingTime;
                 remainingTime *= (1.0f - k_hit.tFirst);
 
-                const bool k_isFloor = k_hit.normal.y > 0.7f;
+                // Floor detection: normal.y > 0.7 for normal gravity,
+                // normal.y < -0.7 for flipped (ceilings become floors).
+                const bool k_isFloor = state.gravityFlipped ? (k_hit.normal.y < -0.7f) : (k_hit.normal.y > 0.7f);
 
                 if (k_isFloor) {
                     pos.value += k_hit.normal * k_pushback;
@@ -383,7 +388,9 @@ void runCollision(Registry& registry, float dt, const physics::WorldGeometry& wo
                         state.groundNormal = k_hit.normal;
                     }
                 } else {
-                    if (k_wasGrounded && tryStepUp(pos.value, vel.value, shape.halfExtents, remainingTime, world)) {
+                    if (k_wasGrounded && !state.gravityFlipped &&
+                        tryStepUp(pos.value, vel.value, shape.halfExtents, remainingTime, world))
+                    {
                         state.grounded = true;
                         break;
                     }
@@ -393,19 +400,36 @@ void runCollision(Registry& registry, float dt, const physics::WorldGeometry& wo
             }
 
             // Phase 2 — Slope sticking (skip during grapple — player must fly freely)
+            // When gravity is flipped, snap toward ceiling instead of floor.
             if (k_wasGrounded && !state.grappleActive) {
                 const float k_horizSpeed = glm::length(glm::vec3{vel.value.x, 0.0f, vel.value.z});
-                if (k_horizSpeed > 0.001f)
-                    snapToGround(pos.value, vel.value, shape.halfExtents, world);
+                if (k_horizSpeed > 0.001f) {
+                    if (state.gravityFlipped) {
+                        // Snap upward toward ceiling.
+                        const glm::vec3 k_probeTarget = pos.value + glm::vec3{0.0f, k_groundProbeDistance, 0.0f};
+                        const physics::HitResult k_snap =
+                            physics::sweepAll(shape.halfExtents, pos.value, k_probeTarget, world);
+                        if (k_snap.hit && k_snap.normal.y < -0.7f) {
+                            pos.value = pos.value + glm::vec3{0.0f, k_groundProbeDistance * k_snap.tFirst, 0.0f};
+                            pos.value += k_snap.normal * k_pushback;
+                            vel.value.y = 0.0f;
+                        }
+                    } else {
+                        snapToGround(pos.value, vel.value, shape.halfExtents, world);
+                    }
+                }
             }
 
             // Phase 3 — Ground probe (skip during grapple)
             if (!state.grappleActive) {
-                const glm::vec3 k_probeTarget = pos.value - glm::vec3{0.0f, k_groundProbeDistance, 0.0f};
+                // Probe in the direction of gravity: downward normally, upward when flipped.
+                const glm::vec3 k_probeTarget = pos.value + glm::vec3{0.0f, -gravDir * k_groundProbeDistance, 0.0f};
                 const physics::HitResult k_probe =
                     physics::sweepAll(shape.halfExtents, pos.value, k_probeTarget, world);
 
-                if (k_probe.hit && k_probe.normal.y > 0.7f) {
+                const bool k_isGroundProbe =
+                    state.gravityFlipped ? (k_probe.normal.y < -0.7f) : (k_probe.normal.y > 0.7f);
+                if (k_probe.hit && k_isGroundProbe) {
                     state.grounded = true;
                     state.groundNormal = k_probe.normal;
                 }

--- a/src/ecs/systems/HitboxSystem.cpp
+++ b/src/ecs/systems/HitboxSystem.cpp
@@ -6,6 +6,7 @@
 #include "ecs/components/CollisionShape.hpp"
 #include "ecs/components/Hitbox.hpp"
 #include "ecs/components/InputSnapshot.hpp"
+#include "ecs/components/PlayerVisState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/RespawnTimer.hpp"
 
@@ -71,21 +72,43 @@ void updateHitboxes(Registry& registry, const HitboxRig& hitboxRig, float rigSca
         if (const auto* shape = registry.try_get<CollisionShape>(entity))
             halfHeight = shape->halfExtents.y;
 
-        // Vertical offset aligns the model's feet (meshMinY) with the bottom
-        // of the collision AABB.  Matches the renderer's rend.translation.y.
-        const float verticalOffset = -halfHeight - rigMeshMinY * rigScale;
+        // Check whether this entity's gravity is inverted.
+        bool gravFlipped = false;
+        if (const auto* vis = registry.try_get<PlayerVisState>(entity))
+            gravFlipped = vis->gravityFlipped;
 
-        // Build entity world transform:
-        //   translate(entityPos) * translate(0, verticalOffset, 0) * rotateY(yaw) * scale(rigScale)
+        // Vertical offset aligns the model's feet with the collision AABB.
+        // Normal gravity: feet at AABB bottom  →  offset = -(halfHeight + meshMinY * scale)
+        // Flipped gravity: feet at AABB top    →  offset = +(halfHeight + meshMinY * scale)
+        // Must match the renderer's Renderable.translation.y.
+        const float verticalOffset =
+            gravFlipped ? (halfHeight + rigMeshMinY * rigScale) : (-halfHeight - rigMeshMinY * rigScale);
+
+        // Build entity world transform.  Must match the renderer's transform:
+        //   translate * mat4_cast(orient) * scale
+        //
+        // Normal:  translate(pos + voff) * rotateY(yaw) * scale(s)
+        // Flipped: translate(pos + voff) * rotateY(yaw) * rotateZ(π) * scale(s)
+        //
+        // The extra rotateZ(π) flips the skeleton upside-down so hitbox
+        // capsules (head, torso, legs) land where the visual model is drawn.
         const float cosY = std::cos(yaw);
         const float sinY = std::sin(yaw);
 
-        // Compose manually for efficiency (single 4x4).
-        // Must match the renderer's transform: translate * mat4_cast(angleAxis(yaw, Y)) * scale.
         glm::mat4 worldTransform(1.0f);
-        worldTransform[0] = glm::vec4(cosY * rigScale, 0.0f, -sinY * rigScale, 0.0f);
-        worldTransform[1] = glm::vec4(0.0f, rigScale, 0.0f, 0.0f);
-        worldTransform[2] = glm::vec4(sinY * rigScale, 0.0f, cosY * rigScale, 0.0f);
+        if (gravFlipped) {
+            // rotateY(yaw) * rotateZ(π) * scale(s)
+            // rotateZ(π) = diag(-1, -1, 1), so:
+            //   col0 negated, col1 negated, col2 unchanged vs. normal.
+            worldTransform[0] = glm::vec4(-cosY * rigScale, 0.0f, sinY * rigScale, 0.0f);
+            worldTransform[1] = glm::vec4(0.0f, -rigScale, 0.0f, 0.0f);
+            worldTransform[2] = glm::vec4(sinY * rigScale, 0.0f, cosY * rigScale, 0.0f);
+        } else {
+            // rotateY(yaw) * scale(s)
+            worldTransform[0] = glm::vec4(cosY * rigScale, 0.0f, -sinY * rigScale, 0.0f);
+            worldTransform[1] = glm::vec4(0.0f, rigScale, 0.0f, 0.0f);
+            worldTransform[2] = glm::vec4(sinY * rigScale, 0.0f, cosY * rigScale, 0.0f);
+        }
         worldTransform[3] = glm::vec4(pos.value.x, pos.value.y + verticalOffset, pos.value.z, 1.0f);
 
         for (size_t i = 0; i < hitboxRig.definitions.size(); ++i) {

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -1408,7 +1408,8 @@ void runMovement(Registry& registry, float dt, const physics::WorldGeometry& wor
             // Jump detaches with a look-biased launch. Crouch cancels with drop.
             bool grapplePulling = false;
             {
-                const glm::vec3 k_eye = pos.value + glm::vec3(0, shape.halfExtents.y * 0.77f, 0);
+                const float grapEyeDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+                const glm::vec3 k_eye = pos.value + glm::vec3(0, shape.halfExtents.y * 0.77f * grapEyeDir, 0);
                 tryFireGrapple(state, input, k_eye, world);
                 state.sim.grappleInputLastTick = input.grapple;
 

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -199,6 +199,10 @@ void tickTimers(PlayerStateRef state, float dt)
         if (state.sim.grappleCooldownTimer <= 0.0f)
             state.sim.grappleCooldownActive = false;
     }
+
+    // Gravity flip cooldown.
+    if (state.sim.gravityFlipCooldown > 0.0f)
+        state.sim.gravityFlipCooldown -= dt;
 }
 
 } // namespace
@@ -242,11 +246,12 @@ namespace
 {
 
 /// @brief Handle all jump types: ground, double, coyote, wall, climb, ledge, slidehop.
-/// @param vel    Velocity (modified in place).
-/// @param input  Current input snapshot.
-/// @param state  Player state (modified in place).
-/// @param dt     Fixed physics delta time in seconds (unused).
-void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state, float /*dt*/)
+/// @param vel     Velocity (modified in place).
+/// @param input   Current input snapshot.
+/// @param state   Player state (modified in place).
+/// @param dt      Fixed physics delta time in seconds (unused).
+/// @param gravDir +1.0 for normal gravity, -1.0 for flipped (inverts all vertical impulses).
+void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state, float /*dt*/, float gravDir = 1.0f)
 {
     if (!input.jump) {
         // Key released — clear the wallrun autobhop lock so the next press
@@ -259,7 +264,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
     if (state.vis.moveMode == MoveMode::LedgeGrabbing) {
         if (state.sim.ledgeHoldTimer >= tms::k_ledgeMinHoldTime) {
             // Mantle: jump up onto the ledge.
-            vel.y = tms::k_ledgeJumpUpForce;
+            vel.y = tms::k_ledgeJumpUpForce * gravDir;
             // Push away from wall (which actually pushes over the ledge since normal points away from wall).
             vel += state.sim.ledgeNormal * tms::k_ledgeJumpBackForce;
             state.vis.moveMode = MoveMode::OnFoot;
@@ -280,7 +285,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
         if (state.sim.wallJumpLocked)
             return;
 
-        vel.y = tms::k_wallJumpUpForce;
+        vel.y = tms::k_wallJumpUpForce * gravDir;
         vel += state.sim.wallNormal * tms::k_wallJumpSideForce;
         state.vis.moveMode = MoveMode::OnFoot;
         state.vis.exitingWall = true;
@@ -298,7 +303,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
 
     // Climb jump
     if (state.vis.moveMode == MoveMode::Climbing) {
-        vel.y = tms::k_climbJumpUpForce;
+        vel.y = tms::k_climbJumpUpForce * gravDir;
         vel += state.sim.climbWallNormal * tms::k_climbJumpBackForce;
         state.vis.moveMode = MoveMode::OnFoot;
         state.vis.exitingClimb = true;
@@ -321,7 +326,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
         if (state.sim.wallJumpLocked)
             return;
 
-        vel.y = tms::k_wallJumpUpForce;
+        vel.y = tms::k_wallJumpUpForce * gravDir;
         vel += state.sim.wallBlacklistNormal * tms::k_wallJumpSideForce;
         state.sim.coyoteTimer = 0.0f;
         state.sim.wasWallRunning = false;
@@ -333,7 +338,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
 
     // Slidehop
     if (state.vis.moveMode == MoveMode::Sliding) {
-        vel.y = tms::k_slidehopJumpSpeed;
+        vel.y = tms::k_slidehopJumpSpeed * gravDir;
         state.vis.moveMode = MoveMode::OnFoot;
         state.vis.crouching = false;
         state.vis.grounded = false;
@@ -353,7 +358,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
 
     // Ground jump (or coyote ground jump)
     if (state.vis.grounded || state.sim.coyoteTimer > 0.0f) {
-        vel.y = tms::k_jumpSpeed;
+        vel.y = tms::k_jumpSpeed * gravDir;
         state.vis.grounded = false;
         state.sim.coyoteTimer = 0.0f;
         state.vis.jumpCount = 1;
@@ -380,9 +385,10 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
     const bool k_jumpRisingEdge = input.jump && !state.sim.jumpHeldLastTick;
     if (state.sim.canDoubleJump && state.vis.jumpCount < 2 && k_jumpRisingEdge && state.sim.jumpCooldown <= 0.0f) {
         // Reset vertical velocity before applying double jump (feels better than additive).
-        if (vel.y < 0.0f)
+        // When flipped, "falling" means vel.y > 0 so the check direction inverts.
+        if (vel.y * gravDir < 0.0f)
             vel.y = 0.0f;
-        vel.y += tms::k_doubleJumpSpeed;
+        vel.y += tms::k_doubleJumpSpeed * gravDir;
         state.sim.canDoubleJump = false;
         state.vis.jumpCount = 2;
         state.sim.jumpedThisTick = true;
@@ -831,7 +837,8 @@ void handleWallRunning(glm::vec3& pos,
     } else {
         const float k_rampT = (state.sim.wallRunTimer - tms::k_wallrunGripTime) / tms::k_wallrunGravityRampTime;
         const float k_gravFactor = std::clamp(k_rampT, 0.0f, 1.0f);
-        vel.y -= physics::k_gravity * k_gravFactor * dt;
+        const float k_gravDir = state.vis.gravityFlipped ? 1.0f : -1.0f;
+        vel.y += k_gravDir * physics::k_gravity * k_gravFactor * dt;
     }
 
     // Camera tilt.
@@ -1277,6 +1284,21 @@ void runMovement(Registry& registry, float dt, const physics::WorldGeometry& wor
             // 0. Tick timers
             tickTimers(state, dt);
 
+            // 0b. Gravity flip toggle (rising edge of G key with cooldown).
+            {
+                const bool flipEdge = input.flipGravity && !state.sim.flipGravityHeldLastTick;
+                if (flipEdge && state.sim.gravityFlipCooldown <= 0.0f) {
+                    state.vis.gravityFlipped = !state.vis.gravityFlipped;
+                    state.sim.gravityFlipCooldown = physics::k_gravityFlipCooldown;
+                    // Clear grounded so the player doesn't stick to the old surface.
+                    state.vis.grounded = false;
+                }
+                state.sim.flipGravityHeldLastTick = input.flipGravity;
+            }
+
+            // Gravity direction multiplier: +1 normal, -1 flipped.
+            const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+
             // 1. Wall / climb / ledge detection
             // Pass the previous wall normal so the detector can trace toward
             // curved surfaces (cylinders, concave walls) whose normal rotates
@@ -1328,7 +1350,7 @@ void runMovement(Registry& registry, float dt, const physics::WorldGeometry& wor
             //     grapple-rising-edge + jump same-tick is a rare edge case and
             //     handleGrapple's velocity override wins anyway.
             if (!state.vis.grappleActive)
-                handleJump(vel.value, input, state, dt);
+                handleJump(vel.value, input, state, dt, gravDir);
 
             // 5. Mode-specific movement
             switch (state.vis.moveMode) {
@@ -1342,7 +1364,7 @@ void runMovement(Registry& registry, float dt, const physics::WorldGeometry& wor
                     if (glm::length(k_wishDir) > 0.001f)
                         vel.value = physics::accelerate(vel.value, k_wishDir, k_wishSpeed, physics::k_groundAccel, dt);
                 } else {
-                    vel.value = physics::applyGravity(vel.value, dt);
+                    vel.value = physics::applyGravity(vel.value, dt, state.vis.gravityFlipped);
                     if (glm::length(k_wishDir) > 0.001f) {
                         // Air wish-speed depends on current horizontal speed:
                         // generous when stalled, classic Quake floor at speed.

--- a/src/ecs/systems/PlayerStatusSystem.cpp
+++ b/src/ecs/systems/PlayerStatusSystem.cpp
@@ -138,6 +138,9 @@ inline void handleDeath(entt::entity& player,
         registry.emplace_or_replace<RespawnTimer>(player, RespawnTimer{.timeRemaining = 5.0f});
         registry.patch<PlayerMatchStats>(player, [&](PlayerMatchStats& stats) { stats.deaths++; });
 
+        // Clear input so dead players don't continue shooting/moving.
+        registry.emplace_or_replace<InputSnapshot>(player);
+
         // Award killer
         if (killer != player) {
             registry.get_or_emplace<PlayerMatchStats>(killer).kills++;
@@ -215,19 +218,34 @@ void runPlayerStatus(Registry& registry, float dt)
     registry.view<Player, InputSnapshot>().each([&registry, dt](entt::entity e, InputSnapshot& snap) {
         if (registry.all_of<RespawnTimer>(e)) {
             auto& respawnTimer = registry.get<RespawnTimer>(e);
+
+            // Allow skipping the respawn timer early by pressing space.
+            if (snap.skipRespawn) {
+                snap.skipRespawn = false;
+                respawnTimer.timeRemaining = 0.0f;
+            }
+
             respawnTimer.timeRemaining -= dt;
             if (respawnTimer.timeRemaining <= 0) {
                 handleRespawn(e, registry);
             }
+
+            // Consume killSelf while dead — prevent re-death on respawn.
+            snap.killSelf = false;
         } else {
+            // Clear stale skipRespawn from previous death cycle so it
+            // doesn't fire instantly if the player dies again.
+            snap.skipRespawn = false;
+
             Health& playerHealth = registry.get_or_emplace<Health>(e);
             handleHealing(playerHealth, dt);
-        }
 
-        if (snap.killSelf) {
-            snap.killSelf = false;
-            std::vector<NetKillEvent> kills;
-            applyDamage(999.0f, e, e, registry, kills, BodyRegion::Head);
+            // Only process killSelf when alive.
+            if (snap.killSelf) {
+                snap.killSelf = false;
+                std::vector<NetKillEvent> kills;
+                applyDamage(999.0f, e, e, registry, kills, BodyRegion::Head);
+            }
         }
     });
 }

--- a/src/ecs/systems/PlayerStatusSystem.cpp
+++ b/src/ecs/systems/PlayerStatusSystem.cpp
@@ -21,6 +21,7 @@
 #include "network/NetKillEvent.hpp"
 
 #include <ecs/components/RespawnPoint.hpp>
+#include <limits>
 #include <random>
 #include <vector>
 
@@ -48,25 +49,57 @@ void applyHeal(float amount, Health& playerHealth)
     }
 }
 
+/// @brief Cooldown duration set on a spawn point after a player spawns there.
+inline constexpr float k_spawnPointCooldown = 5.0f;
+
+/// @brief Choose a respawn point with cooldown-aware selection.
+///
+/// Prefers available (cooldown = 0) spawn points, picking randomly among them.
+/// If all spawn points are on cooldown, picks the one with the lowest remaining
+/// cooldown.  Sets a 3-second cooldown on the chosen point.
 inline glm::vec3 chooseRespawnPoint(Registry& registry)
 {
-    std::vector<glm::vec3> respawnPoints;
-
     auto view = registry.view<RespawnPoint, Position>();
 
+    // Collect available (off-cooldown) spawn points.
+    std::vector<entt::entity> available;
+    entt::entity lowestCooldownEntity = entt::null;
+    float lowestCooldown = std::numeric_limits<float>::max();
+
     for (entt::entity e : view) {
-        respawnPoints.push_back(view.get<Position>(e).value);
+        auto& sp = view.get<RespawnPoint>(e);
+        if (sp.available) {
+            available.push_back(e);
+        }
+        if (sp.cooldown < lowestCooldown) {
+            lowestCooldown = sp.cooldown;
+            lowestCooldownEntity = e;
+        }
     }
 
-    if (!respawnPoints.empty()) {
-        std::random_device rd;  // seed
-        std::mt19937 gen(rd()); // Mersenne Twister RNG
-        std::uniform_int_distribution<> dist(0, respawnPoints.size() - 1);
-        int idx = dist(gen);
-        return respawnPoints[idx];
-    } else {
-        return glm::vec3(0.0f, 200.0f, 0.0f);
+    entt::entity chosen = entt::null;
+
+    if (!available.empty()) {
+        // Pick randomly among available spawn points.
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_int_distribution<std::size_t> dist(0, available.size() - 1);
+        chosen = available[dist(gen)];
+    } else if (lowestCooldownEntity != entt::null) {
+        // All on cooldown — pick the one closest to being ready.
+        chosen = lowestCooldownEntity;
     }
+
+    if (chosen != entt::null) {
+        // Set cooldown on the chosen spawn point.
+        auto& sp = view.get<RespawnPoint>(chosen);
+        sp.cooldown = k_spawnPointCooldown;
+        sp.available = false;
+        return view.get<Position>(chosen).value;
+    }
+
+    // Fallback when no spawn points exist in the world.
+    return glm::vec3(0.0f, 200.0f, 0.0f);
 }
 
 /// @brief Reset a dead player to a fresh spawn state.
@@ -245,6 +278,19 @@ void runPlayerStatus(Registry& registry, float dt)
                 snap.killSelf = false;
                 std::vector<NetKillEvent> kills;
                 applyDamage(999.0f, e, e, registry, kills, BodyRegion::Head);
+            }
+        }
+    });
+}
+
+void runSpawnPointCooldowns(Registry& registry, float dt)
+{
+    registry.view<RespawnPoint>().each([dt](RespawnPoint& sp) {
+        if (!sp.available) {
+            sp.cooldown -= dt;
+            if (sp.cooldown <= 0.0f) {
+                sp.cooldown = 0.0f;
+                sp.available = true;
             }
         }
     });

--- a/src/ecs/systems/PlayerStatusSystem.hpp
+++ b/src/ecs/systems/PlayerStatusSystem.hpp
@@ -44,4 +44,10 @@ void applyDamage(float damage,
 /// @param registry  The ECS registry.
 /// @param dt        Fixed physics delta time in seconds.
 void runPlayerStatus(Registry& registry, float dt);
+
+/// @brief Tick spawn point cooldowns.  Each spawn point's cooldown decrements
+/// by dt and becomes available again when it reaches zero.
+/// @param registry  The ECS registry.
+/// @param dt        Fixed physics delta time in seconds.
+void runSpawnPointCooldowns(Registry& registry, float dt);
 } // namespace systems

--- a/src/ecs/systems/WeaponSpawnerSystem.cpp
+++ b/src/ecs/systems/WeaponSpawnerSystem.cpp
@@ -7,6 +7,7 @@
 #include "ecs/components/CollisionShape.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/Player.hpp"
+#include "ecs/components/PlayerVisState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/WeaponConfig.hpp"
 #include "ecs/components/WeaponSpawner.hpp"
@@ -46,12 +47,13 @@ inline glm::vec3 viewForward(float yaw, float pitch)
 inline void
 checkForPlayers(Registry& registry, Position spawnerPos, CollisionShape spawnerShape, WeaponSpawner& spawner)
 {
-    auto view = registry.view<Player, Position, CollisionShape, InputSnapshot, WeaponState>();
+    auto view = registry.view<Player, Position, CollisionShape, InputSnapshot, WeaponState, PlayerVisState>();
     view.each([&](entt::entity player,
                   const Position& pos,
                   const CollisionShape& shape,
                   const InputSnapshot& input,
-                  WeaponState& weapon) {
+                  WeaponState& weapon,
+                  const PlayerVisState& pvis) {
         if (overlapsAABB(spawnerPos.value, spawnerShape.halfExtents, pos.value, shape.halfExtents) && spawner.hasWeapon)
         {
             const WeaponConfig config = getWeaponConfig(spawner.type);
@@ -72,7 +74,8 @@ checkForPlayers(Registry& registry, Position spawnerPos, CollisionShape spawnerS
         static constexpr float k_pickupMaxAngleDeg = 12.0f;
         static const float k_pickupMinDot = std::cos(glm::radians(k_pickupMaxAngleDeg));
 
-        const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.77f, 0.0f};
+        const float spawnEyeDir = pvis.gravityFlipped ? -1.0f : 1.0f;
+        const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.77f * spawnEyeDir, 0.0f};
         const glm::vec3 toWeapon = spawnerPos.value - eye;
         const float distSq = glm::dot(toWeapon, toWeapon);
 

--- a/src/ecs/systems/WeaponSystem.cpp
+++ b/src/ecs/systems/WeaponSystem.cpp
@@ -137,15 +137,18 @@ inline glm::vec3 viewForward(float yaw, float pitch)
 /// @brief Offset the muzzle origin from the eye position for tracer visuals.
 ///
 /// Shifts the origin right and down from eye, slightly forward, so tracers
-/// don't originate from the center of the screen.
-/// @param eye             Eye position (camera origin).
-/// @param direction       Normalized view direction.
-/// @param gravityFlipped  When true, "down" is +Y (ceiling walker).
+/// don't originate from the center of the screen.  The "right" side of the
+/// screen is the same regardless of gravity flip (the 180° camera roll
+/// negates both the right AND up vectors, so the screen-right direction in
+/// world space is unchanged).  Only the eye position itself changes when
+/// flipped — and the caller already handles that.
+/// @param eye        Eye position (camera origin).
+/// @param direction  Normalized view direction.
 /// @return Offset muzzle position in world space.
-inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction, bool gravityFlipped = false)
+inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction)
 {
-    const glm::vec3 worldUp = gravityFlipped ? glm::vec3{0.0f, -1.0f, 0.0f} : glm::vec3{0.0f, 1.0f, 0.0f};
-    glm::vec3 right = glm::cross(direction, worldUp);
+    constexpr glm::vec3 k_worldUp{0.0f, 1.0f, 0.0f};
+    glm::vec3 right = glm::cross(direction, k_worldUp);
     if (glm::dot(right, right) < physics::k_parallelEpsilon) {
         right = glm::vec3{1.0f, 0.0f, 0.0f};
     } else {
@@ -596,7 +599,7 @@ inline void handleFire(Registry& registry,
     const float eyeDirDiscrete = gravityFlipped ? -1.0f : 1.0f;
     const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * eyeDirDiscrete, 0.0f};
     const glm::vec3 direction = viewForward(input.yaw, input.pitch);
-    const glm::vec3 muzzle = muzzleOrigin(eye, direction, gravityFlipped);
+    const glm::vec3 muzzle = muzzleOrigin(eye, direction);
 
     if (config.hitscan) {
         // Phase 6 lag-compensated hitscan (see beam path for details).

--- a/src/ecs/systems/WeaponSystem.cpp
+++ b/src/ecs/systems/WeaponSystem.cpp
@@ -137,15 +137,17 @@ inline glm::vec3 viewForward(float yaw, float pitch)
 /// @brief Offset the muzzle origin from the eye position for tracer visuals.
 ///
 /// Shifts the origin right and down from eye, slightly forward, so tracers
-/// don't originate from the center of the screen.  The "right" side of the
-/// screen is the same regardless of gravity flip (the 180° camera roll
-/// negates both the right AND up vectors, so the screen-right direction in
-/// world space is unchanged).  Only the eye position itself changes when
-/// flipped — and the caller already handles that.
-/// @param eye        Eye position (camera origin).
-/// @param direction  Normalized view direction.
+/// don't originate from the center of the screen.
+/// @param eye             Eye position (camera origin).
+/// @param direction       Normalized view direction.
+/// @param gravityFlipped  When true, negate the horizontal offset so the
+///                        tracer originates from the viewmodel side.  The
+///                        viewmodel stays on screen-right, but the 180°
+///                        camera roll reverses world-left/right — so
+///                        world-right (the normal offset) appears on the
+///                        wrong side of the screen.
 /// @return Offset muzzle position in world space.
-inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction)
+inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction, bool gravityFlipped = false)
 {
     constexpr glm::vec3 k_worldUp{0.0f, 1.0f, 0.0f};
     glm::vec3 right = glm::cross(direction, k_worldUp);
@@ -154,6 +156,13 @@ inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction)
     } else {
         right = glm::normalize(right);
     }
+
+    // Flip only the horizontal offset — the viewmodel is still on
+    // screen-right but the 180° roll maps that to the opposite
+    // world-space direction.  The vertical ("down from eye") stays
+    // the same because the viewmodel rendering already compensates.
+    if (gravityFlipped)
+        right = -right;
 
     const glm::vec3 up = glm::normalize(glm::cross(right, direction));
     return eye + right * 15.0f - up * 8.0f + direction * 5.0f;
@@ -599,7 +608,7 @@ inline void handleFire(Registry& registry,
     const float eyeDirDiscrete = gravityFlipped ? -1.0f : 1.0f;
     const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * eyeDirDiscrete, 0.0f};
     const glm::vec3 direction = viewForward(input.yaw, input.pitch);
-    const glm::vec3 muzzle = muzzleOrigin(eye, direction);
+    const glm::vec3 muzzle = muzzleOrigin(eye, direction, gravityFlipped);
 
     if (config.hitscan) {
         // Phase 6 lag-compensated hitscan (see beam path for details).

--- a/src/ecs/systems/WeaponSystem.cpp
+++ b/src/ecs/systems/WeaponSystem.cpp
@@ -14,6 +14,7 @@
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LagCompTarget.hpp"
 #include "ecs/components/Position.hpp"
+#include "ecs/components/RespawnTimer.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/WeaponConfig.hpp"
 #include "ecs/components/WeaponState.hpp"
@@ -692,6 +693,10 @@ void runWeapon(Registry& registry,
                   const Position& pos,
                   const CollisionShape& shape,
                   WeaponState& weapon) {
+        // Dead players cannot fire or interact with weapons.
+        if (registry.all_of<RespawnTimer>(shooter))
+            return;
+
         handleSwitch(input, weapon);
         handleCooldown(weapon, dt);
 

--- a/src/ecs/systems/WeaponSystem.cpp
+++ b/src/ecs/systems/WeaponSystem.cpp
@@ -13,6 +13,7 @@
 #include "ecs/components/HitboxHistory.hpp"
 #include "ecs/components/InputSnapshot.hpp"
 #include "ecs/components/LagCompTarget.hpp"
+#include "ecs/components/PlayerVisState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/RespawnTimer.hpp"
 #include "ecs/components/Velocity.hpp"
@@ -137,13 +138,14 @@ inline glm::vec3 viewForward(float yaw, float pitch)
 ///
 /// Shifts the origin right and down from eye, slightly forward, so tracers
 /// don't originate from the center of the screen.
-/// @param eye        Eye position (camera origin).
-/// @param direction  Normalized view direction.
+/// @param eye             Eye position (camera origin).
+/// @param direction       Normalized view direction.
+/// @param gravityFlipped  When true, "down" is +Y (ceiling walker).
 /// @return Offset muzzle position in world space.
-inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction)
+inline glm::vec3 muzzleOrigin(glm::vec3 eye, glm::vec3 direction, bool gravityFlipped = false)
 {
-    constexpr glm::vec3 k_worldUp{0.0f, 1.0f, 0.0f};
-    glm::vec3 right = glm::cross(direction, k_worldUp);
+    const glm::vec3 worldUp = gravityFlipped ? glm::vec3{0.0f, -1.0f, 0.0f} : glm::vec3{0.0f, 1.0f, 0.0f};
+    glm::vec3 right = glm::cross(direction, worldUp);
     if (glm::dot(right, right) < physics::k_parallelEpsilon) {
         right = glm::vec3{1.0f, 0.0f, 0.0f};
     } else {
@@ -390,27 +392,29 @@ inline void captureShotDebug(Registry& registry,
 /// Emits NetParticleEvent entries for tracer/impact effects and applies damage
 /// through applyDamage() which may trigger kill events.
 ///
-/// @param registry      The ECS registry.
-/// @param shooter       Entity that is firing.
-/// @param input         Current input snapshot.
-/// @param pos           Shooter position.
-/// @param shape         Shooter collision shape (for eye height).
-/// @param weapon        Shooter weapon state (modified in place).
-/// @param dt            Fixed physics delta time in seconds.
-/// @param outParticles  Accumulates particle events for network broadcast.
-/// @param killEvents    Accumulates kill events for network broadcast.
-/// @param outShotDebug  PR-20: optional server-side debug capture sink.
-///                      When non-null, each hitscan-fire path pushes one
-///                      `ShotDebugCapture` row while `RewindHitboxesGuard`
-///                      is still active, so the captured `targets[*].
-///                      capsules` reflect the historical sample the
-///                      server actually raycast against.
+/// @param registry        The ECS registry.
+/// @param shooter         Entity that is firing.
+/// @param input           Current input snapshot.
+/// @param pos             Shooter position.
+/// @param shape           Shooter collision shape (for eye height).
+/// @param weapon          Shooter weapon state (modified in place).
+/// @param gravityFlipped  True when the shooter's gravity is inverted.
+/// @param dt              Fixed physics delta time in seconds.
+/// @param outParticles    Accumulates particle events for network broadcast.
+/// @param killEvents      Accumulates kill events for network broadcast.
+/// @param outShotDebug    PR-20: optional server-side debug capture sink.
+///                        When non-null, each hitscan-fire path pushes one
+///                        `ShotDebugCapture` row while `RewindHitboxesGuard`
+///                        is still active, so the captured `targets[*].
+///                        capsules` reflect the historical sample the
+///                        server actually raycast against.
 inline void handleFire(Registry& registry,
                        entt::entity shooter,
                        const InputSnapshot& input,
                        const Position& pos,
                        const CollisionShape& shape,
                        WeaponState& weapon,
+                       bool gravityFlipped,
                        float dt,
                        std::vector<NetParticleEvent>& outParticles,
                        std::vector<NetKillEvent>& killEvents,
@@ -437,7 +441,8 @@ inline void handleFire(Registry& registry,
         }
 
         // Raycast to find beam endpoint.
-        const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f, 0.0f};
+        const float eyeDir = gravityFlipped ? -1.0f : 1.0f;
+        const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * eyeDir, 0.0f};
         const glm::vec3 direction = viewForward(input.yaw, input.pitch);
         // Phase 6 lag-compensated hitscan. The guard reads
         // `LagCompTarget` off `shooter` (set each tick by the server's
@@ -503,7 +508,8 @@ inline void handleFire(Registry& registry,
 
         gun.fireCooldown = config.fireCooldown;
 
-        const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f, 0.0f};
+        const float eyeDirCharge = gravityFlipped ? -1.0f : 1.0f;
+        const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * eyeDirCharge, 0.0f};
         const glm::vec3 direction = viewForward(input.yaw, input.pitch);
         // Phase 6 lag-compensated hitscan (see beam path for details).
         // PR-5: ray-filtered rewind, see beam path.
@@ -587,9 +593,10 @@ inline void handleFire(Registry& registry,
 
     gun.fireCooldown = config.fireCooldown;
 
-    const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f, 0.0f};
+    const float eyeDirDiscrete = gravityFlipped ? -1.0f : 1.0f;
+    const glm::vec3 eye = pos.value + glm::vec3{0.0f, shape.halfExtents.y * 0.75f * eyeDirDiscrete, 0.0f};
     const glm::vec3 direction = viewForward(input.yaw, input.pitch);
-    const glm::vec3 muzzle = muzzleOrigin(eye, direction);
+    const glm::vec3 muzzle = muzzleOrigin(eye, direction, gravityFlipped);
 
     if (config.hitscan) {
         // Phase 6 lag-compensated hitscan (see beam path for details).
@@ -687,12 +694,13 @@ void runWeapon(Registry& registry,
                std::vector<NetKillEvent>& killEvents,
                std::vector<net::shotdebug::ShotDebugCapture>* outShotDebug)
 {
-    auto view = registry.view<InputSnapshot, Position, CollisionShape, WeaponState>();
+    auto view = registry.view<InputSnapshot, Position, CollisionShape, WeaponState, PlayerVisState>();
     view.each([&](entt::entity shooter,
                   InputSnapshot& input,
                   const Position& pos,
                   const CollisionShape& shape,
-                  WeaponState& weapon) {
+                  WeaponState& weapon,
+                  const PlayerVisState& vis) {
         // Dead players cannot fire or interact with weapons.
         if (registry.all_of<RespawnTimer>(shooter))
             return;
@@ -708,7 +716,17 @@ void runWeapon(Registry& registry,
                 beam->active = false;
         }
 
-        handleFire(registry, shooter, input, pos, shape, weapon, dt, outParticles, killEvents, outShotDebug);
+        handleFire(registry,
+                   shooter,
+                   input,
+                   pos,
+                   shape,
+                   weapon,
+                   vis.gravityFlipped,
+                   dt,
+                   outParticles,
+                   killEvents,
+                   outShotDebug);
         if (input.reload) {
             GunInstance& gun = getEquippedGun(weapon);
             handleReload(gun);

--- a/src/network/RegistrySerialization.cpp
+++ b/src/network/RegistrySerialization.cpp
@@ -14,6 +14,7 @@
 #include "ecs/components/PlayerVisState.hpp"
 #include "ecs/components/Position.hpp"
 #include "ecs/components/Projectile.hpp"
+#include "ecs/components/RespawnPoint.hpp"
 #include "ecs/components/RespawnTimer.hpp"
 #include "ecs/components/Velocity.hpp"
 #include "ecs/components/WeaponSpawner.hpp"
@@ -146,6 +147,7 @@ using Synced = std::tuple<entt::entity,
                           DeathInfo,
                           RespawnTimer,
                           WeaponSpawner,
+                          RespawnPoint,
                           AnimSnapshot>;
 
 // ── PR-10: snapshot delta encoding ──────────────────────────────────────

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -147,21 +147,21 @@ void ServerGame::run()
     registry.emplace<Position>(railSpawner, glm::vec3{-100.0f, 15.0f, -240.0f});
     registry.emplace<CollisionShape>(railSpawner);
 
-    // Static respawn points
+    // Static respawn points (with cooldown state)
     const entt::entity playerSpawner1 = registry.create();
-    registry.emplace<RespawnPoint>(playerSpawner1);
-    registry.emplace<Position>(playerSpawner1, glm::vec3{0.0f, 2000.0f, 0.0f});
+    registry.emplace<RespawnPoint>(playerSpawner1, RespawnPoint{});
+    registry.emplace<Position>(playerSpawner1, glm::vec3{-444.0f, 0.0f, 2000.0f});
 
     const entt::entity playerSpawner2 = registry.create();
-    registry.emplace<RespawnPoint>(playerSpawner2);
+    registry.emplace<RespawnPoint>(playerSpawner2, RespawnPoint{});
     registry.emplace<Position>(playerSpawner2, glm::vec3{800.0f, 40.0f, 800.0f});
 
     const entt::entity playerSpawner3 = registry.create();
-    registry.emplace<RespawnPoint>(playerSpawner3);
+    registry.emplace<RespawnPoint>(playerSpawner3, RespawnPoint{});
     registry.emplace<Position>(playerSpawner3, glm::vec3{800.0f, 430.0f, -800.0f});
 
     const entt::entity playerSpawner4 = registry.create();
-    registry.emplace<RespawnPoint>(playerSpawner4);
+    registry.emplace<RespawnPoint>(playerSpawner4, RespawnPoint{});
     registry.emplace<Position>(playerSpawner4, glm::vec3{0.0f, 200.0f, 0.0f});
 
     while (running) {
@@ -423,6 +423,10 @@ void ServerGame::tick(float dt, Uint64 nextTick)
     {
         GROUP2_PROF_SCOPE("playerStatus");
         systems::runPlayerStatus(registry, dt);
+    }
+    {
+        GROUP2_PROF_SCOPE("spawnPointCooldowns");
+        systems::runSpawnPointCooldowns(registry, dt);
     }
     {
         GROUP2_PROF_SCOPE("weaponSpawners");

--- a/src/server/game/ServerGame.cpp
+++ b/src/server/game/ServerGame.cpp
@@ -156,10 +156,6 @@ void ServerGame::run()
     registry.emplace<RespawnPoint>(playerSpawner2, RespawnPoint{});
     registry.emplace<Position>(playerSpawner2, glm::vec3{800.0f, 40.0f, 800.0f});
 
-    const entt::entity playerSpawner3 = registry.create();
-    registry.emplace<RespawnPoint>(playerSpawner3, RespawnPoint{});
-    registry.emplace<Position>(playerSpawner3, glm::vec3{800.0f, 430.0f, -800.0f});
-
     const entt::entity playerSpawner4 = registry.create();
     registry.emplace<RespawnPoint>(playerSpawner4, RespawnPoint{});
     registry.emplace<Position>(playerSpawner4, glm::vec3{0.0f, 200.0f, 0.0f});


### PR DESCRIPTION
This pull request adds new debug UI features for weapon spawners and player spawn points, and introduces several improvements for gravity-flipped gameplay (such as upside-down camera and controls). It also makes some minor gameplay and rendering fixes. The most important changes are summarized below:

**Debug UI Enhancements:**

* Added `buildWeaponSpawnerUI` and `buildSpawnPointUI` methods to `DebugUI`, providing new ImGui debug windows and overlays for visualizing weapon spawners and player spawn points, including per-entity details and cooldown states. (`src/client/debug/DebugUI.cpp`, `src/client/debug/DebugUI.hpp`) [[1]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83R1937-R2187) [[2]](diffhunk://#diff-64b7c6c5c85ccbd9e568c342177e6d18500227f1da7f27114843413669fdc301R171-R195)
* Integrated the new debug windows into the main debug menu and render loop, allowing toggling and visualization during gameplay. (`src/client/debug/DebugUI.cpp`, `src/client/game/Game.cpp`) [[1]](diffhunk://#diff-a56c2f3a0260098afda0f9f4c6a77e141424c5c51eab04bd9b1e1229a47d9b83R157-R158) [[2]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4R2755-R2756)

**Gravity Flip / Upside-Down Gameplay Improvements:**

* Updated player camera logic to correctly position the viewpoint and apply a 180° roll when gravity is flipped, ensuring an authentic upside-down experience. (`src/client/game/Game.cpp`) [[1]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L1440-R1457) [[2]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L1453-R1471)
* Modified input systems (mouse, keyboard, and gamepad) to respect the player's gravity direction, so controls invert appropriately when upside-down. (`src/client/game/Game.cpp`) [[1]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4R1246-R1267) [[2]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L1268-R1278) [[3]](diffhunk://#diff-f776f1df21c3a5d5962a0e89a5984331ce212a3e7af90f69d93c2793653b70e4L1303-R1316)
* Ensured the weapon viewmodel follows the camera roll, so it appears correctly oriented even when the player is upside-down. (`src/client/game/Game.cpp`)

**Gameplay and Rendering Fixes:**

* Fixed an issue where dead remote players' meshes could be visible; now only alive players are rendered. (`src/client/game/Game.cpp`)
* Improved the death screen UI with a "Press SPACE to skip" prompt and adjusted buffer sizes for display text. (`src/client/game/Game.cpp`)