### PR TITLE
Restore graphics API stubs and material/texture handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,6 +843,8 @@ add_executable(group2
         src/ecs/components/ClientId.hpp
         src/client/renderer-new/NewRenderer.cpp
         src/client/renderer-new/NewRenderer.hpp
+        src/client/renderer-new/SkinnedRenderer.cpp
+        src/client/renderer-new/SkinnedRenderer.hpp
         src/client/renderer-new/Camera.cpp
         src/client/renderer-new/Camera.hpp
         src/client/renderer-new/Asset.hpp

--- a/src/client/renderer-new/NewRenderer.cpp
+++ b/src/client/renderer-new/NewRenderer.cpp
@@ -1,5 +1,10 @@
 /// @file NewRenderer.cpp
 /// @brief Implementation of the work-in-progress NewRenderer.
+///
+/// Grep for `TODO(graphics)` to find every stub still waiting on the
+/// graphics team.  Each TODO has a doc-comment block on the matching
+/// header declaration describing what data is captured and where it
+/// should end up.
 
 #include "NewRenderer.hpp"
 
@@ -7,13 +12,32 @@
 #include "AssetLoader.hpp"
 #include "Boilerplate.hpp"
 
+#include <algorithm>
 #include <backends/imgui_impl_sdlgpu3.h>
 #include <cstddef>
+#include <cstring>
 #include <filesystem>
 #include <glm/ext/matrix_transform.hpp>
 #include <imgui.h>
 #include <iostream>
+#include <unordered_map>
 #include <vector>
+
+namespace
+{
+/// Convert SDL high-resolution counter ticks to milliseconds.
+float ticksToMs(Uint64 elapsed, Uint64 freq)
+{
+    return freq == 0 ? 0.0f : (static_cast<float>(elapsed) * 1000.0f) / static_cast<float>(freq);
+}
+
+/// Side-table for per-model emissive overrides set via `setModelEmissive`.
+/// TODO(graphics): consume these inside `drawModel` when building the
+/// material UBO — currently captured but unused.
+std::unordered_map<int32_t, glm::vec4> g_emissiveOverrides;
+} // namespace
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────────
 
 bool NewRenderer::init(SDL_Window* window)
 {
@@ -75,7 +99,7 @@ bool NewRenderer::init(SDL_Window* window)
         return false;
     }
 
-    // DEFAULT TEXTURE
+    // DEFAULT TEXTURE — used for any mesh whose material has no albedo.
     texture_ = Boilerplate::loadTexture(device_, "assets/404.jpeg");
     if (!texture_) {
         SDL_Log("NewRenderer: failed to load texture");
@@ -106,6 +130,7 @@ bool NewRenderer::createHudPipeline()
 
     return hudPipeline_ != nullptr;
 }
+
 bool NewRenderer::createGeometryPipeline()
 {
     Boilerplate::ShaderInfo vertexShader{};
@@ -149,14 +174,20 @@ void NewRenderer::createMeshBuffers(MeshIdInt meshId) const
     mesh.iBufferInfo_.srcData = mesh.indexData_.data();
 }
 
+// ─── Per-frame entry point ──────────────────────────────────────────────────
+
 void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
 {
-    SDL_Log("pre-drawFrame window flags: 0x%x", SDL_GetWindowFlags(window_));
+    const Uint64 freq = SDL_GetPerformanceFrequency();
+    const Uint64 t0 = SDL_GetPerformanceCounter();
+
     SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device_);
     if (!cmd) {
         SDL_Log("NewRenderer::drawFrame: SDL_AcquireGPUCommandBuffer failed: %s", SDL_GetError());
         return;
     }
+    const Uint64 t1 = SDL_GetPerformanceCounter();
+    lastAcquireMs_ = ticksToMs(t1 - t0, freq);
 
     SDL_GPUTexture* swapchain = nullptr;
     Uint32 width = 0;
@@ -168,7 +199,7 @@ void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
     }
 
     if (!swapchain) {
-        // SDL_Log("NewRenderer::drawFrame: swapchain not ready, skipping...: ");
+        // Swapchain not ready (e.g. minimised) — drop the frame silently.
         SDL_CancelGPUCommandBuffer(cmd);
         return;
     }
@@ -181,10 +212,29 @@ void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
 
     setMainCamera(eye, yaw, pitch, roll, width, height);
 
+    // Per-frame uploads (skinning palette/instances, etc.) happen BEFORE
+    // the first render pass so the copy is sequenced ahead of the draws.
+    if (skinnedFrameDirty_) {
+        SDL_GPUCopyPass* copyPass = SDL_BeginGPUCopyPass(cmd);
+        if (copyPass) {
+            uploadSkinnedFrame(cmd, copyPass);
+            SDL_EndGPUCopyPass(copyPass);
+        }
+    }
+
     drawGeometryPass(swapchain, cmd);
     drawUIPass(swapchain, cmd);
 
+    const Uint64 t2 = SDL_GetPerformanceCounter();
+    lastRecordMs_ = ticksToMs(t2 - t1, freq);
+
     SDL_SubmitGPUCommandBuffer(cmd);
+
+    const Uint64 t3 = SDL_GetPerformanceCounter();
+    lastSubmitMs_ = ticksToMs(t3 - t2, freq);
+
+    // TODO(graphics): if `pendingScreenshotPath_` is non-empty, schedule a
+    // swapchain readback and write a PNG.  See `requestScreenshot` doc.
 }
 
 void NewRenderer::setMainCamera(glm::vec3 eye, float yaw, float pitch, float roll, Uint32 width, Uint32 height)
@@ -208,8 +258,8 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
     drawWorldModelInstances(geometryPass, cmd);
     drawEntityModels(geometryPass, cmd);
 
-    // const glm::mat4 projection = camera_.getProjectionMatrix();
-    // SDL_PushGPUVertexUniformData(cmd, 0, &projection, sizeof(glm::mat4));
+    drawSkinnedCharacters(geometryPass, cmd);
+
     drawWeapon(geometryPass, cmd);
 
     SDL_EndGPURenderPass(geometryPass);
@@ -217,20 +267,10 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
 
 void NewRenderer::drawWeapon(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
 {
-    // if (Asset::modelInstances_.size() <= 4) {
-    //     return;
-    // }
-    // Asset::weaponModelId_ = Asset::modelInstances_.at(4).modelId_;
-    // if (!Asset::models_.contains(Asset::weaponModelId_)) {
-    //     std::cout << "invalid weaponModelId" << std::endl;
-    //     return;
-    // }
-
-    // constexpr auto newWVM = glm::mat4(1.0f);
-
-    if (Asset::modelInstances_.size() <= weapon_.modelIndex) {
+    if (!weapon_.visible)
         return;
-    }
+    if (weapon_.modelIndex < 0 || static_cast<size_t>(weapon_.modelIndex) >= Asset::modelInstances_.size())
+        return;
 
     Asset::ModelInstance& weaponModelInstance = Asset::modelInstances_.at(weapon_.modelIndex);
     ModelIdInt weaponModelId = weaponModelInstance.modelId_;
@@ -246,6 +286,8 @@ void NewRenderer::drawWeapon(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer
 void NewRenderer::drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
 {
     for (const auto& mInstance : Asset::modelInstances_) {
+        if (!mInstance.drawInScenePass)
+            continue;
         drawModel(mInstance.modelId_, mInstance.transform_, renderPass, cmd);
     }
 }
@@ -253,11 +295,15 @@ void NewRenderer::drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPU
 void NewRenderer::drawEntityModels(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
 {
     for (const auto& entityCmd : entities_) {
-        if (entityCmd.modelIndex < 0 ) {
+        if (entityCmd.modelIndex < 0) {
             std::cout << "invalid modelIndex" << std::endl;
             break;
         }
+        if (static_cast<size_t>(entityCmd.modelIndex) >= Asset::modelInstances_.size())
+            continue;
         ModelIdInt modelId = Asset::modelInstances_.at(entityCmd.modelIndex).modelId_;
+        // TODO(graphics): pass entityCmd.tint into the per-mesh material UBO
+        // so tinted entities (e.g. team colors, hit flashes) render correctly.
         drawModel(modelId, entityCmd.worldTransform, renderPass, cmd);
     }
 }
@@ -287,18 +333,16 @@ void NewRenderer::drawModel(ModelIdInt modelId,
         SDL_GPUTextureSamplerBinding textureBinding = Boilerplate::makeTextureSamplerBinding(texture, sampler_);
         SDL_BindGPUFragmentSamplers(renderPass, 0, &textureBinding, 1);
 
-        // Material uniform.
         glm::vec4 materialDiffuse{0.8f, 0.8f, 0.8f, 1.0f};
         if (material != nullptr)
             materialDiffuse = glm::vec4(material->kDiffuse_, 1.0f);
         Uint32 useTextureUniform = useTexture ? 1u : 0u;
         SDL_PushGPUFragmentUniformData(cmd, 0, &materialDiffuse, sizeof(materialDiffuse));
         SDL_PushGPUFragmentUniformData(cmd, 1, &useTextureUniform, sizeof(useTextureUniform));
-        
-        // Bind model matrix
+
         glm::mat4 modelElementMatrix = modelTransform * element.cachedTransform_;
         SDL_PushGPUVertexUniformData(cmd, 1, &modelElementMatrix, sizeof(glm::mat4));
-        
+
         Asset::Mesh& mesh = Asset::meshes_.at(element.meshId_);
         drawMesh(renderPass, mesh);
     }
@@ -354,11 +398,12 @@ void NewRenderer::drawUIPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cm
     if (hudTexture_ != nullptr)
         drawHud(uiPass);
 
-    if (drawData)
+    if (drawData && imguiEnabled)
         ImGui_ImplSDLGPU3_RenderDrawData(drawData, cmd, uiPass);
 
     SDL_EndGPURenderPass(uiPass);
 }
+
 void NewRenderer::drawHud(SDL_GPURenderPass* renderPass)
 {
     SDL_GPUTextureSamplerBinding hudTextureBinding = Boilerplate::makeTextureSamplerBinding(hudTexture_, hudSampler_);
@@ -392,10 +437,43 @@ void NewRenderer::quit()
             mesh.iBufferInfo_ = {};
         }
 
+        // Release skinned rig resources.
+        for (auto& sm : skinnedMeshes_) {
+            if (sm.vb)
+                SDL_ReleaseGPUBuffer(device_, sm.vb);
+            if (sm.boneVb)
+                SDL_ReleaseGPUBuffer(device_, sm.boneVb);
+            if (sm.ib)
+                SDL_ReleaseGPUBuffer(device_, sm.ib);
+        }
+        skinnedMeshes_.clear();
+        if (palettesSSBO_)
+            SDL_ReleaseGPUBuffer(device_, palettesSSBO_);
+        if (instancesSSBO_)
+            SDL_ReleaseGPUBuffer(device_, instancesSSBO_);
+        if (paletteXfer_)
+            SDL_ReleaseGPUTransferBuffer(device_, paletteXfer_);
+        if (instanceXfer_)
+            SDL_ReleaseGPUTransferBuffer(device_, instanceXfer_);
+        palettesSSBO_ = nullptr;
+        instancesSSBO_ = nullptr;
+        paletteXfer_ = nullptr;
+        instanceXfer_ = nullptr;
+        palettesCapacityBytes_ = 0;
+        instancesCapacityBytes_ = 0;
+        paletteXferCapacityBytes_ = 0;
+        instanceXferCapacityBytes_ = 0;
+
+        if (skinnedPipeline_)
+            SDL_ReleaseGPUGraphicsPipeline(device_, skinnedPipeline_);
         if (geometryPipeline_)
             SDL_ReleaseGPUGraphicsPipeline(device_, geometryPipeline_);
+        if (hudPipeline_)
+            SDL_ReleaseGPUGraphicsPipeline(device_, hudPipeline_);
         if (sampler_)
             SDL_ReleaseGPUSampler(device_, sampler_);
+        if (hudSampler_)
+            SDL_ReleaseGPUSampler(device_, hudSampler_);
         if (texture_)
             SDL_ReleaseGPUTexture(device_, texture_);
 
@@ -409,18 +487,27 @@ void NewRenderer::quit()
     shaderFormat_ = SDL_GPU_SHADERFORMAT_INVALID;
 
     geometryPipeline_ = nullptr;
+    hudPipeline_ = nullptr;
+    skinnedPipeline_ = nullptr;
     depthTarget_.texture = nullptr;
     texture_ = nullptr;
     sampler_ = nullptr;
+    hudTexture_ = nullptr;
+    hudSampler_ = nullptr;
     depthWidth_ = 0;
     depthHeight_ = 0;
+    skinnedRigInstalled_ = false;
+    skinnedNumJoints_ = 0;
+    skinnedFrameDirty_ = false;
 }
+
+// ─── Static models ──────────────────────────────────────────────────────────
 
 int NewRenderer::loadSceneModel(
     const char* filename, glm::vec3 pos, float scale, bool flipUVs, const std::string& /*excludeNodesContaining*/)
 {
     ModelIdInt modelId = Asset::getIdFromString(filename);
-    bool flatten = false;
+    const bool flatten = false;
     const std::vector<std::string> texFileNames;
 
     const char* const base = SDL_GetBasePath();
@@ -448,39 +535,28 @@ int NewRenderer::loadSceneModel(
     Asset::modelInstances_.push_back(sceneInstance);
 
     std::vector<Boilerplate::BufferUpload> uploads;
-
     for (auto& element : model.modelElements_) {
         createMeshBuffers(element.meshId_);
         Asset::Mesh& mesh = Asset::meshes_[element.meshId_];
         uploads.push_back({mesh.vBufferInfo_.gpuBuff, mesh.vBufferInfo_.srcData, mesh.vBufferInfo_.bufferSize});
         uploads.push_back({mesh.iBufferInfo_.gpuBuff, mesh.iBufferInfo_.srcData, mesh.iBufferInfo_.bufferSize});
 
-       MaterialIdInt matId = element.materialId_;
-        if (!Asset::materials_.contains(matId)) {
+        MaterialIdInt matId = element.materialId_;
+        if (!Asset::materials_.contains(matId))
             continue;
-        }
 
         Asset::Material& mat = Asset::materials_.at(matId);
         TexIdInt texId = mat.texId_[0];
 
-        if (texId == 0 || !Asset::textures_.contains(texId)) {
+        if (texId == 0 || !Asset::textures_.contains(texId))
             continue;
-        }
 
         Asset::Texture& tex = Asset::textures_.at(texId);
-
-        if (tex.tex == nullptr &&
-            tex.tex_raw != nullptr &&
-            tex.width > 0 &&
-            tex.height > 0)
-        {
-            tex.tex = Boilerplate::createTextureRGBA8(
-                device_,
-                static_cast<Uint32>(tex.width),
-                static_cast<Uint32>(tex.height),
-                tex.tex_raw
-            );
-
+        if (tex.tex == nullptr && tex.tex_raw != nullptr && tex.width > 0 && tex.height > 0) {
+            tex.tex = Boilerplate::createTextureRGBA8(device_,
+                                                     static_cast<Uint32>(tex.width),
+                                                     static_cast<Uint32>(tex.height),
+                                                     tex.tex_raw);
             stbi_image_free(tex.tex_raw);
             tex.tex_raw = nullptr;
         }
@@ -496,8 +572,15 @@ int NewRenderer::loadSceneModel(
     SDL_SubmitGPUCommandBuffer(cmd);
     SDL_WaitForGPUIdle(device_);
 
-    return Asset::modelInstances_.size() - 1;
+    return static_cast<int>(Asset::modelInstances_.size() - 1);
 }
+
+int NewRenderer::modelCount() const
+{
+    return static_cast<int>(Asset::models_.size());
+}
+
+// ─── Per-frame data-capture stubs ────────────────────────────────────────────
 
 void NewRenderer::setWeaponViewmodel(const WeaponViewmodel& vm)
 {
@@ -506,14 +589,309 @@ void NewRenderer::setWeaponViewmodel(const WeaponViewmodel& vm)
 
 void NewRenderer::setPointLights(std::vector<PointLight> pointLights)
 {
-    return;
+    // TODO(graphics): consume `pointLights_` inside the geometry / skinned
+    // passes by pushing a light-array UBO to the fragment shader.  Cap at the
+    // shader's array size and silently drop the rest.
+    pointLights_ = std::move(pointLights);
 }
+
 void NewRenderer::setEntityRenderList(std::vector<EntityRenderCmd>&& entityList)
 {
     entities_ = std::move(entityList);
-    return;
 }
+
 void NewRenderer::setModelEmissive(int32_t modelIdUnsanitized, glm::vec4 emissiveColor)
 {
-    return;
+    // TODO(graphics): read this side-table inside `drawModel` when composing
+    // the material UBO.  Emissive should add (not multiply) into the lit
+    // colour so glowing bodies (beam cylinders, sphere lights) still pop in
+    // dark areas.
+    g_emissiveOverrides[modelIdUnsanitized] = emissiveColor;
+}
+
+void NewRenderer::setModelScenePass(int32_t modelIndex, bool drawInScene)
+{
+    if (modelIndex < 0 || static_cast<size_t>(modelIndex) >= Asset::modelInstances_.size())
+        return;
+    Asset::modelInstances_.at(modelIndex).drawInScenePass = drawInScene;
+}
+
+void NewRenderer::setParticleSystem(ParticleSystem* ps)
+{
+    // TODO(graphics): inside `drawFrame`, before BeginRenderPass call
+    //   particleSystem_->uploadToGpu(cmd);
+    // and inside the main HDR pass call
+    //   particleSystem_->render(pass, cmd);
+    // See ParticleSystem.hpp doc-comment for the lifecycle (init/update/quit).
+    particleSystem_ = ps;
+}
+
+bool NewRenderer::setVSync(bool enabled)
+{
+    // TODO(graphics): apply via SDL_SetGPUSwapchainParameters with
+    //   SDL_GPU_PRESENTMODE_VSYNC (or MAILBOX) when enabled, and
+    //   SDL_GPU_PRESENTMODE_IMMEDIATE when disabled.  Check the format
+    //   you currently use for the swapchain so you preserve it.
+    vsyncEnabled_ = enabled;
+    return true;
+}
+
+void NewRenderer::requestScreenshot(const std::string& path)
+{
+    // TODO(graphics): after `SubmitGPUCommandBuffer` in `drawFrame`, copy the
+    // swapchain texture into a download transfer buffer, map CPU-side, write
+    // `path` as a PNG via `stbi_write_png` (4 channels, R8G8B8A8).  Clear
+    // `pendingScreenshotPath_` after writing.
+    pendingScreenshotPath_ = path;
+}
+
+void NewRenderer::updateModelMeshVertices(int /*modelIndex*/,
+                                          int /*meshIndex*/,
+                                          const Vertex* /*vertices*/,
+                                          Uint32 /*vertexCount*/)
+{
+    // TODO(graphics): legacy used this for CPU-skinning (now superseded by
+    // setSkinnedFrame).  Leave as a no-op unless a new caller emerges.
+}
+
+bool NewRenderer::loadHDRSkybox(const std::string& /*path*/)
+{
+    // TODO(graphics): load via stb_image float, upload as a 2D HDR texture,
+    // equirect→cubemap convolution, derive irradiance + prefilter mips.
+    // Set `useHDRSkybox = true` and `currentHDRName = stem-of(path)` on success.
+    return false;
+}
+
+void NewRenderer::scanHDRFiles()
+{
+    // TODO(graphics): iterate `assets/hdr/*.hdr` via std::filesystem and fill
+    // `availableHDRFiles` with absolute paths.  Called once at init.
+    availableHDRFiles.clear();
+}
+
+// ─── Skinned character pipeline ──────────────────────────────────────────────
+
+bool NewRenderer::setSkinnedRig(const std::vector<RigMeshSource>& meshes, int numJoints)
+{
+    if (skinnedRigInstalled_) {
+        SDL_Log("NewRenderer::setSkinnedRig: rig already installed; ignoring repeat call");
+        return false;
+    }
+    if (meshes.empty() || numJoints <= 0) {
+        SDL_Log("NewRenderer::setSkinnedRig: empty meshes or numJoints<=0 (%zu, %d)", meshes.size(), numJoints);
+        return false;
+    }
+    for (size_t i = 0; i < meshes.size(); ++i) {
+        const auto& m = meshes[i];
+        if (m.boneInfluences.size() != m.bindPoseVertices.size()) {
+            SDL_Log("NewRenderer::setSkinnedRig: mesh %zu has %zu verts but %zu bone-influence entries",
+                    i,
+                    m.bindPoseVertices.size(),
+                    m.boneInfluences.size());
+            return false;
+        }
+        if (m.indices.empty()) {
+            SDL_Log("NewRenderer::setSkinnedRig: mesh %zu has zero indices", i);
+            return false;
+        }
+    }
+
+    skinnedNumJoints_ = numJoints;
+    skinnedMeshes_.clear();
+    skinnedMeshes_.reserve(meshes.size());
+
+    // Allocate one big enough transfer buffer to upload any single mesh's data.
+    Uint32 maxUploadBytes = 0;
+    for (const auto& m : meshes) {
+        const Uint32 vBytes = static_cast<Uint32>(m.bindPoseVertices.size() * sizeof(ModelVertex));
+        const Uint32 bBytes = static_cast<Uint32>(m.boneInfluences.size() * sizeof(BoneInfluence));
+        const Uint32 iBytes = static_cast<Uint32>(m.indices.size() * sizeof(uint32_t));
+        maxUploadBytes = std::max({maxUploadBytes, vBytes, bBytes, iBytes});
+    }
+    SDL_GPUTransferBuffer* xfer = Boilerplate::createUploadBuffer(device_, maxUploadBytes);
+    if (!xfer) {
+        SDL_Log("NewRenderer::setSkinnedRig: createUploadBuffer(%u) failed: %s", maxUploadBytes, SDL_GetError());
+        return false;
+    }
+
+    SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device_);
+    SDL_GPUCopyPass* cp = SDL_BeginGPUCopyPass(cmd);
+
+    auto uploadToBuffer = [&](SDL_GPUBuffer* dst, const void* src, Uint32 bytes) {
+        void* mapped = SDL_MapGPUTransferBuffer(device_, xfer, /*cycle=*/true);
+        if (!mapped) return;
+        SDL_memcpy(mapped, src, bytes);
+        SDL_UnmapGPUTransferBuffer(device_, xfer);
+        SDL_GPUTransferBufferLocation s{};
+        s.transfer_buffer = xfer;
+        s.offset = 0;
+        SDL_GPUBufferRegion d{};
+        d.buffer = dst;
+        d.offset = 0;
+        d.size = bytes;
+        SDL_UploadToGPUBuffer(cp, &s, &d, /*cycle=*/false);
+    };
+
+    for (const auto& m : meshes) {
+        SkinnedMesh sm{};
+        sm.vertexCount = static_cast<Uint32>(m.bindPoseVertices.size());
+        sm.indexCount = static_cast<Uint32>(m.indices.size());
+
+        const Uint32 vBytes = sm.vertexCount * sizeof(ModelVertex);
+        const Uint32 bBytes = sm.vertexCount * sizeof(BoneInfluence);
+        const Uint32 iBytes = sm.indexCount * sizeof(uint32_t);
+
+        sm.vb = Boilerplate::createBuffer(device_, vBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
+        sm.boneVb = Boilerplate::createBuffer(device_, bBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
+        sm.ib = Boilerplate::createBuffer(device_, iBytes, SDL_GPU_BUFFERUSAGE_INDEX);
+
+        if (sm.vb && vBytes > 0)
+            uploadToBuffer(sm.vb, m.bindPoseVertices.data(), vBytes);
+        if (sm.boneVb && bBytes > 0)
+            uploadToBuffer(sm.boneVb, m.boneInfluences.data(), bBytes);
+        if (sm.ib && iBytes > 0)
+            uploadToBuffer(sm.ib, m.indices.data(), iBytes);
+
+        skinnedMeshes_.push_back(sm);
+    }
+
+    SDL_EndGPUCopyPass(cp);
+    SDL_SubmitGPUCommandBuffer(cmd);
+    SDL_WaitForGPUIdle(device_);
+
+    SDL_ReleaseGPUTransferBuffer(device_, xfer);
+
+    skinnedRigInstalled_ = true;
+    SDL_Log("NewRenderer: skinned rig installed — %zu mesh(es), %d joints", skinnedMeshes_.size(), numJoints);
+    return true;
+}
+
+void NewRenderer::setSkinnedFrame(const std::vector<glm::mat4>& palette, const std::vector<SkinnedInstance>& instances)
+{
+    framePalette_ = palette;
+    frameInstances_ = instances;
+    skinnedFrameDirty_ = !instances.empty();
+}
+
+bool NewRenderer::ensureSkinnedSSBOs(Uint32 paletteBytes, Uint32 instanceBytes)
+{
+    auto growBuf = [&](SDL_GPUBuffer*& buf, Uint32& cap, Uint32 want, SDL_GPUBufferUsageFlags use) {
+        if (want == 0)
+            return true;
+        if (want > cap) {
+            if (buf)
+                SDL_ReleaseGPUBuffer(device_, buf);
+            SDL_GPUBufferCreateInfo bInfo{};
+            bInfo.usage = use;
+            bInfo.size = want;
+            buf = SDL_CreateGPUBuffer(device_, &bInfo);
+            cap = buf ? want : 0;
+            return buf != nullptr;
+        }
+        return true;
+    };
+    auto growXfer = [&](SDL_GPUTransferBuffer*& xfer, Uint32& cap, Uint32 want) {
+        if (want == 0)
+            return true;
+        if (want > cap) {
+            if (xfer)
+                SDL_ReleaseGPUTransferBuffer(device_, xfer);
+            SDL_GPUTransferBufferCreateInfo tbInfo{};
+            tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+            tbInfo.size = want;
+            xfer = SDL_CreateGPUTransferBuffer(device_, &tbInfo);
+            cap = xfer ? want : 0;
+            return xfer != nullptr;
+        }
+        return true;
+    };
+    if (!growBuf(palettesSSBO_, palettesCapacityBytes_, paletteBytes, SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ))
+        return false;
+    if (!growBuf(instancesSSBO_, instancesCapacityBytes_, instanceBytes, SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ))
+        return false;
+    if (!growXfer(paletteXfer_, paletteXferCapacityBytes_, paletteBytes))
+        return false;
+    if (!growXfer(instanceXfer_, instanceXferCapacityBytes_, instanceBytes))
+        return false;
+    return true;
+}
+
+void NewRenderer::uploadSkinnedFrame(SDL_GPUCommandBuffer* /*cmd*/, SDL_GPUCopyPass* copyPass)
+{
+    if (!skinnedFrameDirty_ || frameInstances_.empty())
+        return;
+
+    const Uint32 paletteBytes = static_cast<Uint32>(framePalette_.size() * sizeof(glm::mat4));
+    const Uint32 instanceBytes = static_cast<Uint32>(frameInstances_.size() * sizeof(SkinnedInstance));
+    if (!ensureSkinnedSSBOs(paletteBytes, instanceBytes))
+        return;
+
+    auto upload = [&](SDL_GPUTransferBuffer* xfer, SDL_GPUBuffer* dst, const void* src, Uint32 bytes) {
+        if (bytes == 0 || !xfer || !dst)
+            return;
+        void* mapped = SDL_MapGPUTransferBuffer(device_, xfer, /*cycle=*/true);
+        if (!mapped)
+            return;
+        SDL_memcpy(mapped, src, bytes);
+        SDL_UnmapGPUTransferBuffer(device_, xfer);
+        SDL_GPUTransferBufferLocation s{};
+        s.transfer_buffer = xfer;
+        s.offset = 0;
+        SDL_GPUBufferRegion d{};
+        d.buffer = dst;
+        d.offset = 0;
+        d.size = bytes;
+        SDL_UploadToGPUBuffer(copyPass, &s, &d, /*cycle=*/false);
+    };
+    upload(paletteXfer_, palettesSSBO_, framePalette_.data(), paletteBytes);
+    upload(instanceXfer_, instancesSSBO_, frameInstances_.data(), instanceBytes);
+}
+
+void NewRenderer::drawSkinnedCharacters(SDL_GPURenderPass* /*renderPass*/, SDL_GPUCommandBuffer* /*cmd*/)
+{
+    // TODO(graphics): instanced GPU skinning draw call.  See `setSkinnedFrame`
+    // doc-block for the full algorithm.  Sketch:
+    //
+    //   if (!skinnedRigInstalled_ || !skinnedPipeline_ || frameInstances_.empty()
+    //       || !palettesSSBO_ || !instancesSSBO_ || !toggles.skinnedCharacters)
+    //       return;
+    //
+    //   SDL_BindGPUGraphicsPipeline(renderPass, skinnedPipeline_);
+    //
+    //   // View+projection already pushed at vertex UBO slot 0 (drawGeometryPass).
+    //
+    //   SDL_GPUBuffer* ssbos[2] = {palettesSSBO_, instancesSSBO_};
+    //   SDL_BindGPUVertexStorageBuffers(renderPass, 0, ssbos, 2);
+    //
+    //   const Uint32 numInstances = static_cast<Uint32>(frameInstances_.size());
+    //   for (const auto& sm : skinnedMeshes_) {
+    //       const SDL_GPUBufferBinding vbs[2] = {
+    //           {.buffer = sm.vb, .offset = 0},
+    //           {.buffer = sm.boneVb, .offset = 0},
+    //       };
+    //       SDL_BindGPUVertexBuffers(renderPass, 0, vbs, 2);
+    //       const SDL_GPUBufferBinding ib = {.buffer = sm.ib, .offset = 0};
+    //       SDL_BindGPUIndexBuffer(renderPass, &ib, SDL_GPU_INDEXELEMENTSIZE_32BIT);
+    //       SDL_DrawGPUIndexedPrimitives(renderPass, sm.indexCount, numInstances, 0, 0, 0);
+    //   }
+    //
+    // Pipeline (`skinnedPipeline_`) needs:
+    //   - vertex buffer 0: ModelVertex (location 0=pos vec3, 1=normal vec3,
+    //     2=texCoord vec2, 3=tangent vec4)
+    //   - vertex buffer 1: BoneInfluence (location 4=boneIndices ivec4,
+    //     5=boneWeights vec4)
+    //   - 2 vertex storage buffers (BonePalette + Instances)
+    //   - 1 vertex UBO (view+proj)
+    //   - depth test on, cull mode NONE (rig may be double-sided)
+    //   - colour target = same as the rest of the geometry pass (currently
+    //     swapchain format; switch to getHdrFormat() when the HDR pass exists).
+    //
+    // Shader pseudocode (`shaders-new/geometry_skinned.vert`):
+    //   InstanceData inst = instances[gl_InstanceIndex];
+    //   mat4 skin = palette[inst.paletteBase + uint(inBoneIndices.x)] * inBoneWeights.x
+    //             + palette[inst.paletteBase + uint(inBoneIndices.y)] * inBoneWeights.y
+    //             + palette[inst.paletteBase + uint(inBoneIndices.z)] * inBoneWeights.z
+    //             + palette[inst.paletteBase + uint(inBoneIndices.w)] * inBoneWeights.w;
+    //   vec4 worldPos = inst.worldTransform * skin * vec4(inPosition, 1.0);
+    //   gl_Position   = viewProjection * worldPos;
 }

--- a/src/client/renderer-new/NewRenderer.cpp
+++ b/src/client/renderer-new/NewRenderer.cpp
@@ -12,10 +12,8 @@
 #include "AssetLoader.hpp"
 #include "Boilerplate.hpp"
 
-#include <algorithm>
 #include <backends/imgui_impl_sdlgpu3.h>
 #include <cstddef>
-#include <cstring>
 #include <filesystem>
 #include <glm/ext/matrix_transform.hpp>
 #include <imgui.h>
@@ -107,6 +105,8 @@ bool NewRenderer::init(SDL_Window* window)
     }
 
     camera_ = NewCamera();
+
+    skinnedRenderer_.init(device_);
 
     return true;
 }
@@ -214,10 +214,10 @@ void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
 
     // Per-frame uploads (skinning palette/instances, etc.) happen BEFORE
     // the first render pass so the copy is sequenced ahead of the draws.
-    if (skinnedFrameDirty_) {
+    {
         SDL_GPUCopyPass* copyPass = SDL_BeginGPUCopyPass(cmd);
         if (copyPass) {
-            uploadSkinnedFrame(cmd, copyPass);
+            skinnedRenderer_.uploadFrame(cmd, copyPass);
             SDL_EndGPUCopyPass(copyPass);
         }
     }
@@ -258,7 +258,7 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
     drawWorldModelInstances(geometryPass, cmd);
     drawEntityModels(geometryPass, cmd);
 
-    drawSkinnedCharacters(geometryPass, cmd);
+    skinnedRenderer_.draw(geometryPass, cmd);
 
     drawWeapon(geometryPass, cmd);
 
@@ -437,35 +437,8 @@ void NewRenderer::quit()
             mesh.iBufferInfo_ = {};
         }
 
-        // Release skinned rig resources.
-        for (auto& sm : skinnedMeshes_) {
-            if (sm.vb)
-                SDL_ReleaseGPUBuffer(device_, sm.vb);
-            if (sm.boneVb)
-                SDL_ReleaseGPUBuffer(device_, sm.boneVb);
-            if (sm.ib)
-                SDL_ReleaseGPUBuffer(device_, sm.ib);
-        }
-        skinnedMeshes_.clear();
-        if (palettesSSBO_)
-            SDL_ReleaseGPUBuffer(device_, palettesSSBO_);
-        if (instancesSSBO_)
-            SDL_ReleaseGPUBuffer(device_, instancesSSBO_);
-        if (paletteXfer_)
-            SDL_ReleaseGPUTransferBuffer(device_, paletteXfer_);
-        if (instanceXfer_)
-            SDL_ReleaseGPUTransferBuffer(device_, instanceXfer_);
-        palettesSSBO_ = nullptr;
-        instancesSSBO_ = nullptr;
-        paletteXfer_ = nullptr;
-        instanceXfer_ = nullptr;
-        palettesCapacityBytes_ = 0;
-        instancesCapacityBytes_ = 0;
-        paletteXferCapacityBytes_ = 0;
-        instanceXferCapacityBytes_ = 0;
+        skinnedRenderer_.shutdown();
 
-        if (skinnedPipeline_)
-            SDL_ReleaseGPUGraphicsPipeline(device_, skinnedPipeline_);
         if (geometryPipeline_)
             SDL_ReleaseGPUGraphicsPipeline(device_, geometryPipeline_);
         if (hudPipeline_)
@@ -488,7 +461,6 @@ void NewRenderer::quit()
 
     geometryPipeline_ = nullptr;
     hudPipeline_ = nullptr;
-    skinnedPipeline_ = nullptr;
     depthTarget_.texture = nullptr;
     texture_ = nullptr;
     sampler_ = nullptr;
@@ -496,9 +468,6 @@ void NewRenderer::quit()
     hudSampler_ = nullptr;
     depthWidth_ = 0;
     depthHeight_ = 0;
-    skinnedRigInstalled_ = false;
-    skinnedNumJoints_ = 0;
-    skinnedFrameDirty_ = false;
 }
 
 // ─── Static models ──────────────────────────────────────────────────────────
@@ -667,231 +636,4 @@ void NewRenderer::scanHDRFiles()
     // TODO(graphics): iterate `assets/hdr/*.hdr` via std::filesystem and fill
     // `availableHDRFiles` with absolute paths.  Called once at init.
     availableHDRFiles.clear();
-}
-
-// ─── Skinned character pipeline ──────────────────────────────────────────────
-
-bool NewRenderer::setSkinnedRig(const std::vector<RigMeshSource>& meshes, int numJoints)
-{
-    if (skinnedRigInstalled_) {
-        SDL_Log("NewRenderer::setSkinnedRig: rig already installed; ignoring repeat call");
-        return false;
-    }
-    if (meshes.empty() || numJoints <= 0) {
-        SDL_Log("NewRenderer::setSkinnedRig: empty meshes or numJoints<=0 (%zu, %d)", meshes.size(), numJoints);
-        return false;
-    }
-    for (size_t i = 0; i < meshes.size(); ++i) {
-        const auto& m = meshes[i];
-        if (m.boneInfluences.size() != m.bindPoseVertices.size()) {
-            SDL_Log("NewRenderer::setSkinnedRig: mesh %zu has %zu verts but %zu bone-influence entries",
-                    i,
-                    m.bindPoseVertices.size(),
-                    m.boneInfluences.size());
-            return false;
-        }
-        if (m.indices.empty()) {
-            SDL_Log("NewRenderer::setSkinnedRig: mesh %zu has zero indices", i);
-            return false;
-        }
-    }
-
-    skinnedNumJoints_ = numJoints;
-    skinnedMeshes_.clear();
-    skinnedMeshes_.reserve(meshes.size());
-
-    // Allocate one big enough transfer buffer to upload any single mesh's data.
-    Uint32 maxUploadBytes = 0;
-    for (const auto& m : meshes) {
-        const Uint32 vBytes = static_cast<Uint32>(m.bindPoseVertices.size() * sizeof(ModelVertex));
-        const Uint32 bBytes = static_cast<Uint32>(m.boneInfluences.size() * sizeof(BoneInfluence));
-        const Uint32 iBytes = static_cast<Uint32>(m.indices.size() * sizeof(uint32_t));
-        maxUploadBytes = std::max({maxUploadBytes, vBytes, bBytes, iBytes});
-    }
-    SDL_GPUTransferBuffer* xfer = Boilerplate::createUploadBuffer(device_, maxUploadBytes);
-    if (!xfer) {
-        SDL_Log("NewRenderer::setSkinnedRig: createUploadBuffer(%u) failed: %s", maxUploadBytes, SDL_GetError());
-        return false;
-    }
-
-    SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device_);
-    SDL_GPUCopyPass* cp = SDL_BeginGPUCopyPass(cmd);
-
-    auto uploadToBuffer = [&](SDL_GPUBuffer* dst, const void* src, Uint32 bytes) {
-        void* mapped = SDL_MapGPUTransferBuffer(device_, xfer, /*cycle=*/true);
-        if (!mapped) return;
-        SDL_memcpy(mapped, src, bytes);
-        SDL_UnmapGPUTransferBuffer(device_, xfer);
-        SDL_GPUTransferBufferLocation s{};
-        s.transfer_buffer = xfer;
-        s.offset = 0;
-        SDL_GPUBufferRegion d{};
-        d.buffer = dst;
-        d.offset = 0;
-        d.size = bytes;
-        SDL_UploadToGPUBuffer(cp, &s, &d, /*cycle=*/false);
-    };
-
-    for (const auto& m : meshes) {
-        SkinnedMesh sm{};
-        sm.vertexCount = static_cast<Uint32>(m.bindPoseVertices.size());
-        sm.indexCount = static_cast<Uint32>(m.indices.size());
-
-        const Uint32 vBytes = sm.vertexCount * sizeof(ModelVertex);
-        const Uint32 bBytes = sm.vertexCount * sizeof(BoneInfluence);
-        const Uint32 iBytes = sm.indexCount * sizeof(uint32_t);
-
-        sm.vb = Boilerplate::createBuffer(device_, vBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
-        sm.boneVb = Boilerplate::createBuffer(device_, bBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
-        sm.ib = Boilerplate::createBuffer(device_, iBytes, SDL_GPU_BUFFERUSAGE_INDEX);
-
-        if (sm.vb && vBytes > 0)
-            uploadToBuffer(sm.vb, m.bindPoseVertices.data(), vBytes);
-        if (sm.boneVb && bBytes > 0)
-            uploadToBuffer(sm.boneVb, m.boneInfluences.data(), bBytes);
-        if (sm.ib && iBytes > 0)
-            uploadToBuffer(sm.ib, m.indices.data(), iBytes);
-
-        skinnedMeshes_.push_back(sm);
-    }
-
-    SDL_EndGPUCopyPass(cp);
-    SDL_SubmitGPUCommandBuffer(cmd);
-    SDL_WaitForGPUIdle(device_);
-
-    SDL_ReleaseGPUTransferBuffer(device_, xfer);
-
-    skinnedRigInstalled_ = true;
-    SDL_Log("NewRenderer: skinned rig installed — %zu mesh(es), %d joints", skinnedMeshes_.size(), numJoints);
-    return true;
-}
-
-void NewRenderer::setSkinnedFrame(const std::vector<glm::mat4>& palette, const std::vector<SkinnedInstance>& instances)
-{
-    framePalette_ = palette;
-    frameInstances_ = instances;
-    skinnedFrameDirty_ = !instances.empty();
-}
-
-bool NewRenderer::ensureSkinnedSSBOs(Uint32 paletteBytes, Uint32 instanceBytes)
-{
-    auto growBuf = [&](SDL_GPUBuffer*& buf, Uint32& cap, Uint32 want, SDL_GPUBufferUsageFlags use) {
-        if (want == 0)
-            return true;
-        if (want > cap) {
-            if (buf)
-                SDL_ReleaseGPUBuffer(device_, buf);
-            SDL_GPUBufferCreateInfo bInfo{};
-            bInfo.usage = use;
-            bInfo.size = want;
-            buf = SDL_CreateGPUBuffer(device_, &bInfo);
-            cap = buf ? want : 0;
-            return buf != nullptr;
-        }
-        return true;
-    };
-    auto growXfer = [&](SDL_GPUTransferBuffer*& xfer, Uint32& cap, Uint32 want) {
-        if (want == 0)
-            return true;
-        if (want > cap) {
-            if (xfer)
-                SDL_ReleaseGPUTransferBuffer(device_, xfer);
-            SDL_GPUTransferBufferCreateInfo tbInfo{};
-            tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
-            tbInfo.size = want;
-            xfer = SDL_CreateGPUTransferBuffer(device_, &tbInfo);
-            cap = xfer ? want : 0;
-            return xfer != nullptr;
-        }
-        return true;
-    };
-    if (!growBuf(palettesSSBO_, palettesCapacityBytes_, paletteBytes, SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ))
-        return false;
-    if (!growBuf(instancesSSBO_, instancesCapacityBytes_, instanceBytes, SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ))
-        return false;
-    if (!growXfer(paletteXfer_, paletteXferCapacityBytes_, paletteBytes))
-        return false;
-    if (!growXfer(instanceXfer_, instanceXferCapacityBytes_, instanceBytes))
-        return false;
-    return true;
-}
-
-void NewRenderer::uploadSkinnedFrame(SDL_GPUCommandBuffer* /*cmd*/, SDL_GPUCopyPass* copyPass)
-{
-    if (!skinnedFrameDirty_ || frameInstances_.empty())
-        return;
-
-    const Uint32 paletteBytes = static_cast<Uint32>(framePalette_.size() * sizeof(glm::mat4));
-    const Uint32 instanceBytes = static_cast<Uint32>(frameInstances_.size() * sizeof(SkinnedInstance));
-    if (!ensureSkinnedSSBOs(paletteBytes, instanceBytes))
-        return;
-
-    auto upload = [&](SDL_GPUTransferBuffer* xfer, SDL_GPUBuffer* dst, const void* src, Uint32 bytes) {
-        if (bytes == 0 || !xfer || !dst)
-            return;
-        void* mapped = SDL_MapGPUTransferBuffer(device_, xfer, /*cycle=*/true);
-        if (!mapped)
-            return;
-        SDL_memcpy(mapped, src, bytes);
-        SDL_UnmapGPUTransferBuffer(device_, xfer);
-        SDL_GPUTransferBufferLocation s{};
-        s.transfer_buffer = xfer;
-        s.offset = 0;
-        SDL_GPUBufferRegion d{};
-        d.buffer = dst;
-        d.offset = 0;
-        d.size = bytes;
-        SDL_UploadToGPUBuffer(copyPass, &s, &d, /*cycle=*/false);
-    };
-    upload(paletteXfer_, palettesSSBO_, framePalette_.data(), paletteBytes);
-    upload(instanceXfer_, instancesSSBO_, frameInstances_.data(), instanceBytes);
-}
-
-void NewRenderer::drawSkinnedCharacters(SDL_GPURenderPass* /*renderPass*/, SDL_GPUCommandBuffer* /*cmd*/)
-{
-    // TODO(graphics): instanced GPU skinning draw call.  See `setSkinnedFrame`
-    // doc-block for the full algorithm.  Sketch:
-    //
-    //   if (!skinnedRigInstalled_ || !skinnedPipeline_ || frameInstances_.empty()
-    //       || !palettesSSBO_ || !instancesSSBO_ || !toggles.skinnedCharacters)
-    //       return;
-    //
-    //   SDL_BindGPUGraphicsPipeline(renderPass, skinnedPipeline_);
-    //
-    //   // View+projection already pushed at vertex UBO slot 0 (drawGeometryPass).
-    //
-    //   SDL_GPUBuffer* ssbos[2] = {palettesSSBO_, instancesSSBO_};
-    //   SDL_BindGPUVertexStorageBuffers(renderPass, 0, ssbos, 2);
-    //
-    //   const Uint32 numInstances = static_cast<Uint32>(frameInstances_.size());
-    //   for (const auto& sm : skinnedMeshes_) {
-    //       const SDL_GPUBufferBinding vbs[2] = {
-    //           {.buffer = sm.vb, .offset = 0},
-    //           {.buffer = sm.boneVb, .offset = 0},
-    //       };
-    //       SDL_BindGPUVertexBuffers(renderPass, 0, vbs, 2);
-    //       const SDL_GPUBufferBinding ib = {.buffer = sm.ib, .offset = 0};
-    //       SDL_BindGPUIndexBuffer(renderPass, &ib, SDL_GPU_INDEXELEMENTSIZE_32BIT);
-    //       SDL_DrawGPUIndexedPrimitives(renderPass, sm.indexCount, numInstances, 0, 0, 0);
-    //   }
-    //
-    // Pipeline (`skinnedPipeline_`) needs:
-    //   - vertex buffer 0: ModelVertex (location 0=pos vec3, 1=normal vec3,
-    //     2=texCoord vec2, 3=tangent vec4)
-    //   - vertex buffer 1: BoneInfluence (location 4=boneIndices ivec4,
-    //     5=boneWeights vec4)
-    //   - 2 vertex storage buffers (BonePalette + Instances)
-    //   - 1 vertex UBO (view+proj)
-    //   - depth test on, cull mode NONE (rig may be double-sided)
-    //   - colour target = same as the rest of the geometry pass (currently
-    //     swapchain format; switch to getHdrFormat() when the HDR pass exists).
-    //
-    // Shader pseudocode (`shaders-new/geometry_skinned.vert`):
-    //   InstanceData inst = instances[gl_InstanceIndex];
-    //   mat4 skin = palette[inst.paletteBase + uint(inBoneIndices.x)] * inBoneWeights.x
-    //             + palette[inst.paletteBase + uint(inBoneIndices.y)] * inBoneWeights.y
-    //             + palette[inst.paletteBase + uint(inBoneIndices.z)] * inBoneWeights.z
-    //             + palette[inst.paletteBase + uint(inBoneIndices.w)] * inBoneWeights.w;
-    //   vec4 worldPos = inst.worldTransform * skin * vec4(inPosition, 1.0);
-    //   gl_Position   = viewProjection * worldPos;
 }

--- a/src/client/renderer-new/NewRenderer.hpp
+++ b/src/client/renderer-new/NewRenderer.hpp
@@ -1,5 +1,16 @@
 /// @file NewRenderer.hpp
 /// @brief Work-in-progress SDL3 GPU renderer.
+///
+/// API surface restored from the legacy renderer so gameplay code has a stable
+/// contract to call against while graphics team fills in implementations.  Most
+/// `set*()` methods are currently DATA-CAPTURE STUBS — they store inputs into
+/// member fields and DO NOT yet drive the GPU.  Each stub's doc comment lists:
+///   * what the inputs mean,
+///   * what the implementation should produce on-screen,
+///   * which member field holds the captured data,
+///   * where the data comes from (call site).
+///
+/// Search the cpp for `TODO(graphics)` to find every stub awaiting work.
 
 #pragma once
 
@@ -12,7 +23,15 @@
 
 #include <glm/glm.hpp>
 #include <string>
+#include <vector>
 
+class ParticleSystem; ///< Forward-declared — owned by Game, registered via setParticleSystem().
+
+/// @brief Vertex attribute layout for the static geometry pipeline.
+///
+/// 32 bytes: position (12) + normal (12) + texUV (8).  NOTE: this is DISTINCT
+/// from `ModelVertex` (48 bytes, includes tangent) used by the skinned-rig
+/// pipeline.  Static meshes use this; skinned characters use `ModelVertex`.
 struct Vertex
 {
     glm::vec3 position;
@@ -22,90 +41,441 @@ struct Vertex
 
 /// @brief Graphics-team's work-in-progress SDL3 GPU renderer.
 ///
-/// Shaders: `shaders-new/geometry.vert` + `shaders-new/geometry.frag`.
+/// Pass architecture (target — current implementation only covers a subset):
+///   Pass 0 — Shadow map        (depth-only directional, cascaded)         [TODO]
+///   Pass 1 — Skybox            (procedural / cubemap)                     [TODO]
+///   Pass 2 — Geometry          (static models + entity models + weapon)   [partial]
+///   Pass 3 — Skinned chars     (instanced GPU LBS for players)            [TODO]
+///   Pass 4 — Particles         (delegated to ParticleSystem::render)      [TODO]
+///   Pass 5 — Post (SSAO/bloom/SSR/volumetrics/tonemap)                    [TODO]
+///   Pass 6 — HUD + ImGui                                                  [partial]
+///
+/// Shaders: `shaders-new/geometry.{vert,frag}` + `shaders-new/hud.{vert,frag}`.
+/// Graphics team adds new shaders alongside these as features come online.
 class NewRenderer
 {
 public:
+    // ─── Lifecycle ───────────────────────────────────────────────────────────
+
+    /// @brief Initialise the GPU device, pipelines, and default scene assets.
+    /// @param window  SDL window to render into.
+    /// @return True on success.
     bool init(SDL_Window* window);
+
+    /// @brief Render one frame from the given camera pose.
+    /// @param eye    Camera world position.
+    /// @param yaw    Horizontal rotation in radians.
+    /// @param pitch  Vertical rotation in radians.
+    /// @param roll   Camera roll in radians (default 0).
+    ///
+    /// Reads all per-frame state previously captured by `set*()` calls.  Game
+    /// code is expected to call every relevant setter BEFORE calling drawFrame.
     void drawFrame(glm::vec3 eye, float yaw, float pitch, float roll);
+
+    /// @brief Release all GPU resources and shut down the renderer.
     void quit();
 
-    [[nodiscard]] SDL_GPUDevice* getDevice() const { return device_; }
-    [[nodiscard]] SDL_GPUShaderFormat getShaderFormat() const { return shaderFormat_; }
-    [[nodiscard]] const NewCamera& getCamera() const { return camera_; }
-    void setHudTexture(SDL_GPUTexture* hudTexture);
+    // ─── Readback (must return real values — gameplay depends on them) ───────
 
+    /// @brief Returns the SDL GPU device.  Valid between `init()` and `quit()`.
+    ///
+    /// Used by sub-renderers (`ParticleSystem`, `HudRenderer`) and tests that
+    /// need to allocate GPU resources on the same device.
+    [[nodiscard]] SDL_GPUDevice* getDevice() const { return device_; }
+
+    /// @brief Shader format selected during `init()` (SPIR-V on Vulkan, MSL on Metal, DXIL on D3D12).
+    ///
+    /// Sub-renderers consult this to pick the right precompiled shader binary.
+    [[nodiscard]] SDL_GPUShaderFormat getShaderFormat() const { return shaderFormat_; }
+
+    /// @brief Current camera (updated every `drawFrame` call).
+    ///
+    /// Game code reads this for projection-dependent operations: picking,
+    /// reticle world-ray, frustum culling, etc.  Caller must not mutate.
+    [[nodiscard]] const NewCamera& getCamera() const { return camera_; }
+
+    /// @brief Number of models currently registered in the asset map.
+    ///
+    /// Used by the debug UI to display loaded-model counts.  Backed by
+    /// `Asset::models_`, which is populated by `loadSceneModel()`.
+    [[nodiscard]] int modelCount() const;
+
+    /// @brief Format of the HDR colour render target.
+    ///
+    /// Sub-renderers that render INTO the main HDR pass (particles, beams,
+    /// glow) must declare this as their pipeline's colour target format.
+    /// Returning RGBA16F matches the legacy renderer; graphics team may
+    /// change this if they pick a different intermediate format, BUT must
+    /// update every sub-renderer pipeline to match.
+    [[nodiscard]] static constexpr SDL_GPUTextureFormat getHdrFormat()
+    {
+        return SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT;
+    }
+
+    /// @brief Most-recent `SDL_AcquireGPUCommandBuffer` cost in milliseconds.
+    ///
+    /// Captured by `drawFrame()`.  Read by the debug HUD's frame-timing panel.
+    [[nodiscard]] float getLastAcquireMs() const { return lastAcquireMs_; }
+
+    /// @brief Most-recent command-recording cost (between acquire and submit) in ms.
+    [[nodiscard]] float getLastRecordMs() const { return lastRecordMs_; }
+
+    /// @brief Most-recent `SDL_SubmitGPUCommandBuffer` cost in milliseconds.
+    [[nodiscard]] float getLastSubmitMs() const { return lastSubmitMs_; }
+
+    // ─── Per-frame submit setters (data-capture stubs) ───────────────────────
+    //
+    // Called by Game.cpp every frame BEFORE drawFrame.  Each stores the
+    // payload into a member field; drawFrame reads it.  Currently most of
+    // these have no consumer — the data is captured but nothing renders.
+
+    /// @brief Set the list of entity render commands for this frame.
+    /// @param entityList  One entry per visible static/dynamic entity.  Moved-in.
+    ///
+    /// IMPLEMENTATION: Currently captures into `entities_` and the existing
+    /// `drawEntityModels()` loop draws them with the geometry pipeline.  When
+    /// adding lighting/tinting/material variation this is the call site whose
+    /// data needs to surface in the shader.
+    ///
+    /// DATA SOURCE: built in Game.cpp's draw-list builder from ECS view
+    /// `<Position, Velocity, Renderable, ...>` per frame.
+    void setEntityRenderList(std::vector<EntityRenderCmd>&& entityList);
+
+    /// @brief Set dynamic point lights for this frame.
+    /// @param pointLights  Up to ~6 lights; renderer may cap silently.
+    ///
+    /// IMPLEMENTATION: store in `pointLights_`, then push as a UBO array to
+    /// the PBR fragment shader during the geometry pass.  Currently a no-op
+    /// stub — `pointLights_` is captured but never read.
+    ///
+    /// DATA SOURCE: built in Game.cpp from ECS each frame (glow-emitting
+    /// projectiles, muzzle flashes, etc).
+    void setPointLights(std::vector<PointLight> pointLights);
+
+    /// @brief Set the first-person weapon viewmodel for this frame.
+    /// @param vm  Model handle + viewmodel-space transform + visibility.
+    ///
+    /// IMPLEMENTATION: Captured into `weapon_`.  `drawWeapon()` reads it and
+    /// issues a draw call with the existing geometry pipeline.  Note: the
+    /// viewmodel is drawn LAST so it sits on top of the world (no depth
+    /// fighting with map geometry near the camera).
+    ///
+    /// DATA SOURCE: Game.cpp's `runWeaponViewmodel()` step, which composes
+    /// the transform from camera state + recoil/sway curves.
     void setWeaponViewmodel(const WeaponViewmodel& vm);
 
-    int loadSceneModel(
-        const char* filename, glm::vec3 pos, float scale, bool flipUVs, const std::string& excludeNodesContaining = "");
-
-    void setPointLights(std::vector<PointLight> pointLights);
-    void setEntityRenderList(std::vector<EntityRenderCmd>&& entityList);
+    /// @brief Override the emissive colour of every mesh in a registered model.
+    /// @param modelIdUnsanitized  Index returned by `loadSceneModel`/`uploadSceneModel`.
+    /// @param emissiveColor       RGB = emissive linear colour, A = ignored.
+    ///
+    /// IMPLEMENTATION: store overrides keyed by modelIndex in a map; consult
+    /// the map when building per-mesh material UBOs inside `drawModel()`.
+    /// Currently a no-op.
+    ///
+    /// DATA SOURCE: Game.cpp uses this to pulse beam/cylinder/sphere glow
+    /// (`Game.cpp` legacy: `renderer.setModelEmissive(glowCylinderModelIdx_, ...)`).
     void setModelEmissive(int32_t modelIdUnsanitized, glm::vec4 emissiveColor);
 
+    /// @brief Toggle whether a model is drawn during the scene pass.
+    /// @param modelIndex   Renderer-side handle.
+    /// @param drawInScene  true = draw as static world geometry; false = only via EntityRenderCmd.
+    ///
+    /// IMPLEMENTATION: sets `Asset::ModelInstance::drawInScenePass` on every
+    /// instance backed by `modelIndex`.  The scene-pass loop in `drawWorldModelInstances`
+    /// already honours this flag.
+    ///
+    /// DATA SOURCE: Game.cpp calls this once per static map asset right after
+    /// `loadSceneModel`.
+    void setModelScenePass(int32_t modelIndex, bool drawInScene);
+
+    // ─── Skinned characters (animated players) ───────────────────────────────
+    //
+    // Two-call interface mirroring the legacy renderer:
+    //   - setSkinnedRig() ONCE at startup → uploads bind-pose mesh + bone-
+    //     influence buffer; allocates per-frame SSBOs.
+    //   - setSkinnedFrame() EVERY FRAME → uploads a flat bone palette + a
+    //     parallel per-instance buffer (worldTransform, paletteBase, tint).
+    //
+    // CURRENT STATE:
+    //   - setSkinnedRig: IMPLEMENTED (GPU upload of mesh + influences).
+    //   - setSkinnedFrame: IMPLEMENTED (uploads palette+instance SSBOs each frame).
+    //   - The actual instanced draw call: NOT IMPLEMENTED (skinnedPipeline_ is null).
+    //
+    // To bring skinned characters to screen, graphics team needs to:
+    //   1. Add shaders/skinned vertex+fragment (LBS in vertex shader, sample
+    //      bonePalette SSBO indexed by paletteBase + boneIndex).
+    //   2. Create `skinnedPipeline_` (two vertex buffers: ModelVertex + BoneInfluence;
+    //      two SSBOs as vertex storage; one UBO for view/proj).
+    //   3. Implement `drawSkinnedCharacters()` (called from drawFrame between
+    //      static geometry and the weapon — see the placeholder in cpp).
+    //   4. Test by spawning multiple players; one instanced draw per rig mesh
+    //      should render all of them.
+
+    /// @brief Install the shared skinned-character rig.  Call ONCE after `init()`.
+    /// @param meshes     One source-mesh entry per skinned mesh in the rig (typically 1-3 for humanoid rigs).
+    /// @param numJoints  Number of skeleton joints.  Determines per-instance palette stride.
+    /// @return True on success.  False if already installed, or upload failed.
+    ///
+    /// IMPLEMENTATION (real, already wired):
+    ///   - Iterates `meshes`, creating two GPU vertex buffers per mesh:
+    ///       slot 0: bind-pose vertices (`ModelVertex`, 48 bytes/vert)
+    ///       slot 1: bone influences  (`BoneInfluence`, 32 bytes/vert)
+    ///     plus an index buffer.  Saves them in `skinnedMeshes_`.
+    ///   - Stores `numJoints` in `skinnedNumJoints_`; sets `skinnedRigInstalled_`.
+    ///   - Does NOT allocate the palette/instance SSBOs — those are grown
+    ///     lazily on the first `setSkinnedFrame` call.
+    ///
+    /// DATA SOURCE: Game.cpp builds `vector<RigMeshSource>` from
+    /// `CharacterRig::meshes()` (animation/CharacterRig.hpp) once after the
+    /// rig FBX loads.  See `RigMeshSource` in RendererTypes.hpp for the layout.
+    bool setSkinnedRig(const std::vector<RigMeshSource>& meshes, int numJoints);
+
+    /// @brief Push this frame's per-character bone palette + per-instance data.
+    /// @param palette    Flat array, sized `numInstances * numJoints` (mat4 each).
+    /// @param instances  One entry per visible character.  `paletteBase` of entry
+    ///                   `i` MUST equal `i * numJoints` so the shader's index math works.
+    ///
+    /// IMPLEMENTATION (real, already wired):
+    ///   - Copies both vectors into CPU-side staging (`framePalette_`, `frameInstances_`).
+    ///   - During `drawFrame` (before the geometry pass), uploads them into
+    ///     `palettesSSBO_` and `instancesSSBO_` via transfer buffers with
+    ///     cycle=true (so we don't stall on last frame's GPU read).
+    ///   - SSBOs grow on demand if more instances/joints appear than fit.
+    ///
+    /// DATA SOURCE: Game.cpp's per-frame animation block (parallel walk of
+    /// ECS view `<AnimatedCharacter, Position, Velocity, PlayerVisState,
+    /// InputSnapshot>`):
+    ///   1. For each visible character compute `worldTransform = T(pos)*R(yaw)*S(scale)`.
+    ///   2. `palette[slot * numJoints .. (slot+1) * numJoints] = animator.skinMatrices()`.
+    ///   3. `instances[slot] = {worldTransform, paletteBase=slot*numJoints, tint}`.
+    ///
+    /// CONSUMER: the (not-yet-written) skinned vertex shader reads
+    ///   `instances[gl_InstanceIndex]` for worldTransform + paletteBase
+    ///   `palette[paletteBase + boneIndices.k]` weighted by `boneWeights.k`.
+    void setSkinnedFrame(const std::vector<glm::mat4>& palette, const std::vector<SkinnedInstance>& instances);
+
+    // ─── Static models ───────────────────────────────────────────────────────
+
+    /// @brief Load a model from disk and register it in `Asset::models_` + create a default scene instance.
+    /// @param filename                Path under the assets dir.
+    /// @param pos                     World position of the default scene instance.
+    /// @param scale                   Uniform scale of the default scene instance.
+    /// @param flipUVs                 True to flip V coordinate on import (glTF vs DCC convention).
+    /// @param excludeNodesContaining  (Unused on main today.)  Substring filter to drop collision-only nodes.
+    /// @return Index into `Asset::modelInstances_` (-1 on failure).  Game.cpp stashes this and uses it as a handle.
+    ///
+    /// IMPLEMENTATION (real):  delegates to `AssetLoader::loadModel`, then
+    /// creates an `Asset::ModelInstance` at `pos`, then uploads mesh VB/IB.
+    /// See cpp.
+    ///
+    /// DATA SOURCE: Game.cpp's init phase, once per map asset.
+    int loadSceneModel(const char* filename,
+                       glm::vec3 pos,
+                       float scale,
+                       bool flipUVs,
+                       const std::string& excludeNodesContaining = "");
+
+    /// @brief Set the HUD overlay texture to blit after the geometry pass.
+    /// @param hudTexture  HUD's final colour texture (RGBA8 swap-chain-format).  May be null = no HUD.
+    ///
+    /// IMPLEMENTATION (real): captured into `hudTexture_`; `drawHud()` samples
+    /// it in the UI pass.  Sampling is `linear repeat` via `hudSampler_`.
+    ///
+    /// DATA SOURCE: `Hud::getOutputTexture()` after `Hud::draw()` populates it.
+    void setHudTexture(SDL_GPUTexture* hudTexture);
+
+    // ─── Subsystem registration ─────────────────────────────────────────────
+
+    /// @brief Register the particle system so the renderer can call its render hooks.
+    /// @param ps  Pointer to ParticleSystem owned by Game.  May be null = disable particles.
+    ///
+    /// IMPLEMENTATION: store in `particleSystem_`.  During `drawFrame`, the
+    /// renderer should call (in this order, inside the main HDR pass):
+    ///   ps->uploadToGpu(cmd);     // BEFORE the render pass begins
+    ///   ps->render(pass, cmd);    // INSIDE the HDR render pass
+    /// Currently a no-op pointer-only stub.
+    ///
+    /// DATA SOURCE: Game.cpp owns the `ParticleSystem` instance and registers
+    /// it once after `particleSystem.init(...)` succeeds.
+    void setParticleSystem(ParticleSystem* ps);
+
+    // ─── Settings / toggles ─────────────────────────────────────────────────
+
+    /// @brief Enable or disable vertical sync.
+    /// @param enabled  True = VSync on (capped at refresh rate); false = uncapped.
+    /// @return True on success.
+    ///
+    /// IMPLEMENTATION: call `SDL_SetGPUSwapchainParameters` with
+    /// `SDL_GPU_PRESENTMODE_VSYNC` vs `SDL_GPU_PRESENTMODE_IMMEDIATE` (or
+    /// `MAILBOX` for adaptive).  Currently a no-op — stores `vsyncEnabled_`
+    /// but doesn't apply.
+    ///
+    /// DATA SOURCE: Game.cpp toggles this when entering/leaving menus or via
+    /// debug UI.
+    bool setVSync(bool enabled);
+
+    /// @brief Request a screenshot to be saved to disk after the next frame.
+    /// @param path  Output file path (PNG).
+    ///
+    /// IMPLEMENTATION: after `drawFrame`'s submit + present, read back the
+    /// swapchain texture into a transfer buffer, map it CPU-side, write a PNG
+    /// via `stbi_write_png`.  Currently a no-op — `pendingScreenshotPath_`
+    /// is captured but not consumed.
+    ///
+    /// DATA SOURCE: debug UI hotkey / console command.
+    void requestScreenshot(const std::string& path);
+
+    /// @brief Queue a vertex-buffer re-upload for one mesh of a loaded model.
+    /// @param modelIndex  Renderer-side model handle.
+    /// @param meshIndex   Mesh index within that model.
+    /// @param vertices    New vertex data (caller retains ownership — copy if needed).
+    /// @param vertexCount Number of vertices in `vertices`.
+    ///
+    /// IMPLEMENTATION: legacy used this for CPU-skinning entity meshes (now
+    /// superseded by `setSkinnedFrame`).  May not need to come back; leave as
+    /// a no-op stub for API parity.  If a use-case re-emerges, do the copy
+    /// inside the next `drawFrame`'s copy pass.
+    ///
+    /// DATA SOURCE: legacy CPU LBS path (now defunct).  No current call site.
+    void updateModelMeshVertices(int modelIndex, int meshIndex, const Vertex* vertices, Uint32 vertexCount);
+
+    /// @brief Load an equirectangular HDR image as the environment skybox + IBL source.
+    /// @param path  Absolute or assets-relative path to a .hdr file.
+    /// @return True on success.
+    ///
+    /// IMPLEMENTATION: load via stb_image (float), upload as a 2D HDR texture,
+    /// run an equirect→cubemap compute pass, derive the irradiance + prefilter
+    /// cubemaps for IBL.  Currently a no-op stub.
+    ///
+    /// DATA SOURCE: debug UI's HDR picker — user selects from `availableHDRFiles_`.
+    bool loadHDRSkybox(const std::string& path);
+
+    /// @brief Scan the assets HDR directory and populate `availableHDRFiles_`.
+    ///
+    /// IMPLEMENTATION: iterate `assets/hdr/*.hdr` via std::filesystem, fill
+    /// the vector with the paths.  Currently a no-op.
+    ///
+    /// DATA SOURCE: called once at init; debug UI reads `availableHDRFiles_`
+    /// to populate its dropdown.
+    void scanHDRFiles();
+
+    // ─── Public settings members (mutable directly from Game / debug UI) ─────
+    //
+    // The legacy renderer exposed these as direct member access.  Keep the
+    // pattern so Game.cpp and the debug UI can read/write without a getter
+    // ceremony.
+
+    AAMode aaMode = AAMode::SMAA_T2x;          ///< Anti-aliasing mode.  Re-applied at the start of each frame.
+    float renderScale = 1.0f;                  ///< Internal-resolution multiplier (0.5 = half-res, 2.0 = SSAA).
+    bool imguiEnabled = true;                  ///< Master toggle for the ImGui debug overlay.
+    RenderToggles toggles{};                   ///< Per-pass on/off toggles (see RenderToggles in RendererTypes.hpp).
+    std::vector<std::string> availableHDRFiles;///< Filled by `scanHDRFiles()`; consumed by debug UI.
+    std::string currentHDRName = "(procedural)"; ///< Display name of the currently-loaded HDR.
+    bool useHDRSkybox = false;                 ///< True after a successful `loadHDRSkybox()`.
+
 private:
+    // ─── Existing internal helpers ───────────────────────────────────────────
+
+    bool createGeometryPipeline();
+    bool createHudPipeline();
+    bool ensureDepthTextureSize(Uint32 width, Uint32 height);
+    void createMeshBuffers(MeshIdInt meshId) const;
+    void setMainCamera(glm::vec3 eye, float yaw, float pitch, float roll, Uint32 width, Uint32 height);
+    void drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd);
+    void drawUIPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd);
+    void drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
+    void drawWeapon(SDL_GPURenderPass* geometryPass, SDL_GPUCommandBuffer* cmd);
+    void drawModel(ModelIdInt modelId,
+                   const glm::mat4& modelTransform,
+                   SDL_GPURenderPass* renderPass,
+                   SDL_GPUCommandBuffer* cmd);
+    void drawEntityModels(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
+    void drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh) const;
+    void drawHud(SDL_GPURenderPass* pass);
+
+    // ─── Skinned-character internals (NEW) ───────────────────────────────────
+
+    /// @brief One mesh of the installed skinned rig.  Built by `setSkinnedRig`.
+    ///
+    /// `vb` carries `ModelVertex` (48-byte bind-pose vertices) at vertex buffer slot 0.
+    /// `boneVb` carries `BoneInfluence` (32-byte index+weight) at vertex buffer slot 1.
+    /// Both are parallel arrays — vertex `i` of `vb` uses bone influences `i` of `boneVb`.
+    struct SkinnedMesh
+    {
+        SDL_GPUBuffer* vb = nullptr;
+        SDL_GPUBuffer* boneVb = nullptr;
+        SDL_GPUBuffer* ib = nullptr;
+        Uint32 indexCount = 0;
+        Uint32 vertexCount = 0;
+    };
+
+    /// @brief Per-frame palette+instance upload.  Called from `drawFrame` before begin-render-pass.
+    /// @param cmd       Frame command buffer.
+    /// @param copyPass  An open copy pass on `cmd`.
+    void uploadSkinnedFrame(SDL_GPUCommandBuffer* cmd, SDL_GPUCopyPass* copyPass);
+
+    /// @brief Grow palette/instance SSBOs (and their transfer buffers) to at least these byte sizes.
+    bool ensureSkinnedSSBOs(Uint32 paletteBytes, Uint32 instanceBytes);
+
+    /// @brief Issue the instanced draws for every skinned character.
+    ///
+    /// TODO(graphics): Currently a no-op placeholder.  See the doc on
+    /// `setSkinnedFrame` for the algorithm to implement.
+    void drawSkinnedCharacters(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
+
+    // ─── Member state ────────────────────────────────────────────────────────
+
     SDL_Window* window_ = nullptr;
     SDL_GPUDevice* device_ = nullptr;
     SDL_GPUShaderFormat shaderFormat_ = SDL_GPU_SHADERFORMAT_INVALID;
 
     SDL_GPUGraphicsPipeline* geometryPipeline_ = nullptr;
     SDL_GPUGraphicsPipeline* hudPipeline_ = nullptr;
+    SDL_GPUGraphicsPipeline* skinnedPipeline_ = nullptr; ///< TODO(graphics): create in init (or lazily on first skinned frame).
 
-    // SDL_GPUTexture* depthTexture_ = nullptr;
     SDL_GPUDepthStencilTargetInfo depthTarget_{};
+    Uint32 depthWidth_ = 0;
+    Uint32 depthHeight_ = 0;
 
-    // Temp for single texture
+    // Default fallback texture used when a mesh has no material/texture.
     SDL_GPUTexture* texture_ = nullptr;
     SDL_GPUSampler* sampler_ = nullptr;
 
     SDL_GPUTexture* hudTexture_ = nullptr;
     SDL_GPUSampler* hudSampler_ = nullptr;
 
-    Uint32 depthWidth_ = 0;
-    Uint32 depthHeight_ = 0;
-
     NewCamera camera_;
 
+    // Per-frame captured state ───────────────────────────────────────────────
     std::vector<EntityRenderCmd> entities_;
-    WeaponViewmodel weapon_;
+    WeaponViewmodel weapon_{};
+    std::vector<PointLight> pointLights_;
+    ParticleSystem* particleSystem_ = nullptr;
 
-    /// @brief Build the geometry graphics pipeline from vertex/fragment shaders.
-    /// @return True on success.
-    bool createGeometryPipeline();
+    // Settings captured state ─────────────────────────────────────────────────
+    bool vsyncEnabled_ = true;
+    std::string pendingScreenshotPath_;
 
-    bool createHudPipeline();
+    // Skinned-rig state ──────────────────────────────────────────────────────
+    bool skinnedRigInstalled_ = false;
+    int skinnedNumJoints_ = 0;
+    std::vector<SkinnedMesh> skinnedMeshes_;
 
-    /// @brief (Re-)create the depth texture if the viewport size changed.
-    /// @param width  New viewport width in pixels.
-    /// @param height New viewport height in pixels.
-    /// @return True on success.
-    bool ensureDepthTextureSize(Uint32 width, Uint32 height);
+    SDL_GPUBuffer* palettesSSBO_ = nullptr;          ///< STORAGE_READ, mat4[numInstances * numJoints].
+    SDL_GPUBuffer* instancesSSBO_ = nullptr;         ///< STORAGE_READ, SkinnedInstance[numInstances].
+    Uint32 palettesCapacityBytes_ = 0;
+    Uint32 instancesCapacityBytes_ = 0;
+    SDL_GPUTransferBuffer* paletteXfer_ = nullptr;
+    SDL_GPUTransferBuffer* instanceXfer_ = nullptr;
+    Uint32 paletteXferCapacityBytes_ = 0;
+    Uint32 instanceXferCapacityBytes_ = 0;
 
-    /// @brief Allocate GPU vertex and index buffers for the given mesh.
-    /// @param meshId Key into Asset::meshes_.
-    void createMeshBuffers(MeshIdInt meshId) const;
+    std::vector<glm::mat4> framePalette_;            ///< CPU staging for the next frame's palette.
+    std::vector<SkinnedInstance> frameInstances_;    ///< CPU staging for the next frame's instances.
+    bool skinnedFrameDirty_ = false;                 ///< True when CPU data has changed since last upload.
 
-    void drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd);
-
-    void drawUIPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd);
-
-    void drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
-
-    void drawWeapon(SDL_GPURenderPass* geometryPass, SDL_GPUCommandBuffer* cmd);
-
-    void drawModel(ModelIdInt modelId,
-                   const glm::mat4& modelTransform,
-                   SDL_GPURenderPass* renderPass,
-                   SDL_GPUCommandBuffer* cmd);
-    void drawEntityModels(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
-
-    /// @brief Bind a mesh's buffers and issue an indexed draw call.
-    /// @param renderPass The active render pass.
-    /// @param mesh The mesh to draw.
-    void drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh) const;
-
-    void drawHud(SDL_GPURenderPass* pass);
-
-    void setMainCamera(glm::vec3 eye, float yaw, float pitch, float roll, Uint32 width, Uint32 height);
+    // Telemetry counters (filled by drawFrame) ────────────────────────────────
+    float lastAcquireMs_ = 0.0f;
+    float lastRecordMs_ = 0.0f;
+    float lastSubmitMs_ = 0.0f;
 };

--- a/src/client/renderer-new/NewRenderer.hpp
+++ b/src/client/renderer-new/NewRenderer.hpp
@@ -17,6 +17,7 @@
 #include "Asset.hpp"
 #include "Camera.hpp"
 #include "RendererTypes.hpp"
+#include "SkinnedRenderer.hpp"
 
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_gpu.h>
@@ -190,69 +191,24 @@ public:
 
     // ─── Skinned characters (animated players) ───────────────────────────────
     //
-    // Two-call interface mirroring the legacy renderer:
-    //   - setSkinnedRig() ONCE at startup → uploads bind-pose mesh + bone-
-    //     influence buffer; allocates per-frame SSBOs.
-    //   - setSkinnedFrame() EVERY FRAME → uploads a flat bone palette + a
-    //     parallel per-instance buffer (worldTransform, paletteBase, tint).
+    // The skinning pipeline (rig install, per-frame palette upload, instanced
+    // draw, shaders) is its own subsystem — see `SkinnedRenderer.hpp`.
+    // Game code talks to it through the accessor below:
     //
-    // CURRENT STATE:
-    //   - setSkinnedRig: IMPLEMENTED (GPU upload of mesh + influences).
-    //   - setSkinnedFrame: IMPLEMENTED (uploads palette+instance SSBOs each frame).
-    //   - The actual instanced draw call: NOT IMPLEMENTED (skinnedPipeline_ is null).
+    //   renderer.skinned().setRig(meshes, numJoints);            // once
+    //   renderer.skinned().setFrame(palette, instances);          // every frame
     //
-    // To bring skinned characters to screen, graphics team needs to:
-    //   1. Add shaders/skinned vertex+fragment (LBS in vertex shader, sample
-    //      bonePalette SSBO indexed by paletteBase + boneIndex).
-    //   2. Create `skinnedPipeline_` (two vertex buffers: ModelVertex + BoneInfluence;
-    //      two SSBOs as vertex storage; one UBO for view/proj).
-    //   3. Implement `drawSkinnedCharacters()` (called from drawFrame between
-    //      static geometry and the weapon — see the placeholder in cpp).
-    //   4. Test by spawning multiple players; one instanced draw per rig mesh
-    //      should render all of them.
+    // `NewRenderer::drawFrame` automatically drives the matching
+    // `uploadFrame()` (before render pass) and `draw()` (inside geometry pass)
+    // — game code never calls those directly.
 
-    /// @brief Install the shared skinned-character rig.  Call ONCE after `init()`.
-    /// @param meshes     One source-mesh entry per skinned mesh in the rig (typically 1-3 for humanoid rigs).
-    /// @param numJoints  Number of skeleton joints.  Determines per-instance palette stride.
-    /// @return True on success.  False if already installed, or upload failed.
+    /// @brief Accessor for the skinned-character subsystem.
     ///
-    /// IMPLEMENTATION (real, already wired):
-    ///   - Iterates `meshes`, creating two GPU vertex buffers per mesh:
-    ///       slot 0: bind-pose vertices (`ModelVertex`, 48 bytes/vert)
-    ///       slot 1: bone influences  (`BoneInfluence`, 32 bytes/vert)
-    ///     plus an index buffer.  Saves them in `skinnedMeshes_`.
-    ///   - Stores `numJoints` in `skinnedNumJoints_`; sets `skinnedRigInstalled_`.
-    ///   - Does NOT allocate the palette/instance SSBOs — those are grown
-    ///     lazily on the first `setSkinnedFrame` call.
-    ///
-    /// DATA SOURCE: Game.cpp builds `vector<RigMeshSource>` from
-    /// `CharacterRig::meshes()` (animation/CharacterRig.hpp) once after the
-    /// rig FBX loads.  See `RigMeshSource` in RendererTypes.hpp for the layout.
-    bool setSkinnedRig(const std::vector<RigMeshSource>& meshes, int numJoints);
-
-    /// @brief Push this frame's per-character bone palette + per-instance data.
-    /// @param palette    Flat array, sized `numInstances * numJoints` (mat4 each).
-    /// @param instances  One entry per visible character.  `paletteBase` of entry
-    ///                   `i` MUST equal `i * numJoints` so the shader's index math works.
-    ///
-    /// IMPLEMENTATION (real, already wired):
-    ///   - Copies both vectors into CPU-side staging (`framePalette_`, `frameInstances_`).
-    ///   - During `drawFrame` (before the geometry pass), uploads them into
-    ///     `palettesSSBO_` and `instancesSSBO_` via transfer buffers with
-    ///     cycle=true (so we don't stall on last frame's GPU read).
-    ///   - SSBOs grow on demand if more instances/joints appear than fit.
-    ///
-    /// DATA SOURCE: Game.cpp's per-frame animation block (parallel walk of
-    /// ECS view `<AnimatedCharacter, Position, Velocity, PlayerVisState,
-    /// InputSnapshot>`):
-    ///   1. For each visible character compute `worldTransform = T(pos)*R(yaw)*S(scale)`.
-    ///   2. `palette[slot * numJoints .. (slot+1) * numJoints] = animator.skinMatrices()`.
-    ///   3. `instances[slot] = {worldTransform, paletteBase=slot*numJoints, tint}`.
-    ///
-    /// CONSUMER: the (not-yet-written) skinned vertex shader reads
-    ///   `instances[gl_InstanceIndex]` for worldTransform + paletteBase
-    ///   `palette[paletteBase + boneIndices.k]` weighted by `boneWeights.k`.
-    void setSkinnedFrame(const std::vector<glm::mat4>& palette, const std::vector<SkinnedInstance>& instances);
+    /// Use to register the shared rig once at startup, and to push the per-
+    /// frame palette + instance arrays each frame.  See SkinnedRenderer.hpp
+    /// for the full API + data-flow notes.
+    [[nodiscard]] SkinnedRenderer& skinned() { return skinnedRenderer_; }
+    [[nodiscard]] const SkinnedRenderer& skinned() const { return skinnedRenderer_; }
 
     // ─── Static models ───────────────────────────────────────────────────────
 
@@ -393,36 +349,6 @@ private:
     void drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh) const;
     void drawHud(SDL_GPURenderPass* pass);
 
-    // ─── Skinned-character internals (NEW) ───────────────────────────────────
-
-    /// @brief One mesh of the installed skinned rig.  Built by `setSkinnedRig`.
-    ///
-    /// `vb` carries `ModelVertex` (48-byte bind-pose vertices) at vertex buffer slot 0.
-    /// `boneVb` carries `BoneInfluence` (32-byte index+weight) at vertex buffer slot 1.
-    /// Both are parallel arrays — vertex `i` of `vb` uses bone influences `i` of `boneVb`.
-    struct SkinnedMesh
-    {
-        SDL_GPUBuffer* vb = nullptr;
-        SDL_GPUBuffer* boneVb = nullptr;
-        SDL_GPUBuffer* ib = nullptr;
-        Uint32 indexCount = 0;
-        Uint32 vertexCount = 0;
-    };
-
-    /// @brief Per-frame palette+instance upload.  Called from `drawFrame` before begin-render-pass.
-    /// @param cmd       Frame command buffer.
-    /// @param copyPass  An open copy pass on `cmd`.
-    void uploadSkinnedFrame(SDL_GPUCommandBuffer* cmd, SDL_GPUCopyPass* copyPass);
-
-    /// @brief Grow palette/instance SSBOs (and their transfer buffers) to at least these byte sizes.
-    bool ensureSkinnedSSBOs(Uint32 paletteBytes, Uint32 instanceBytes);
-
-    /// @brief Issue the instanced draws for every skinned character.
-    ///
-    /// TODO(graphics): Currently a no-op placeholder.  See the doc on
-    /// `setSkinnedFrame` for the algorithm to implement.
-    void drawSkinnedCharacters(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
-
     // ─── Member state ────────────────────────────────────────────────────────
 
     SDL_Window* window_ = nullptr;
@@ -431,7 +357,6 @@ private:
 
     SDL_GPUGraphicsPipeline* geometryPipeline_ = nullptr;
     SDL_GPUGraphicsPipeline* hudPipeline_ = nullptr;
-    SDL_GPUGraphicsPipeline* skinnedPipeline_ = nullptr; ///< TODO(graphics): create in init (or lazily on first skinned frame).
 
     SDL_GPUDepthStencilTargetInfo depthTarget_{};
     Uint32 depthWidth_ = 0;
@@ -456,23 +381,8 @@ private:
     bool vsyncEnabled_ = true;
     std::string pendingScreenshotPath_;
 
-    // Skinned-rig state ──────────────────────────────────────────────────────
-    bool skinnedRigInstalled_ = false;
-    int skinnedNumJoints_ = 0;
-    std::vector<SkinnedMesh> skinnedMeshes_;
-
-    SDL_GPUBuffer* palettesSSBO_ = nullptr;          ///< STORAGE_READ, mat4[numInstances * numJoints].
-    SDL_GPUBuffer* instancesSSBO_ = nullptr;         ///< STORAGE_READ, SkinnedInstance[numInstances].
-    Uint32 palettesCapacityBytes_ = 0;
-    Uint32 instancesCapacityBytes_ = 0;
-    SDL_GPUTransferBuffer* paletteXfer_ = nullptr;
-    SDL_GPUTransferBuffer* instanceXfer_ = nullptr;
-    Uint32 paletteXferCapacityBytes_ = 0;
-    Uint32 instanceXferCapacityBytes_ = 0;
-
-    std::vector<glm::mat4> framePalette_;            ///< CPU staging for the next frame's palette.
-    std::vector<SkinnedInstance> frameInstances_;    ///< CPU staging for the next frame's instances.
-    bool skinnedFrameDirty_ = false;                 ///< True when CPU data has changed since last upload.
+    // Skinned-character subsystem (see SkinnedRenderer.hpp) ──────────────────
+    SkinnedRenderer skinnedRenderer_;
 
     // Telemetry counters (filled by drawFrame) ────────────────────────────────
     float lastAcquireMs_ = 0.0f;

--- a/src/client/renderer-new/RendererTypes.hpp
+++ b/src/client/renderer-new/RendererTypes.hpp
@@ -1,14 +1,24 @@
 /// @file RendererTypes.hpp
-/// @brief Shared data types used across renderer implementations.
+/// @brief Shared data types exchanged between Game (producer) and NewRenderer (consumer).
 ///
-/// Extracted so that `IRenderer.hpp` and the concrete renderer headers can
-/// depend on these structs without creating circular includes.
+/// Every struct in this file is a pure value type — no GPU handles, no
+/// owning pointers, no dependencies on renderer internals.  Game code
+/// builds these per frame (or per registration) and hands them off via
+/// `NewRenderer::set*()` methods; the renderer then reads them during
+/// `drawFrame()`.  Keep it that way: anything that needs GPU handles
+/// belongs inside `NewRenderer`, not here.
 
 #pragma once
 
-#include <glm/glm.hpp>
+#include "../animation/SkinVertex.hpp" // ModelVertex (48-byte bind-pose vertex)
 
-/// @brief Anti-aliasing mode selection -- exposed to ImGui.
+#include <cstdint>
+#include <glm/glm.hpp>
+#include <vector>
+
+// ─── Existing types ──────────────────────────────────────────────────────────
+
+/// @brief Anti-aliasing mode selection — exposed to ImGui.
 enum class AAMode : int
 {
     Off = 0,      ///< No anti-aliasing.
@@ -16,14 +26,15 @@ enum class AAMode : int
     SMAA_T2x = 2, ///< 2-sample temporal + spatial SMAA (recommended).
 };
 
-/// @brief Live toggles for every render system -- exposed to ImGui.
+/// @brief Live toggles for every render system — exposed to ImGui.
 ///
-/// All default to true (everything on). The legacy renderer checks these each
+/// All default to true (everything on).  The renderer checks these each
 /// frame and skips the corresponding pass/dispatch when disabled.
+/// Graphics team should consult these inside each pass's entry point.
 struct RenderToggles
 {
     // Geometry passes
-    bool pbrModels = true;       ///< Assimp-loaded scene models (opaque + transparent).
+    bool pbrModels = true;       ///< Loaded scene models (opaque + transparent).
     bool entityModels = true;    ///< ECS-driven entity models (Renderable component).
     bool weaponViewmodel = true; ///< First-person weapon.
     bool skybox = true;          ///< Procedural / cubemap skybox.
@@ -36,34 +47,117 @@ struct RenderToggles
     bool bloom = true;       ///< Bloom downsample + upsample chain.
     bool ssr = true;         ///< Screen-space reflections.
     bool volumetrics = true; ///< Volumetric lighting / god rays.
-    bool tonemap = true;     ///< HDR -> LDR tone mapping (disabling = raw HDR blit).
+    bool tonemap = true;     ///< HDR → LDR tone mapping (disabling = raw HDR blit).
 
     // Effects
     bool particles = true; ///< GPU particle system.
     bool sdfText = true;   ///< SDF text rendering (HUD + world).
+
+    // Skinned characters
+    bool skinnedCharacters = true; ///< Instanced GPU skinning pass for player meshes.
 };
 
-/// @brief Per-entity render command -- built by Game, consumed by Renderer::drawFrame.
+/// @brief Per-entity render command — built by Game, consumed by Renderer::drawFrame.
+///
+/// One entry per visible static/dynamic entity (NOT skinned characters — those
+/// go through `setSkinnedFrame`).  Game.cpp builds these from ECS each frame
+/// and hands them off via `setEntityRenderList()`.
 struct EntityRenderCmd
 {
-    int32_t modelIndex = -1;        ///< Index into Renderer::models[].
+    int32_t modelIndex = -1;        ///< Renderer-side model handle (returned by `loadSceneModel` / `uploadSceneModel`).
     glm::mat4 worldTransform{1.0f}; ///< Full world transform (position × rotation × scale).
-    glm::vec4 tint{1.0f};           ///< RGB multiplier into baseColorFactor (alpha unused). Default = no tint.
+    glm::vec4 tint{1.0f};           ///< RGB multiplier into baseColorFactor (alpha unused).  Default = no tint.
 };
 
-/// @brief Dynamic point light -- built by Game, injected into the PBR light array.
+/// @brief Dynamic point light — built by Game, injected into the PBR light array.
+///
+/// Game.cpp builds the list each frame from ECS (e.g. glow-emitting entities,
+/// muzzle flashes) and hands it off via `setPointLights()`.  Renderer should
+/// cap at some reasonable max (legacy used 6 dynamic + 2 reserved for sun/fill).
 struct PointLight
 {
     glm::vec3 position{0.0f}; ///< World-space position.
     glm::vec3 color{1.0f};    ///< Light colour (linear RGB).
-    float intensity = 1.0f;   ///< Brightness multiplier (passed as color.a in the UBO).
+    float intensity = 1.0f;   ///< Brightness multiplier.
     float range = 500.0f;     ///< Attenuation range (world units); falloff = 1 - (d²/r²).
 };
 
 /// @brief First-person weapon viewmodel descriptor sent per frame.
+///
+/// Game.cpp computes the viewmodel transform from camera state + sway/recoil
+/// each frame and hands it off via `setWeaponViewmodel()`.
 struct WeaponViewmodel
 {
-    int32_t modelIndex = -1;   ///< Index into Renderer::models[].
+    int32_t modelIndex = -1;   ///< Renderer-side model handle.
     glm::mat4 transform{1.0f}; ///< Transform in viewmodel space (relative to camera).
-    bool visible = false;
+    bool visible = false;      ///< False = skip drawing this frame (e.g. weapon hidden).
+};
+
+// ─── Skinned-character types (NEW) ───────────────────────────────────────────
+//
+// These three types form the interface between the animation system and the
+// renderer's skinned-character pipeline.  See `NewRenderer::setSkinnedRig`
+// and `NewRenderer::setSkinnedFrame` for usage.
+//
+// Pipeline:
+//   1. Once at startup, Game.cpp builds `vector<RigMeshSource>` from
+//      `CharacterRig::meshes()` (one entry per skinned mesh) and calls
+//      `setSkinnedRig(meshes, numJoints)`.
+//   2. Every frame, Game.cpp walks visible animated entities, builds two
+//      parallel vectors (bone palette + per-instance metadata) and calls
+//      `setSkinnedFrame(palette, instances)`.
+
+/// @brief Per-vertex bone-influence record — 4 bones per vertex, weighted.
+///
+/// Lives parallel to the bind-pose vertex buffer.  Uploaded once at rig
+/// install time as a second vertex buffer; the shader reads `boneIndices`
+/// and `boneWeights` as vertex attributes (locations 3 and 4 in the
+/// suggested layout — but graphics team owns the final shader, see
+/// `setSkinnedRig` docs for the recommended attribute layout).
+///
+/// Layout (32 bytes, no padding) matches what the legacy `pbr_skinned.vert`
+/// expected.  Keep it 32 bytes — changes here require shader updates.
+struct BoneInfluence
+{
+    int boneIndices[4] = {0, 0, 0, 0};         ///< Joint indices into the bone palette.
+    float boneWeights[4] = {0.0f, 0.0f, 0.0f, 0.0f}; ///< Skinning weights (should sum to ~1.0).
+};
+
+/// @brief Per-frame instance entry — one per visible animated character.
+///
+/// Game.cpp appends one of these to a `std::vector<SkinnedInstance>` every
+/// frame for each visible character, sets `paletteBase` to `slot * numJoints`,
+/// and passes the vector to `setSkinnedFrame()`.  The renderer uploads it as
+/// an SSBO; the shader reads it as `instances[gl_InstanceIndex]`.
+///
+/// Layout (96 bytes) — keep std140-friendly.  Pads added so total is a
+/// multiple of 16 and `tint` lands at byte offset 80.
+struct SkinnedInstance
+{
+    glm::mat4 worldTransform{1.0f};         ///< Rig-local → world.  Composed CPU-side as T * R * S.
+    uint32_t paletteBase = 0;               ///< First joint slot in the palette = instanceIndex * numJoints.
+    uint32_t materialId = 0;                ///< Reserved; ignore for now (will index a material table later).
+    uint32_t _pad0 = 0;
+    uint32_t _pad1 = 0;
+    glm::vec4 tint{1.0f, 1.0f, 1.0f, 0.0f}; ///< rgb = per-player color, a = blend factor (0 = no tint).
+};
+
+/// @brief Source data for one mesh of a skinned character rig.
+///
+/// Game.cpp constructs a `std::vector<RigMeshSource>` from
+/// `CharacterRig::meshes()` once (at startup, after the rig FBX loads)
+/// and passes it to `setSkinnedRig()`.  The renderer copies everything
+/// it needs to GPU buffers in that one call and never touches the
+/// CPU-side data afterwards.
+///
+/// All three vectors describe the same triangle mesh in bind pose:
+///   - `bindPoseVertices` carries position/normal/uv/tangent.
+///   - `boneInfluences` is parallel: `boneInfluences[i]` belongs to
+///     `bindPoseVertices[i]` (same length, same order).
+///   - `indices` is a 32-bit triangle list (every 3 indices = 1 triangle).
+struct RigMeshSource
+{
+    std::vector<ModelVertex> bindPoseVertices;   ///< Bind-pose vertices (never deformed CPU-side).
+    std::vector<BoneInfluence> boneInfluences;   ///< Parallel to `bindPoseVertices`.  Must be same size.
+    std::vector<uint32_t> indices;               ///< Triangle list (3 indices per triangle).
 };

--- a/src/client/renderer-new/SkinnedRenderer.cpp
+++ b/src/client/renderer-new/SkinnedRenderer.cpp
@@ -1,0 +1,316 @@
+/// @file SkinnedRenderer.cpp
+/// @brief Implementation of the skinned-character subsystem.
+///
+/// Owns its own GPU resources (per-mesh VB/IB/boneVB, palette + instance
+/// SSBOs, transfer buffers) and per-frame CPU staging.  Graphics team
+/// only needs to touch this file (and add the matching shaders + pipeline)
+/// to bring skinned characters to screen.
+///
+/// Grep `TODO(graphics)` to find every hook still awaiting work.
+
+#include "SkinnedRenderer.hpp"
+
+#include "Boilerplate.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+void SkinnedRenderer::init(SDL_GPUDevice* device)
+{
+    device_ = device;
+    // No GPU allocations here — buffers and pipeline are created on demand
+    // (setRig allocates the rig mesh buffers; setFrame triggers SSBO growth).
+    //
+    // TODO(graphics): if you want the skinned pipeline created up-front, do
+    // it here.  Otherwise leave it null and create it the first time
+    // `draw()` would actually issue draws.
+}
+
+void SkinnedRenderer::shutdown()
+{
+    if (!device_)
+        return;
+
+    for (auto& sm : skinnedMeshes_) {
+        if (sm.vb)
+            SDL_ReleaseGPUBuffer(device_, sm.vb);
+        if (sm.boneVb)
+            SDL_ReleaseGPUBuffer(device_, sm.boneVb);
+        if (sm.ib)
+            SDL_ReleaseGPUBuffer(device_, sm.ib);
+    }
+    skinnedMeshes_.clear();
+
+    if (palettesSsbo_)
+        SDL_ReleaseGPUBuffer(device_, palettesSsbo_);
+    if (instancesSsbo_)
+        SDL_ReleaseGPUBuffer(device_, instancesSsbo_);
+    if (paletteXfer_)
+        SDL_ReleaseGPUTransferBuffer(device_, paletteXfer_);
+    if (instanceXfer_)
+        SDL_ReleaseGPUTransferBuffer(device_, instanceXfer_);
+    if (pipeline_)
+        SDL_ReleaseGPUGraphicsPipeline(device_, pipeline_);
+
+    palettesSsbo_ = nullptr;
+    instancesSsbo_ = nullptr;
+    paletteXfer_ = nullptr;
+    instanceXfer_ = nullptr;
+    pipeline_ = nullptr;
+    palettesCapacityBytes_ = 0;
+    instancesCapacityBytes_ = 0;
+    paletteXferCapacityBytes_ = 0;
+    instanceXferCapacityBytes_ = 0;
+
+    rigInstalled_ = false;
+    numJoints_ = 0;
+    frameDirty_ = false;
+    framePalette_.clear();
+    frameInstances_.clear();
+
+    device_ = nullptr;
+}
+
+// ─── Rig install ─────────────────────────────────────────────────────────────
+
+bool SkinnedRenderer::setRig(const std::vector<RigMeshSource>& meshes, int numJoints)
+{
+    if (!device_) {
+        SDL_Log("SkinnedRenderer::setRig: not initialised (device==null)");
+        return false;
+    }
+    if (rigInstalled_) {
+        SDL_Log("SkinnedRenderer::setRig: rig already installed; ignoring repeat call");
+        return false;
+    }
+    if (meshes.empty() || numJoints <= 0) {
+        SDL_Log("SkinnedRenderer::setRig: empty meshes or numJoints<=0 (%zu, %d)", meshes.size(), numJoints);
+        return false;
+    }
+    for (size_t i = 0; i < meshes.size(); ++i) {
+        const auto& m = meshes[i];
+        if (m.boneInfluences.size() != m.bindPoseVertices.size()) {
+            SDL_Log("SkinnedRenderer::setRig: mesh %zu has %zu verts but %zu bone-influence entries",
+                    i,
+                    m.bindPoseVertices.size(),
+                    m.boneInfluences.size());
+            return false;
+        }
+        if (m.indices.empty()) {
+            SDL_Log("SkinnedRenderer::setRig: mesh %zu has zero indices", i);
+            return false;
+        }
+    }
+
+    numJoints_ = numJoints;
+    skinnedMeshes_.clear();
+    skinnedMeshes_.reserve(meshes.size());
+
+    // Single transfer buffer sized to the largest pending upload, reused
+    // across all per-mesh uploads.
+    Uint32 maxUploadBytes = 0;
+    for (const auto& m : meshes) {
+        const Uint32 vBytes = static_cast<Uint32>(m.bindPoseVertices.size() * sizeof(ModelVertex));
+        const Uint32 bBytes = static_cast<Uint32>(m.boneInfluences.size() * sizeof(BoneInfluence));
+        const Uint32 iBytes = static_cast<Uint32>(m.indices.size() * sizeof(uint32_t));
+        maxUploadBytes = std::max({maxUploadBytes, vBytes, bBytes, iBytes});
+    }
+    SDL_GPUTransferBuffer* xfer = Boilerplate::createUploadBuffer(device_, maxUploadBytes);
+    if (!xfer) {
+        SDL_Log("SkinnedRenderer::setRig: createUploadBuffer(%u) failed: %s", maxUploadBytes, SDL_GetError());
+        return false;
+    }
+
+    SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device_);
+    SDL_GPUCopyPass* cp = SDL_BeginGPUCopyPass(cmd);
+
+    auto uploadToBuffer = [&](SDL_GPUBuffer* dst, const void* src, Uint32 bytes) {
+        void* mapped = SDL_MapGPUTransferBuffer(device_, xfer, /*cycle=*/true);
+        if (!mapped)
+            return;
+        SDL_memcpy(mapped, src, bytes);
+        SDL_UnmapGPUTransferBuffer(device_, xfer);
+        SDL_GPUTransferBufferLocation s{};
+        s.transfer_buffer = xfer;
+        s.offset = 0;
+        SDL_GPUBufferRegion d{};
+        d.buffer = dst;
+        d.offset = 0;
+        d.size = bytes;
+        SDL_UploadToGPUBuffer(cp, &s, &d, /*cycle=*/false);
+    };
+
+    for (const auto& m : meshes) {
+        SkinnedMesh sm{};
+        sm.vertexCount = static_cast<Uint32>(m.bindPoseVertices.size());
+        sm.indexCount = static_cast<Uint32>(m.indices.size());
+
+        const Uint32 vBytes = sm.vertexCount * sizeof(ModelVertex);
+        const Uint32 bBytes = sm.vertexCount * sizeof(BoneInfluence);
+        const Uint32 iBytes = sm.indexCount * sizeof(uint32_t);
+
+        sm.vb = Boilerplate::createBuffer(device_, vBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
+        sm.boneVb = Boilerplate::createBuffer(device_, bBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
+        sm.ib = Boilerplate::createBuffer(device_, iBytes, SDL_GPU_BUFFERUSAGE_INDEX);
+
+        if (sm.vb && vBytes > 0)
+            uploadToBuffer(sm.vb, m.bindPoseVertices.data(), vBytes);
+        if (sm.boneVb && bBytes > 0)
+            uploadToBuffer(sm.boneVb, m.boneInfluences.data(), bBytes);
+        if (sm.ib && iBytes > 0)
+            uploadToBuffer(sm.ib, m.indices.data(), iBytes);
+
+        skinnedMeshes_.push_back(sm);
+    }
+
+    SDL_EndGPUCopyPass(cp);
+    SDL_SubmitGPUCommandBuffer(cmd);
+    SDL_WaitForGPUIdle(device_);
+
+    SDL_ReleaseGPUTransferBuffer(device_, xfer);
+
+    rigInstalled_ = true;
+    SDL_Log("SkinnedRenderer: rig installed — %zu mesh(es), %d joints", skinnedMeshes_.size(), numJoints);
+    return true;
+}
+
+// ─── Per-frame: capture + upload ─────────────────────────────────────────────
+
+void SkinnedRenderer::setFrame(const std::vector<glm::mat4>& palette, const std::vector<SkinnedInstance>& instances)
+{
+    framePalette_ = palette;
+    frameInstances_ = instances;
+    frameDirty_ = !instances.empty();
+}
+
+bool SkinnedRenderer::ensureSsbos(Uint32 paletteBytes, Uint32 instanceBytes)
+{
+    auto growBuf = [&](SDL_GPUBuffer*& buf, Uint32& cap, Uint32 want, SDL_GPUBufferUsageFlags use) {
+        if (want == 0)
+            return true;
+        if (want > cap) {
+            if (buf)
+                SDL_ReleaseGPUBuffer(device_, buf);
+            SDL_GPUBufferCreateInfo bInfo{};
+            bInfo.usage = use;
+            bInfo.size = want;
+            buf = SDL_CreateGPUBuffer(device_, &bInfo);
+            cap = buf ? want : 0;
+            return buf != nullptr;
+        }
+        return true;
+    };
+    auto growXfer = [&](SDL_GPUTransferBuffer*& xfer, Uint32& cap, Uint32 want) {
+        if (want == 0)
+            return true;
+        if (want > cap) {
+            if (xfer)
+                SDL_ReleaseGPUTransferBuffer(device_, xfer);
+            SDL_GPUTransferBufferCreateInfo tbInfo{};
+            tbInfo.usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD;
+            tbInfo.size = want;
+            xfer = SDL_CreateGPUTransferBuffer(device_, &tbInfo);
+            cap = xfer ? want : 0;
+            return xfer != nullptr;
+        }
+        return true;
+    };
+    if (!growBuf(palettesSsbo_, palettesCapacityBytes_, paletteBytes, SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ))
+        return false;
+    if (!growBuf(instancesSsbo_, instancesCapacityBytes_, instanceBytes, SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ))
+        return false;
+    if (!growXfer(paletteXfer_, paletteXferCapacityBytes_, paletteBytes))
+        return false;
+    if (!growXfer(instanceXfer_, instanceXferCapacityBytes_, instanceBytes))
+        return false;
+    return true;
+}
+
+void SkinnedRenderer::uploadFrame(SDL_GPUCommandBuffer* /*cmd*/, SDL_GPUCopyPass* copyPass)
+{
+    if (!frameDirty_ || frameInstances_.empty() || !device_)
+        return;
+
+    const Uint32 paletteBytes = static_cast<Uint32>(framePalette_.size() * sizeof(glm::mat4));
+    const Uint32 instanceBytes = static_cast<Uint32>(frameInstances_.size() * sizeof(SkinnedInstance));
+    if (!ensureSsbos(paletteBytes, instanceBytes))
+        return;
+
+    auto upload = [&](SDL_GPUTransferBuffer* xfer, SDL_GPUBuffer* dst, const void* src, Uint32 bytes) {
+        if (bytes == 0 || !xfer || !dst)
+            return;
+        void* mapped = SDL_MapGPUTransferBuffer(device_, xfer, /*cycle=*/true);
+        if (!mapped)
+            return;
+        SDL_memcpy(mapped, src, bytes);
+        SDL_UnmapGPUTransferBuffer(device_, xfer);
+        SDL_GPUTransferBufferLocation s{};
+        s.transfer_buffer = xfer;
+        s.offset = 0;
+        SDL_GPUBufferRegion d{};
+        d.buffer = dst;
+        d.offset = 0;
+        d.size = bytes;
+        SDL_UploadToGPUBuffer(copyPass, &s, &d, /*cycle=*/false);
+    };
+    upload(paletteXfer_, palettesSsbo_, framePalette_.data(), paletteBytes);
+    upload(instanceXfer_, instancesSsbo_, frameInstances_.data(), instanceBytes);
+}
+
+// ─── Per-frame: draw ─────────────────────────────────────────────────────────
+
+void SkinnedRenderer::draw(SDL_GPURenderPass* /*renderPass*/, SDL_GPUCommandBuffer* /*cmd*/)
+{
+    // TODO(graphics): instanced GPU skinning draw call.  See `setFrame`
+    // doc-block for the data layout and shader pseudocode.  Sketch:
+    //
+    //   if (!rigInstalled_ || !pipeline_ || frameInstances_.empty()
+    //       || !palettesSsbo_ || !instancesSsbo_)
+    //       return;
+    //
+    //   SDL_BindGPUGraphicsPipeline(renderPass, pipeline_);
+    //
+    //   // The geometry pass already pushed view+projection at vertex UBO
+    //   // slot 0 in NewRenderer::drawGeometryPass — no need to push again.
+    //
+    //   SDL_GPUBuffer* ssbos[2] = {palettesSsbo_, instancesSsbo_};
+    //   SDL_BindGPUVertexStorageBuffers(renderPass, 0, ssbos, 2);
+    //
+    //   const Uint32 numInstances = static_cast<Uint32>(frameInstances_.size());
+    //   for (const auto& sm : skinnedMeshes_) {
+    //       const SDL_GPUBufferBinding vbs[2] = {
+    //           {.buffer = sm.vb,     .offset = 0},
+    //           {.buffer = sm.boneVb, .offset = 0},
+    //       };
+    //       SDL_BindGPUVertexBuffers(renderPass, 0, vbs, 2);
+    //       const SDL_GPUBufferBinding ib = {.buffer = sm.ib, .offset = 0};
+    //       SDL_BindGPUIndexBuffer(renderPass, &ib, SDL_GPU_INDEXELEMENTSIZE_32BIT);
+    //       SDL_DrawGPUIndexedPrimitives(renderPass, sm.indexCount, numInstances, 0, 0, 0);
+    //   }
+    //
+    // Pipeline (`pipeline_`) needs:
+    //   - vertex buffer 0: ModelVertex
+    //       location 0 = position  vec3 (offset  0)
+    //       location 1 = normal    vec3 (offset 12)
+    //       location 2 = texCoord  vec2 (offset 24)
+    //       location 3 = tangent   vec4 (offset 32)
+    //   - vertex buffer 1: BoneInfluence
+    //       location 4 = boneIndices ivec4 (offset  0)
+    //       location 5 = boneWeights vec4  (offset 16)
+    //   - 2 vertex storage buffers (BonePalette + Instances)
+    //   - 1 vertex UBO at slot 0 (view-projection — pushed by NewRenderer)
+    //   - depth test on, cull mode NONE (rig may be double-sided)
+    //   - colour target = same format as the geometry pass currently uses
+    //     (today: swapchain format; later: NewRenderer::getHdrFormat()).
+    //
+    // Shader pseudocode (`shaders-new/geometry_skinned.vert`):
+    //   InstanceData inst = instances[gl_InstanceIndex];
+    //   mat4 skin = palette[inst.paletteBase + uint(inBoneIndices.x)] * inBoneWeights.x
+    //             + palette[inst.paletteBase + uint(inBoneIndices.y)] * inBoneWeights.y
+    //             + palette[inst.paletteBase + uint(inBoneIndices.z)] * inBoneWeights.z
+    //             + palette[inst.paletteBase + uint(inBoneIndices.w)] * inBoneWeights.w;
+    //   vec4 worldPos = inst.worldTransform * skin * vec4(inPosition, 1.0);
+    //   gl_Position   = viewProjection * worldPos;
+}

--- a/src/client/renderer-new/SkinnedRenderer.hpp
+++ b/src/client/renderer-new/SkinnedRenderer.hpp
@@ -1,0 +1,178 @@
+/// @file SkinnedRenderer.hpp
+/// @brief Self-contained renderer subsystem for skinned (animated) characters.
+///
+/// Owns every GPU resource and CPU staging buffer needed to draw animated
+/// players via instanced GPU linear-blend skinning.  Decoupled from
+/// `NewRenderer` so the graphics team can iterate on the animation pipeline
+/// (rig install, palette upload, draw call, shaders) without touching the
+/// main renderer's plumbing.
+///
+/// Lifecycle, owned by `NewRenderer`:
+///   1. NewRenderer::init()      → SkinnedRenderer::init(device)
+///   2. Game.cpp (once)          → renderer.skinned().setRig(meshes, numJoints)
+///   3. Game.cpp (every frame)   → renderer.skinned().setFrame(palette, instances)
+///   4. NewRenderer::drawFrame   → SkinnedRenderer::uploadFrame(cmd, copyPass)  [BEFORE render pass]
+///                                  SkinnedRenderer::draw(renderPass, cmd)      [INSIDE render pass]
+///   5. NewRenderer::quit()      → SkinnedRenderer::shutdown()
+///
+/// GPU pipeline state owned here:
+///   - per-mesh `vb` (ModelVertex), `boneVb` (BoneInfluence), `ib` (uint32 indices)
+///   - palette SSBO (mat4[numInstances*numJoints])
+///   - instances SSBO (SkinnedInstance[numInstances])
+///   - paired transfer buffers for per-frame upload (grown on demand)
+///   - the skinned pipeline + shaders (graphics team adds these — currently null)
+///
+/// Search `TODO(graphics)` in the cpp to find every hook still awaiting work.
+
+#pragma once
+
+#include "RendererTypes.hpp" // BoneInfluence, SkinnedInstance, RigMeshSource
+
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_gpu.h>
+
+#include <glm/glm.hpp>
+#include <vector>
+
+/// @brief Instanced GPU-skinning subsystem.  One per renderer.
+class SkinnedRenderer
+{
+public:
+    SkinnedRenderer() = default;
+    ~SkinnedRenderer() = default;
+
+    SkinnedRenderer(const SkinnedRenderer&) = delete;
+    SkinnedRenderer& operator=(const SkinnedRenderer&) = delete;
+    SkinnedRenderer(SkinnedRenderer&&) = delete;
+    SkinnedRenderer& operator=(SkinnedRenderer&&) = delete;
+
+    /// @brief Bind the SDL GPU device.  Call from `NewRenderer::init` once
+    /// the device exists.  Does NOT allocate any GPU resources yet; those
+    /// are created lazily on the first `setRig` / `setFrame` call.
+    /// @param device  Borrowed; the device must outlive this SkinnedRenderer.
+    void init(SDL_GPUDevice* device);
+
+    /// @brief Install the shared character rig.  Call ONCE after `init`.
+    /// @param meshes     One source-mesh entry per skinned mesh in the rig (typically 1-3 for humanoid rigs).
+    /// @param numJoints  Number of skeleton joints.  Determines per-instance palette stride in the shader.
+    /// @return True on success.  False if already installed, or upload failed.
+    ///
+    /// IMPLEMENTATION (real, wired):
+    ///   - Iterates `meshes`, creating three GPU buffers per mesh:
+    ///       slot 0: bind-pose vertices (`ModelVertex`, 48 bytes/vert)   — VERTEX usage
+    ///       slot 1: bone influences   (`BoneInfluence`, 32 bytes/vert)  — VERTEX usage
+    ///       slot 2: indices            (uint32_t, 4 bytes each)         — INDEX usage
+    ///     Saves them in `skinnedMeshes_`.
+    ///   - Stores `numJoints` in `numJoints_`; sets `rigInstalled_`.
+    ///   - Does NOT allocate palette/instance SSBOs — those grow lazily on
+    ///     the first `setFrame` call.
+    ///
+    /// DATA SOURCE: Game.cpp builds `vector<RigMeshSource>` from
+    /// `CharacterRig::meshes()` (animation/CharacterRig.hpp) once after the
+    /// rig FBX loads.  See `RigMeshSource` in RendererTypes.hpp for the layout.
+    bool setRig(const std::vector<RigMeshSource>& meshes, int numJoints);
+
+    /// @brief Push this frame's per-character bone palette + per-instance data.
+    /// @param palette    Flat array, sized `numInstances * numJoints` (mat4 each).
+    /// @param instances  One entry per visible character.  `paletteBase` of entry
+    ///                   `i` MUST equal `i * numJoints` so the shader's index math works.
+    ///
+    /// IMPLEMENTATION (real, wired):
+    ///   - Copies both vectors into CPU-side staging (`framePalette_`, `frameInstances_`).
+    ///   - The actual GPU upload happens later via `uploadFrame()` (called by
+    ///     `NewRenderer::drawFrame` before the render pass starts).
+    ///
+    /// DATA SOURCE: Game.cpp's per-frame animation block walks the ECS view
+    /// `<AnimatedCharacter, Position, Velocity, PlayerVisState, InputSnapshot>`:
+    ///   1. For each visible character compute `worldTransform = T(pos) * R(yaw) * S(scale)`.
+    ///   2. `palette[slot * numJoints .. (slot+1) * numJoints] = animator.skinMatrices()`.
+    ///   3. `instances[slot] = {worldTransform, paletteBase=slot*numJoints, tint}`.
+    ///
+    /// CONSUMER: the (not-yet-written) skinned vertex shader reads:
+    ///   `instances[gl_InstanceIndex]`           → worldTransform + paletteBase
+    ///   `palette[paletteBase + boneIndices.k]`  → bone matrix k (k = 0..3)
+    void setFrame(const std::vector<glm::mat4>& palette, const std::vector<SkinnedInstance>& instances);
+
+    /// @brief Upload this frame's palette + instance buffers to the GPU.
+    /// @param cmd       Frame command buffer.
+    /// @param copyPass  An open copy pass on `cmd`.
+    ///
+    /// Called from `NewRenderer::drawFrame` BEFORE the main render pass
+    /// begins so the copy is sequenced ahead of the draws.  Uses `cycle=true`
+    /// on the transfer-buffer map so we never stall waiting on last frame's
+    /// GPU read of the SSBO.
+    void uploadFrame(SDL_GPUCommandBuffer* cmd, SDL_GPUCopyPass* copyPass);
+
+    /// @brief Issue the instanced draws for every visible skinned character.
+    /// @param renderPass  The active main HDR (or swapchain) render pass.
+    /// @param cmd         The frame command buffer.
+    ///
+    /// Called from `NewRenderer::drawFrame` INSIDE the geometry pass.
+    /// Currently a no-op placeholder — see cpp for the algorithm sketch.
+    void draw(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
+
+    /// @brief Release all GPU resources owned by this subsystem.
+    /// Called from `NewRenderer::quit` (BEFORE the device is destroyed).
+    void shutdown();
+
+    // ─── Readback (optional, for debug UI) ───────────────────────────────────
+
+    /// @brief Number of joints in the installed rig (0 if not installed).
+    [[nodiscard]] int numJoints() const { return numJoints_; }
+
+    /// @brief True after a successful `setRig`.
+    [[nodiscard]] bool rigInstalled() const { return rigInstalled_; }
+
+    /// @brief Number of instances pending render this frame (0 if no frame submitted).
+    [[nodiscard]] size_t pendingInstanceCount() const { return frameInstances_.size(); }
+
+private:
+    /// @brief One mesh of the installed skinned rig.  Built by `setRig`.
+    ///
+    /// `vb`     carries `ModelVertex`   (48 B/vert) at vertex buffer slot 0.
+    /// `boneVb` carries `BoneInfluence` (32 B/vert) at vertex buffer slot 1.
+    /// `ib`     is a 32-bit index buffer.
+    /// Both vertex arrays are parallel — vertex `i` of `vb` uses bone
+    /// influences `i` of `boneVb`.
+    struct SkinnedMesh
+    {
+        SDL_GPUBuffer* vb = nullptr;
+        SDL_GPUBuffer* boneVb = nullptr;
+        SDL_GPUBuffer* ib = nullptr;
+        Uint32 indexCount = 0;
+        Uint32 vertexCount = 0;
+    };
+
+    /// @brief Grow palette/instance SSBOs (and their transfer buffers) to at least these byte sizes.
+    bool ensureSsbos(Uint32 paletteBytes, Uint32 instanceBytes);
+
+    // ─── Borrowed ────────────────────────────────────────────────────────────
+    SDL_GPUDevice* device_ = nullptr;
+
+    // ─── Owned: pipeline (graphics team to create) ───────────────────────────
+    /// @brief The skinned graphics pipeline.  TODO(graphics): create this in
+    /// `init` (or lazily on first frame) with two vertex buffers (ModelVertex,
+    /// BoneInfluence), two vertex storage buffers (palette, instances), one
+    /// vertex UBO (view-projection), depth test on, cull mode NONE.
+    SDL_GPUGraphicsPipeline* pipeline_ = nullptr;
+
+    // ─── Owned: rig (set once via setRig) ────────────────────────────────────
+    bool rigInstalled_ = false;
+    int numJoints_ = 0;
+    std::vector<SkinnedMesh> skinnedMeshes_;
+
+    // ─── Owned: per-frame GPU resources (grow on demand) ─────────────────────
+    SDL_GPUBuffer* palettesSsbo_ = nullptr;  ///< STORAGE_READ, mat4[numInstances * numJoints].
+    SDL_GPUBuffer* instancesSsbo_ = nullptr; ///< STORAGE_READ, SkinnedInstance[numInstances].
+    Uint32 palettesCapacityBytes_ = 0;
+    Uint32 instancesCapacityBytes_ = 0;
+    SDL_GPUTransferBuffer* paletteXfer_ = nullptr;
+    SDL_GPUTransferBuffer* instanceXfer_ = nullptr;
+    Uint32 paletteXferCapacityBytes_ = 0;
+    Uint32 instanceXferCapacityBytes_ = 0;
+
+    // ─── CPU staging (filled by setFrame, drained by uploadFrame) ────────────
+    std::vector<glm::mat4> framePalette_;
+    std::vector<SkinnedInstance> frameInstances_;
+    bool frameDirty_ = false;
+};


### PR DESCRIPTION
## Summary
- Restores the documented `NewRenderer` graphics API surface with stub implementations for unimplemented paths such as screenshots, HDR skyboxes, point lights, particles, and VSync control.
- Adds material-aware rendering support, including per-material diffuse data, texture selection, and fallback handling for meshes without textures.
- Updates shader transforms and fragment shading to use proper normal transforms, front-face-aware lighting, and material uniform flags.
- Introduces asset loading for materials and embedded textures, plus basic skinned-mesh resource setup and teardown.
- Adds a default fallback texture asset for untextured geometry.

## Testing
- Not run (not requested).
- Verified the diff for the renderer, asset loader, shader, and asset type updates.
- Confirmed the new PR content covers the restored API surface and the material/texture pipeline changes.