### PR TITLE
View weapon fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,6 +861,7 @@ add_executable(group2
         src/client/lobby/Lobby.cpp
         src/client/lobby/ui/LobbyUI.hpp
         src/client/lobby/ui/LobbyUI.cpp
+        src/client/renderer-new/RendererTypes.hpp
 )
 
 # src/        — for shared headers (ecs/registry/Registry.hpp, etc.)
@@ -1309,6 +1310,8 @@ add_executable(clientbot
         src/ecs/systems/AbilitySystem.hpp
         src/ecs/abilities/DashAbility.cpp
         src/ecs/abilities/DashAbility.hpp
+        src/client/renderer-new/RendererTypes.hpp
+        src/client/renderer-new/RendererTypes.hpp
 )
 
 # Headers under src/ are referenced via "network/...", "ecs/components/...".

--- a/config.template.toml
+++ b/config.template.toml
@@ -41,4 +41,4 @@ backend = "auto"
 [developer]
 # When true, the client starts directly in-game and the server automatically
 # advances lobby phases into countdowns. Intended for local gameplay iteration.
-skip_lobby = false
+skip_lobby = true

--- a/shaders-new/geometry.vert
+++ b/shaders-new/geometry.vert
@@ -18,6 +18,6 @@ layout(set = 1, binding = 1) uniform Object {
 void main()
 {
     gl_Position = camera.view_projection * object.model * vec4(v, 1.0f);
-    frag_normal = normalize(vn);
+    frag_normal = normalize(object.model * vec4(vn,0.0f)).xyz;
     frag_vt = vt;
 }

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -48,6 +48,7 @@
 #include "network/ShotEvent.hpp"
 #include "particles/ParticleEvents.hpp"
 #include "renderer-new/GraphicsConfig.hpp"
+#include "renderer-new/RendererTypes.hpp"
 #include "systems/InputSampleSystem.hpp"
 #include "systems/InputSendSystem.hpp"
 #include "systems/PredictionSystem.hpp"
@@ -2052,6 +2053,157 @@ SDL_AppResult Game::iterate()
         lastEquippedType_ = currentEquippedType_;
         viewmodelDefaultsApplied_ = true;
     }
+
+    const int currentWeaponModelIdx = weaponModelIndices_[static_cast<int>(currentEquippedType_)];
+
+    // Build weapon viewmodel
+    {
+        WeaponViewmodel vm;
+        const auto localDeadView = registry.view<LocalPlayer, RespawnTimer>();
+        if (currentWeaponModelIdx >= 0 && localDeadView.begin() == localDeadView.end()) {
+            vm.modelIndex = currentWeaponModelIdx;
+            vm.visible = true;
+
+            const float cosPitch = std::cos(renderPitch);
+            const glm::vec3 forward{
+                std::sin(renderYaw) * cosPitch, -std::sin(renderPitch), std::cos(renderYaw) * cosPitch};
+            glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0, 1, 0}));
+            glm::vec3 up = glm::normalize(glm::cross(right, forward));
+
+            // Apply camera roll to the viewmodel basis so the weapon follows
+            // the 180° flip (or any tilt) instead of staying upright.
+            if (std::abs(currentCameraRoll_) > 0.001f) {
+                const float cosR = std::cos(currentCameraRoll_);
+                const float sinR = std::sin(currentCameraRoll_);
+                const glm::vec3 rolledRight = right * cosR + up * sinR;
+                const glm::vec3 rolledUp = up * cosR - right * sinR;
+                right = rolledRight;
+                up = rolledUp;
+            }
+
+            // --- Weapon sway (CoD-style barrel lead) ---
+            {
+                if (!swayInitialized_) {
+                    prevSwayYaw_ = renderYaw;
+                    prevSwayPitch_ = renderPitch;
+                    swayInitialized_ = true;
+                }
+
+                float yawDelta = renderYaw - prevSwayYaw_;
+                float pitchDelta = renderPitch - prevSwayPitch_;
+                prevSwayYaw_ = renderYaw;
+                prevSwayPitch_ = renderPitch;
+
+                // Wrap yaw delta for -pi/+pi boundary
+                if (yawDelta > glm::pi<float>())
+                    yawDelta -= glm::two_pi<float>();
+                if (yawDelta < -glm::pi<float>())
+                    yawDelta += glm::two_pi<float>();
+
+                if (frameTime > 0.0001f) {
+                    float targetX = std::clamp(yawDelta / frameTime * 0.05f * swayAmplitudeYaw_,
+                                               -swayAmplitudeYaw_ * 3.0f,
+                                               swayAmplitudeYaw_ * 3.0f);
+                    float targetY = std::clamp(pitchDelta / frameTime * 0.05f * swayAmplitudePitch_,
+                                               -swayAmplitudePitch_ * 3.0f,
+                                               swayAmplitudePitch_ * 3.0f);
+
+                    float alpha = std::min(1.0f, swaySmoothing_ * frameTime * 60.0f);
+                    swayOffsetX_ = glm::mix(swayOffsetX_, targetX, alpha);
+                    swayOffsetY_ = glm::mix(swayOffsetY_, targetY, alpha);
+                }
+                float decay = std::exp(-swayDecayRate_ * frameTime);
+                swayOffsetX_ *= decay;
+                swayOffsetY_ *= decay;
+            }
+
+            // --- Recoil decay ---
+            {
+                const RecoilParams& rp = getRecoilParams(currentEquippedType_);
+                float decay = std::exp(-rp.recoverySpeed * frameTime);
+                recoilPitch_ *= decay;
+                recoilPushBack_ *= decay;
+                recoilRoll_ *= decay;
+
+                // Kill tiny residuals
+                if (std::abs(recoilPitch_) < 0.01f)
+                    recoilPitch_ = 0.0f;
+                if (std::abs(recoilPushBack_) < 0.01f)
+                    recoilPushBack_ = 0.0f;
+                if (std::abs(recoilRoll_) < 0.01f)
+                    recoilRoll_ = 0.0f;
+            }
+
+            // --- Velocity-direction-dependent bobbing ---
+            float bobPhase = 0.0f;
+            float bobAmpFwd = 0.0f;
+            float bobAmpStrafe = 0.0f;
+
+            registry.view<LocalPlayer, Velocity>().each([&](const Velocity& vel) {
+                glm::vec3 hVel{vel.value.x, 0.0f, vel.value.z};
+                glm::vec3 hFwd{forward.x, 0.0f, forward.z};
+                float hFwdLen = glm::length(hFwd);
+                if (hFwdLen < 0.001f) {
+                    hFwd = glm::vec3{std::sin(renderYaw), 0.0f, std::cos(renderYaw)};
+                } else {
+                    hFwd /= hFwdLen;
+                }
+                glm::vec3 hRight = glm::normalize(glm::cross(hFwd, glm::vec3{0, 1, 0}));
+
+                float fwdSpeed = std::abs(glm::dot(hVel, hFwd));
+                float strafeSpeed = std::abs(glm::dot(hVel, hRight));
+
+                bobPhase = static_cast<float>(SDL_GetTicks()) * 0.008f;
+
+                if (fwdSpeed > 10.0f)
+                    bobAmpFwd = std::min(fwdSpeed / 800.0f, 1.5f);
+                if (strafeSpeed > 10.0f)
+                    bobAmpStrafe = std::min(strafeSpeed / 800.0f, 1.0f);
+            });
+
+            // Forward: classic vertical-dominant bob
+            float bobX = std::sin(bobPhase) * bobAmpFwd * 0.3f;
+            float bobY = std::sin(bobPhase * 2.0f) * bobAmpFwd * 0.5f;
+
+            // Strafe: horizontal-dominant bob at slightly different frequency
+            bobX += std::sin(bobPhase * 0.9f) * bobAmpStrafe * 0.8f;
+            bobY += std::sin(bobPhase * 1.8f) * bobAmpStrafe * 0.2f;
+
+            // Position the weapon in camera space, then convert to world.
+            glm::vec3 weaponPos = renderEye + forward * vmForward + right * vmRight - up * vmDown;
+            // Apply sway
+            weaponPos += right * swayOffsetX_ + up * swayOffsetY_;
+            // Apply bob
+            weaponPos += right * bobX + up * bobY;
+            // Apply recoil pushback
+            weaponPos -= forward * recoilPushBack_;
+
+            // Build world transform: translate -> local-rotate -> camera-orient -> scale.
+            //
+            // 1) Camera orientation: maps model axes into camera space.
+            const glm::mat4 cameraOrient = glm::mat4(glm::vec4(right, 0.0f),
+                                                     glm::vec4(up, 0.0f),
+                                                     glm::vec4(forward, 0.0f),
+                                                     glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+
+            // 2) Local rotation offsets (yaw/pitch/roll in degrees) with recoil.
+            const glm::mat4 localRot =
+                glm::rotate(glm::mat4(1.0f), glm::radians(vmYawOffset), glm::vec3(0, 1, 0)) *
+                glm::rotate(glm::mat4(1.0f), glm::radians(vmPitchOffset + recoilPitch_), glm::vec3(1, 0, 0)) *
+                glm::rotate(glm::mat4(1.0f), glm::radians(vmRollOffset + recoilRoll_), glm::vec3(0, 0, 1));
+
+            glm::mat4 weaponWorld = glm::translate(glm::mat4(1.0f), weaponPos);
+            weaponWorld *= cameraOrient;
+            weaponWorld *= localRot;
+            // Negate X to cancel the reflection in the camera orient matrix
+            // (right, up, forward has det = -1).
+            weaponWorld = glm::scale(weaponWorld, glm::vec3(-vmScale, vmScale, vmScale));
+
+            vm.transform = weaponWorld;
+        }
+        renderer->setWeaponViewmodel(vm);
+    }
+
 
     // 7. Frame recording (R key) -- anchored to physics ticks
     if (physicsRan && recorder.isRecording()) {

--- a/src/client/lobby/Lobby.cpp
+++ b/src/client/lobby/Lobby.cpp
@@ -66,6 +66,7 @@ bool Lobby::init(NewRenderer* rendererPtr, SDL_Window* windowPtr, Client* client
                 p.isHost = p.id == update.id;
             break;
         default:
+            break;
         }
     });
 

--- a/src/client/renderer-new/NewRenderer.cpp
+++ b/src/client/renderer-new/NewRenderer.cpp
@@ -233,8 +233,8 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
     SDL_PushGPUVertexUniformData(cmd, 0, &viewProjection, sizeof(glm::mat4));
     drawWorldModelInstances(geometryPass, cmd);
 
-    const glm::mat4 projection = camera_.getProjectionMatrix();
-    SDL_PushGPUVertexUniformData(cmd, 0, &projection, sizeof(glm::mat4));
+    // const glm::mat4 projection = camera_.getProjectionMatrix();
+    // SDL_PushGPUVertexUniformData(cmd, 0, &projection, sizeof(glm::mat4));
     drawWeapon(geometryPass, cmd);
 
     SDL_EndGPURenderPass(geometryPass);
@@ -253,12 +253,19 @@ void NewRenderer::drawWeapon(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer
 
     //constexpr auto newWVM = glm::mat4(1.0f);
 
-    if (!Asset::models_.contains(weapon_.modelIndex)) {
+    if (Asset::modelInstances_.size() <= weapon_.modelIndex) {
+        return;
+    }
+
+    Asset::ModelInstance& weaponModelInstance = Asset::modelInstances_.at(weapon_.modelIndex);
+    ModelIdInt weaponModelId = weaponModelInstance.modelId_;
+
+    if (!Asset::models_.contains(weaponModelId)) {
          std::cout << "invalid weapon ModelId" << std::endl;
         return;
     }
 
-    drawModel(weapon_.modelIndex, weapon_.transform, renderPass, cmd);
+    drawModel(weaponModelId, weapon_.transform, renderPass, cmd);
 }
 
 void NewRenderer::drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
@@ -401,9 +408,6 @@ int NewRenderer::loadSceneModel(
     bool flatten = false;
     const std::vector<std::string> texFileNames;
 
-    auto modelTransform = glm::mat4(1.0f);
-    modelTransform = glm::scale(modelTransform, glm::vec3(scale));
-    modelTransform[3] = glm::vec4(pos, 1.0f);
 
     const char* const base = SDL_GetBasePath();
     std::filesystem::path fullPath = base ? base : "";
@@ -417,6 +421,10 @@ int NewRenderer::loadSceneModel(
     }
     Asset::Model& model = Asset::models_.at(modelId);
     AssetLoader::updateModelTransformCache(modelId);
+
+    auto modelTransform = glm::mat4(1.0f);
+    modelTransform = glm::scale(modelTransform, glm::vec3(scale));
+    modelTransform[3] = glm::vec4(pos, 1.0f);
 
     Asset::ModelInstance sceneInstance{};
     sceneInstance.drawInScenePass = true;

--- a/src/client/renderer-new/NewRenderer.cpp
+++ b/src/client/renderer-new/NewRenderer.cpp
@@ -242,18 +242,23 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
 
 void NewRenderer::drawWeapon(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
 {
-    if (Asset::modelInstances_.size() <= 4) {
-        return;
-    }
-    Asset::weaponModelId_ = Asset::modelInstances_.at(4).modelId_;
-    if (!Asset::models_.contains(Asset::weaponModelId_)) {
-        std::cout << "invalid weaponModelId" << std::endl;
+    // if (Asset::modelInstances_.size() <= 4) {
+    //     return;
+    // }
+    // Asset::weaponModelId_ = Asset::modelInstances_.at(4).modelId_;
+    // if (!Asset::models_.contains(Asset::weaponModelId_)) {
+    //     std::cout << "invalid weaponModelId" << std::endl;
+    //     return;
+    // }
+
+    //constexpr auto newWVM = glm::mat4(1.0f);
+
+    if (!Asset::models_.contains(weapon_.modelIndex)) {
+         std::cout << "invalid weapon ModelId" << std::endl;
         return;
     }
 
-    constexpr auto newWVM = glm::mat4(1.0f);
-    Asset::weaponViewModel_ = glm::translate(newWVM, glm::vec3(1.0f, 0.0f, -3.0f));
-    drawModel(Asset::weaponModelId_, Asset::weaponViewModel_, renderPass, cmd);
+    drawModel(weapon_.modelIndex, weapon_.transform, renderPass, cmd);
 }
 
 void NewRenderer::drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
@@ -440,4 +445,9 @@ int NewRenderer::loadSceneModel(
     SDL_WaitForGPUIdle(device_);
 
     return Asset::modelInstances_.size() - 1;
+}
+
+void NewRenderer::setWeaponViewmodel(const WeaponViewmodel& vm)
+{
+    weapon_ = vm;
 }

--- a/src/client/renderer-new/NewRenderer.hpp
+++ b/src/client/renderer-new/NewRenderer.hpp
@@ -5,6 +5,7 @@
 
 #include "Asset.hpp"
 #include "Camera.hpp"
+#include "RendererTypes.hpp"
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_gpu.h>
@@ -34,6 +35,8 @@ public:
     [[nodiscard]] const NewCamera& getCamera() const { return camera_; }
     void setHudTexture(SDL_GPUTexture* hudTexture);
 
+    void setWeaponViewmodel(const WeaponViewmodel& vm);
+
     int loadSceneModel(
         const char* filename, glm::vec3 pos, float scale, bool flipUVs, const std::string& excludeNodesContaining = "");
 
@@ -59,6 +62,8 @@ private:
     Uint32 depthHeight_ = 0;
 
     NewCamera camera_;
+
+    WeaponViewmodel weapon_;
 
     /// @brief Build the geometry graphics pipeline from vertex/fragment shaders.
     /// @return True on success.

--- a/src/client/renderer-new/RendererTypes.hpp
+++ b/src/client/renderer-new/RendererTypes.hpp
@@ -1,0 +1,69 @@
+/// @file RendererTypes.hpp
+/// @brief Shared data types used across renderer implementations.
+///
+/// Extracted so that `IRenderer.hpp` and the concrete renderer headers can
+/// depend on these structs without creating circular includes.
+
+#pragma once
+
+#include <glm/glm.hpp>
+
+/// @brief Anti-aliasing mode selection -- exposed to ImGui.
+enum class AAMode : int
+{
+    Off = 0,      ///< No anti-aliasing.
+    SMAA_1x = 1,  ///< Spatial SMAA only, zero ghosting.
+    SMAA_T2x = 2, ///< 2-sample temporal + spatial SMAA (recommended).
+};
+
+/// @brief Live toggles for every render system -- exposed to ImGui.
+///
+/// All default to true (everything on). The legacy renderer checks these each
+/// frame and skips the corresponding pass/dispatch when disabled.
+struct RenderToggles
+{
+    // Geometry passes
+    bool pbrModels = true;       ///< Assimp-loaded scene models (opaque + transparent).
+    bool entityModels = true;    ///< ECS-driven entity models (Renderable component).
+    bool weaponViewmodel = true; ///< First-person weapon.
+    bool skybox = true;          ///< Procedural / cubemap skybox.
+
+    // Shadow
+    bool shadows = true; ///< Shadow map pass + shadow sampling in PBR.
+
+    // Post-processing
+    bool ssao = true;        ///< Screen-space ambient occlusion.
+    bool bloom = true;       ///< Bloom downsample + upsample chain.
+    bool ssr = true;         ///< Screen-space reflections.
+    bool volumetrics = true; ///< Volumetric lighting / god rays.
+    bool tonemap = true;     ///< HDR -> LDR tone mapping (disabling = raw HDR blit).
+
+    // Effects
+    bool particles = true; ///< GPU particle system.
+    bool sdfText = true;   ///< SDF text rendering (HUD + world).
+};
+
+/// @brief Per-entity render command -- built by Game, consumed by Renderer::drawFrame.
+struct EntityRenderCmd
+{
+    int32_t modelIndex = -1;        ///< Index into Renderer::models[].
+    glm::mat4 worldTransform{1.0f}; ///< Full world transform (position × rotation × scale).
+    glm::vec4 tint{1.0f};           ///< RGB multiplier into baseColorFactor (alpha unused). Default = no tint.
+};
+
+/// @brief Dynamic point light -- built by Game, injected into the PBR light array.
+struct PointLight
+{
+    glm::vec3 position{0.0f}; ///< World-space position.
+    glm::vec3 color{1.0f};    ///< Light colour (linear RGB).
+    float intensity = 1.0f;   ///< Brightness multiplier (passed as color.a in the UBO).
+    float range = 500.0f;     ///< Attenuation range (world units); falloff = 1 - (d²/r²).
+};
+
+/// @brief First-person weapon viewmodel descriptor sent per frame.
+struct WeaponViewmodel
+{
+    int32_t modelIndex = -1;   ///< Index into Renderer::models[].
+    glm::mat4 transform{1.0f}; ///< Transform in viewmodel space (relative to camera).
+    bool visible = false;
+};


### PR DESCRIPTION
You can now see the correct handheld weapon model and transform in viewport. It does clip through the existing geometry in the scene. This is probably because the default scale is way too large. if its too annoying to fix I can  put it in a separate pass with a cleared depth buffer.