### PR TITLE
Core/wallruning enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,14 @@ FetchContent_Declare(
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(EnTT)
+if(TARGET EnTT)
+    get_target_property(_entt_include_dirs EnTT INTERFACE_INCLUDE_DIRECTORIES)
+    if(_entt_include_dirs)
+        set_target_properties(EnTT PROPERTIES
+            INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_entt_include_dirs}"
+        )
+    endif()
+endif()
 
 # toml++ - TOML parsing library
 FetchContent_Declare(

--- a/docs/apex-climb-wanted-feature-set.md
+++ b/docs/apex-climb-wanted-feature-set.md
@@ -1,0 +1,211 @@
+# Apex-Style Climb Wanted Feature Set
+
+Source: https://apexmovement.tech/wiki/tech/General%20Tech%3EWall%20Tech%3EClimb%20Fundamentals%3EClimb%20Fundamentals
+
+This file translates Apex's climb fundamentals into a target feature set for our game. It is not a claim that every Apex number should be copied 1:1; units, player capsule size, wallrun rules, and map scale must be tuned against our movement model.
+
+## Design Target
+
+Climbing should feel like a surface attachment mode, not a canned upward elevator. The player should be able to:
+
+- attach from airborne motion into a valid wall;
+- briefly stick even without perfect forward input;
+- climb upward when input/momentum points into the wall;
+- slip or climb downward when input/momentum does not support upward climb;
+- carry useful incoming speed into climb, wallbounce, wall push, end boost, and wallrun transitions;
+- detach predictably by jump, crouch, back input, invalid look angle, invalid surface angle, timer expiry, or ledge/mantle transition;
+- reattach in-air only when attach-point and climb-space rules allow it.
+
+## Core Mechanics
+
+### Attach Requirements
+
+- Player must be airborne. Grounded attach should not occur directly; jumping or falling off a ledge makes the player eligible.
+- Surface must be climbable: steep enough to behave like a wall, not a floor or shallow ramp.
+- View direction can be offset from the wall normal up to a configurable angle. Apex uses an arccos(0.7)-derived limit around 45.57 degrees; our current 30 degree gate is too strict for Apex-like climbing.
+- Movement toward the wall should help attach, but full forward input should not be mandatory. Momentum into the wall can create a brief stick.
+- Initial attach records:
+  - wall normal;
+  - attach point on wall;
+  - attach height along local up;
+  - climb-space baseline/cutoff;
+  - incoming velocity projected into climb tangent axes;
+  - whether the attach came from wallrun, jump, fall, grapple, launch, or ordinary air movement.
+
+### Attach Point
+
+- The attach point is fixed for the lifetime of a single climb.
+- It must not slide upward while the player slips or climbs. This is important because Apex reattach and climb limits depend on the original attach point, not the current body position.
+- Detach and reattach rules compare the next potential attach against the previous attach point and previous wall normal.
+
+### Climb Space
+
+We should model climb space explicitly instead of using only `climbTimer`.
+
+Target concepts:
+
+- `baseline`: bottom of climb space, usually based on last full ground contact.
+- `mini zone`: low zone above baseline; jumping here gives small height and low wall-push force.
+- `green zone`: middle zone used for wallbounces; jumping lower in the zone gives more height.
+- `neutral zone`: upper zone; jump becomes mostly horizontal wall push.
+- `cutoff`: top of climb space; reaching it ends climb and can trigger end boost.
+
+Initial implementation can use approximate configurable heights in our units:
+
+- mini zone: baseline to baseline + `k_climbMiniZoneHeight`;
+- green zone: next `k_climbGreenZoneHeight`;
+- neutral zone: until `k_climbSpaceHeight`;
+- cutoff: baseline + `k_climbSpaceHeight`.
+
+### Upward Climbing
+
+- Upward climbing is based on local-up velocity, not world +Y.
+- If local-up velocity is above a small threshold, climbing should not consume a non-upward timer.
+- Input/momentum into the wall should generate climb-up force.
+- Incoming velocity parallel to the wall should be preserved as much as possible instead of being zeroed.
+- Upward climb speed can be capped, but the cap should not destroy carried momentum needed for tech chains.
+
+### Non-Upward Climbing
+
+- Non-upward climbing covers slipping, downward climb, and sideways climb.
+- Non-upward climb has a timer. Apex uses a 1 second timer; our current 0.25 second grace is only a placeholder.
+- The timer starts at attach and is evaluated against local-up velocity.
+- If the player remains below the upward threshold after the grace expires, detach.
+- If the player was climbing upward and later drops below threshold after the timer has expired, detach.
+
+### Slipping
+
+- Slipping is a valid climb sub-state, not an immediate failure.
+- Slipping happens when:
+  - player attached from momentum but gives no climb input;
+  - input is neutralized, such as forward and backward together;
+  - player releases movement input;
+  - gravity or incoming downward velocity overpowers climb force;
+  - sideways climb is aimed so the combined movement vector no longer points into the wall.
+- Slipping should move local-down along the wall and preserve relevant horizontal momentum.
+
+### Downward Climb
+
+- Downward climb is different from passive slipping and should be faster/intentional.
+- If movement direction points away from the wall, climb should move downward along the wall instead of immediately detaching, as long as look/surface validity remains within climb limits.
+- Back input can be a hard detach if we want stronger readability, but Apex-style behavior distinguishes backward/downward intent from immediate invalid detach in several input combinations.
+
+### Sideways Climb
+
+- Sideways climb is a non-upward climb variant.
+- It should use the same non-up timer.
+- It requires enough contact/momentum into the wall.
+- Horizontal speed should be preserved and can become a setup for wall push, wallbounce, U-bounce-like behavior, or wallrun handoff.
+- Looking slightly opposite the sideways input helps sustain sideways motion; looking into the same direction can trigger slip/downward behavior.
+
+## Detach Rules
+
+### Normal Detaches
+
+Normal detaches should apply climb-space / reattach penalties:
+
+- crouch;
+- jump;
+- back input, if we keep this as a hard detach;
+- wall becomes invalid or no longer detected;
+- surface angle becomes too shallow;
+- view angle exceeds the climb angle limit;
+- non-upward timer expires;
+- attach offset is exhausted;
+- climb space cutoff is reached.
+
+### Abnormal Detaches
+
+Abnormal detaches should not apply the same penalties:
+
+- direct transition into mantle/ledge grab;
+- unclimbable special objects, if we add climb material tags;
+- side-of-wall drop cases where the player simply loses geometry.
+
+## End Boost
+
+- Climb should split into climb phase and end-boost phase.
+- End boost triggers when reaching attach offset or climb-space cutoff.
+- It adds a small local-up boost and preserves carried momentum.
+- Speed boosts should affect end boost more than raw climb height.
+- End boost is a key bridge into superglide-style or wall tech later.
+
+## Reattach
+
+- In-air reattach is allowed.
+- Same-wall reattach should require dropping below the previous attach point or previous attach height.
+- A sufficiently different wall normal can allow a new attach point without dropping below the old one. Apex's referenced angle is about 25.842 degrees; ours should be configurable.
+- Reattach must also respect climb-space validity. Passing attach-point rules alone should not be enough.
+- Reattach state must store previous wall normal, previous attach point, previous attach height, and climb-space baseline/cutoff.
+
+## Wallrun Interplay
+
+Climb and wallrun should be connected, not competing one-frame modes.
+
+- Wallrun into climb:
+  - if velocity into the wall and local-up state are climb-valid, wallrun can convert into climb/stick near obstacles, door frames, or vertical interruption surfaces;
+  - wallrun release/jump should still have priority over accidental climb.
+- Climb into wallrun:
+  - sideways climb can transition into wallrun if horizontal tangent speed and wallrun input are valid;
+  - after non-upward climb timer is near expiry, sideways input can become wallrun-like motion if a side wall is valid.
+- Wallrun around corners:
+  - wallrun surface handoff should use collision-backed anchor/tangent information;
+  - it must never flip 180 degrees just to remain attached;
+  - at gaps or door openings, it should either hand off to a forward-compatible surface or detach.
+- Wall push:
+  - releasing forward in a neutral/upper climb zone, then jumping, should produce a mostly horizontal push away from wall while carrying vertical velocity.
+
+## Implementation Implications
+
+Required new state:
+
+- `climbAttachPoint`
+- `climbAttachHeight`
+- `climbBaseline`
+- `climbSpaceCutoff`
+- `climbZone`
+- `climbNonUpTimer`
+- `climbPreviousWallNormal`
+- `climbPreviousAttachHeight`
+- `climbDetachPenalty`
+- `climbDetachKind`
+- `climbIncomingVelocity`
+
+Required constants:
+
+- climb angle limit;
+- climbable surface minimum steepness;
+- upward velocity threshold;
+- non-upward climb timer;
+- slip speed;
+- downward climb speed;
+- sideways climb max speed;
+- attach offset height;
+- climb space height;
+- mini/green/neutral zone boundaries;
+- reattach different-wall angle;
+- normal detach climb-space penalty;
+- jump detach penalty per zone;
+- end boost local-up impulse;
+- wall-push horizontal impulses per zone.
+
+Required tests:
+
+- attach from airborne forward input;
+- attach from wallward momentum with delayed forward input;
+- reject grounded attach;
+- reject shallow surfaces;
+- reject excessive look angle;
+- upward climb has no timer while local-up velocity stays above threshold;
+- non-upward climb detaches after timer;
+- slip persists before timer expiry;
+- downward climb moves local-down faster than slip;
+- sideways climb uses non-up timer and preserves tangent speed;
+- same-wall reattach blocked above previous attach point;
+- different-wall reattach allowed by angle threshold;
+- climb-space cutoff triggers end boost;
+- attach-offset exhaustion triggers end boost;
+- mantle transition does not apply normal detach penalty;
+- wall push from neutral zone gives mostly horizontal velocity;
+- wallrun-to-climb and climb-to-wallrun transitions do not fight each other.
+

--- a/docs/superpowers/plans/2026-05-16-apex-climb-implementation.md
+++ b/docs/superpowers/plans/2026-05-16-apex-climb-implementation.md
@@ -1,0 +1,374 @@
+# Apex-Style Climb Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current simple climb elevator with an Apex-inspired surface attachment system covering attach, climb space, upward/non-upward climb, slip/downward/sideways motion, detach penalties, end boost, reattach, and wallrun interplay.
+
+**Architecture:** `MovementSystem` remains the state owner for traversal intent and velocity shaping. `WallDetection` remains the mesh query source, but climb needs a stable climb attachment query equivalent in quality to wallrun attachment. Keep the first implementation deterministic and server-authoritative; animation/camera polish follows after movement state is correct.
+
+**Tech Stack:** C++23, EnTT, GLM, `physics_trimesh_tests`, authored static trimesh collision.
+
+---
+
+## Reference
+
+- Feature set: `docs/apex-climb-wanted-feature-set.md`
+- Source mechanics: https://apexmovement.tech/wiki/tech/General%20Tech%3EWall%20Tech%3EClimb%20Fundamentals%3EClimb%20Fundamentals
+
+## Files
+
+- Modify: `src/ecs/components/PlayerSimState.hpp`
+- Modify: `src/ecs/components/PlayerVisState.hpp` if climb zone/debug visibility is needed by client animation or HUD.
+- Modify: `src/ecs/physics/TitanfallConstants.hpp`
+- Modify: `src/ecs/physics/WallDetection.hpp`
+- Modify: `src/ecs/physics/WallDetection.cpp`
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify: `src/ecs/physics/PhaseDiagnostic.hpp`
+- Modify: `src/ecs/physics/PhaseDiagnostic.cpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+---
+
+### Task 1: Climb Space State
+
+**Files:**
+- Modify: `src/ecs/components/PlayerSimState.hpp`
+- Modify: `src/ecs/physics/TitanfallConstants.hpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing state/default tests**
+
+Add a test near `climbSameWallReattachRequiresMeaningfulDrop()`:
+
+```cpp
+bool climbSpaceDefaultsAreDeterministic()
+{
+    PlayerSimState state;
+    bool ok = true;
+    ok &= expect(state.climbAttachHeight == 0.0f, "climb attach height should default deterministically");
+    ok &= expect(state.climbBaseline == 0.0f, "climb baseline should default deterministically");
+    ok &= expect(state.climbSpaceCutoff == 0.0f, "climb cutoff should default deterministically");
+    ok &= expect(state.climbPreviousAttachHeight <= -1e9f, "previous attach height should default to none");
+    ok &= expect(!state.climbEndBoostQueued, "end boost should not default active");
+    return ok;
+}
+```
+
+Add it to `main()`.
+
+- [ ] **Step 2: Verify red**
+
+Run:
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+```
+
+Expected: compile failure for missing fields.
+
+- [ ] **Step 3: Add state and constants**
+
+Add to `PlayerSimState`:
+
+```cpp
+float climbBaseline{0.0f};
+float climbSpaceCutoff{0.0f};
+float climbAttachOffsetLimit{0.0f};
+glm::vec3 climbPreviousWallNormal{0.0f};
+float climbPreviousAttachHeight{-1e10f};
+float climbDetachPenalty{0.0f};
+bool climbEndBoostQueued{false};
+```
+
+Add to `TitanfallConstants.hpp`:
+
+```cpp
+constexpr float k_climbLookAngleLimit = 45.572995f;
+constexpr float k_climbSurfaceMinDotUp = 0.7f;
+constexpr float k_climbSpaceHeight = 147.0f;
+constexpr float k_climbAttachOffset = 100.0f;
+constexpr float k_climbMiniZoneHeight = 19.0f;
+constexpr float k_climbGreenZoneHeight = 28.0f;
+constexpr float k_climbReattachDifferentWallAngle = 25.842f;
+constexpr float k_climbNormalDetachPenalty = 128.0f;
+constexpr float k_climbJumpDetachPenalty = 256.0f;
+constexpr float k_climbEndBoostUp = 28.0f;
+```
+
+- [ ] **Step 4: Verify green**
+
+Run the same test command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ecs/components/PlayerSimState.hpp src/ecs/physics/TitanfallConstants.hpp tests/physics_trimesh_tests.cpp
+git commit -m "Add climb space state"
+```
+
+### Task 2: Stable Climb Attachment Query
+
+**Files:**
+- Modify: `src/ecs/physics/WallDetection.hpp`
+- Modify: `src/ecs/physics/WallDetection.cpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for:
+
+```cpp
+bool climbAttachAllowsMomentumStickWithoutForward();
+bool climbAttachRejectsShallowSurface();
+bool climbAttachRejectsExcessLookAngle();
+```
+
+The first test should give the player airborne velocity into a wall with no forward input and expect `MoveMode::Climbing` for at least one tick.
+
+- [ ] **Step 2: Verify red**
+
+Expected: no-forward momentum attach fails with the current `tryEnterClimb` intent gate.
+
+- [ ] **Step 3: Add query result**
+
+Extend `WallDetectionResult` or add `ClimbAttachmentResult` with:
+
+```cpp
+bool found{false};
+glm::vec3 point{0.0f};
+glm::vec3 normal{0.0f};
+uint32_t meshIndex{UINT32_MAX};
+uint32_t triId{UINT32_MAX};
+physics::TriRegion region{physics::TriRegion::Face};
+```
+
+Use capsule/segment closest-point queries against trimeshes, not sphere-vs-AABB approximations.
+
+- [ ] **Step 4: Update attach logic**
+
+Attach if:
+
+```cpp
+const bool airborne = !state.vis.grounded;
+const bool surfaceSteepEnough = std::abs(glm::dot(wallNormal, localUp)) < tms::k_climbSurfaceMinDotUp;
+const bool lookValid = lookAngle <= glm::radians(tms::k_climbLookAngleLimit);
+const bool hasInputIntent = glm::dot(wishDir, -wallNormal) >= tms::k_climbIntentThreshold;
+const bool hasMomentumIntent = glm::dot(horizVel(vel), -wallNormal) > 25.0f;
+const bool canStick = hasInputIntent || hasMomentumIntent;
+```
+
+- [ ] **Step 5: Verify green and commit**
+
+Run `physics_trimesh_tests`, then commit:
+
+```bash
+git add src/ecs/physics/WallDetection.hpp src/ecs/physics/WallDetection.cpp src/ecs/systems/MovementSystem.cpp tests/physics_trimesh_tests.cpp
+git commit -m "Add stable climb attachment query"
+```
+
+### Task 3: Upward, Slip, Downward, And Sideways Climb
+
+**Files:**
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify: `src/ecs/physics/TitanfallConstants.hpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing behavior tests**
+
+Add tests:
+
+```cpp
+bool upwardClimbTimerDoesNotExpireWhileMovingUp();
+bool nonUpwardClimbExpiresAfterOneSecond();
+bool slipMovesLocalDownBeforeTimerExpiry();
+bool downwardClimbIsFasterThanPassiveSlip();
+bool sidewaysClimbPreservesWallTangentSpeed();
+```
+
+- [ ] **Step 2: Verify red**
+
+Expected: current implementation uses a short placeholder non-up timer, has no downward climb, and damps tangent velocity too aggressively.
+
+- [ ] **Step 3: Implement climb sub-mode selection**
+
+Inside `handleClimbing` compute:
+
+```cpp
+const glm::vec3 localUp{0.0f, state.vis.gravityFlipped ? -1.0f : 1.0f, 0.0f};
+const float upSpeed = glm::dot(vel, localUp);
+const glm::vec3 wallNormal = normalizedOrZero(state.sim.climbWallNormal);
+const glm::vec3 wallTangentVelocity = vel - wallNormal * glm::dot(vel, wallNormal);
+const glm::vec3 wishDir = physics::computeWishDir(input.yaw, input.forward, input.back, input.left, input.right);
+const float wallIntent = glm::dot(wishDir, -wallNormal);
+```
+
+Rules:
+
+- `wallIntent > threshold`: upward climb force.
+- `wallIntent < -threshold`: downward climb force.
+- mostly sideways input: tangent acceleration, non-up timer.
+- no input: slip local-down, non-up timer.
+- upSpeed above threshold: reset/ignore non-up expiry.
+
+- [ ] **Step 4: Verify green and commit**
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+git add src/ecs/systems/MovementSystem.cpp src/ecs/physics/TitanfallConstants.hpp tests/physics_trimesh_tests.cpp
+git commit -m "Implement Apex-style climb submodes"
+```
+
+### Task 4: Climb Zones, Detach Penalties, And End Boost
+
+**Files:**
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify: `src/ecs/physics/PhaseDiagnostic.hpp`
+- Modify: `src/ecs/physics/PhaseDiagnostic.cpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests:
+
+```cpp
+bool miniZoneJumpGivesSmallWallPush();
+bool greenZoneJumpGivesHigherWallbounceImpulse();
+bool neutralZoneJumpGivesMostlyHorizontalWallPush();
+bool climbSpaceCutoffTriggersEndBoost();
+bool mantleDetachDoesNotApplyClimbSpacePenalty();
+```
+
+- [ ] **Step 2: Verify red**
+
+Expected: zone-specific jump outputs and end boost do not exist.
+
+- [ ] **Step 3: Implement zones**
+
+Compute zone from local-up position:
+
+```cpp
+const float climbHeight = glm::dot(pos - state.sim.climbAttachPoint, localUp);
+```
+
+Classify mini/green/neutral/cutoff from constants. Store in diagnostics.
+
+- [ ] **Step 4: Implement detach penalties and end boost**
+
+Normal detaches lower climb baseline. Jump detaches use zone-specific penalty. Mantle transitions skip penalty. End boost queues a local-up impulse when attach offset or cutoff is crossed.
+
+- [ ] **Step 5: Verify green and commit**
+
+Run tests and commit:
+
+```bash
+git add src/ecs/systems/MovementSystem.cpp src/ecs/physics/PhaseDiagnostic.hpp src/ecs/physics/PhaseDiagnostic.cpp tests/physics_trimesh_tests.cpp
+git commit -m "Add climb zones and end boost"
+```
+
+### Task 5: Reattach Rules
+
+**Files:**
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests:
+
+```cpp
+bool sameWallReattachRequiresDroppingBelowAttachPoint();
+bool differentWallReattachAllowedAbovePreviousAttachByAngle();
+bool reattachStillRequiresValidClimbSpace();
+```
+
+- [ ] **Step 2: Verify red**
+
+Expected: current same-wall check is height-only and does not combine attach point with climb-space validity.
+
+- [ ] **Step 3: Implement reattach gate**
+
+Allow attach if:
+
+```cpp
+const bool lowerThanPreviousAttach = currentAttachHeight < state.sim.climbPreviousAttachHeight;
+const bool differentEnoughWall =
+    std::acos(std::clamp(glm::dot(newNormal, state.sim.climbPreviousWallNormal), -1.0f, 1.0f)) >=
+    glm::radians(tms::k_climbReattachDifferentWallAngle);
+const bool attachPointValid = lowerThanPreviousAttach || differentEnoughWall;
+const bool climbSpaceValid = currentAttachHeight >= state.sim.climbBaseline &&
+                             currentAttachHeight <= state.sim.climbSpaceCutoff;
+```
+
+- [ ] **Step 4: Verify green and commit**
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+git add src/ecs/systems/MovementSystem.cpp tests/physics_trimesh_tests.cpp
+git commit -m "Implement Apex-style climb reattach rules"
+```
+
+### Task 6: Wallrun And Climb Interplay
+
+**Files:**
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests:
+
+```cpp
+bool wallrunIntoVerticalBlockCanBecomeClimbStick();
+bool sidewaysClimbCanTransitionIntoWallrun();
+bool wallrunReleaseStillOverridesAccidentalClimb();
+bool wallrunDoorGapDropsInsteadOfReverseOrAirAttach();
+```
+
+- [ ] **Step 2: Verify red**
+
+Expected: at least wallrun-to-climb and sideways-climb-to-wallrun fail.
+
+- [ ] **Step 3: Implement transition priority**
+
+Priority should be:
+
+1. jump release / explicit wallrun kick;
+2. mantle/ledge;
+3. valid wallrun continuation;
+4. wallrun-to-climb if forward obstacle is climbable and jump is held;
+5. drop.
+
+- [ ] **Step 4: Verify green and commit**
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+git add src/ecs/systems/MovementSystem.cpp tests/physics_trimesh_tests.cpp
+git commit -m "Connect climb and wallrun transitions"
+```
+
+### Final Verification
+
+- [ ] Run:
+
+```bash
+./build/debug/physics_trimesh_tests
+cmake --build build/debug --target group2 server -j 4
+PATH="/tmp/group2-clang-format-18:$PATH" git ls-files '*.cpp' '*.hpp' '*.h' '*.cc' '*.cxx' '*.c' '*.hh' '*.ipp' | PATH="/tmp/group2-clang-format-18:$PATH" xargs clang-format-18 --dry-run --Werror
+```
+
+- [ ] Playtest:
+  - climb straight up a wall;
+  - delayed forward stick;
+  - slip and downward climb;
+  - sideways climb;
+  - wall push around doors;
+  - wallrun into climb;
+  - climb into wallrun;
+  - repeated in-air reattach.
+
+- [ ] Commit final fixes.
+

--- a/docs/superpowers/plans/2026-05-17-traversal-polish.md
+++ b/docs/superpowers/plans/2026-05-17-traversal-polish.md
@@ -16,7 +16,7 @@
 - Modify: `tests/physics_trimesh_tests.cpp`
 - Modify: `src/ecs/systems/MovementSystem.cpp`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add tests that set `PlayerVisState::gravityFlipped = true` during `MoveMode::Climbing` and `MoveMode::LedgeGrabbing`.
 
@@ -24,7 +24,7 @@ Expected red behavior before the fix:
 - Climbing sets positive `vel.y`, which is wrong when local up is `-Y`.
 - Ledge auto-mantle sets positive `vel.y`, which is wrong when local up is `-Y`.
 
-- [ ] **Step 2: Run red tests**
+- [x] **Step 2: Run red tests**
 
 Run:
 
@@ -35,7 +35,7 @@ cmake --build build/debug --target physics_trimesh_tests -j 4
 
 Expected: FAIL with messages about flipped climb moving along local up and flipped ledge mantle pushing along local up.
 
-- [ ] **Step 3: Implement local-up movement**
+- [x] **Step 3: Implement local-up movement**
 
 Change climb and ledge velocity shaping to use:
 
@@ -52,11 +52,11 @@ if (upVel < 0.0f)
     vel.y = 0.0f;
 ```
 
-- [ ] **Step 4: Verify green**
+- [x] **Step 4: Verify green**
 
 Run the same test command. Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add tests/physics_trimesh_tests.cpp src/ecs/systems/MovementSystem.cpp
@@ -70,13 +70,13 @@ git commit -m "Fix inverted gravity climb and ledge movement"
 - Modify: `src/ecs/systems/MovementSystem.cpp`
 - Modify if query scoring needs a lower-level fix: `src/ecs/physics/TriMeshCollision.cpp`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add a simulation test for a wallrun approaching an authored outside 90-degree corner. The player starts on the first wall with `wallNormal = {-1,0,0}` and `wallForward = {0,0,1}`. The test expects the next movement tick to stay in `MoveMode::WallRunning`, rotate to the continuation wall normal `{0,0,-1}`, and keep forward speed non-negative against the redirected wall forward.
 
 Add a simulation test for a wallrun approaching a door/gap/dead-end with no forward-compatible continuation. The test expects the next movement tick to leave wallrunning and preserve non-reversed horizontal velocity.
 
-- [ ] **Step 2: Run red tests**
+- [x] **Step 2: Run red tests**
 
 Run:
 
@@ -87,7 +87,7 @@ cmake --build build/debug --target physics_trimesh_tests -j 4
 
 Expected: at least one new wallrun handoff/drop test fails before the production edit.
 
-- [ ] **Step 3: Implement candidate compatibility**
+- [x] **Step 3: Implement candidate compatibility**
 
 In `handleWallRunning`, accept a refreshed attachment only when the new surface can produce a forward-compatible tangent:
 
@@ -99,11 +99,11 @@ const bool notReversedVelocity = glm::dot(horizVel(vel), redirected) > -1.0f;
 
 If no compatible candidate exists, call `exitWallrun()` and return. Do not flip `wallForward` 180 degrees to keep the player attached.
 
-- [ ] **Step 4: Prefer outside-corner candidates over stale wall candidates**
+- [x] **Step 4: Prefer outside-corner candidates over stale wall candidates**
 
 When a lookahead attachment is available, prefer a candidate whose normal turns by up to 90 degrees and whose redirected tangent remains forward-compatible. Reject candidates with a turn greater than `k_wallrunMaxFaceRedirect` or with a tangent opposite the stored travel direction.
 
-- [ ] **Step 5: Verify green**
+- [x] **Step 5: Verify green**
 
 Run:
 
@@ -115,7 +115,7 @@ cmake --build build/debug --target group2 server -j 4
 
 Expected: all pass with no compiler warnings.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add tests/physics_trimesh_tests.cpp src/ecs/systems/MovementSystem.cpp src/ecs/physics/TriMeshCollision.cpp
@@ -130,7 +130,7 @@ git commit -m "Stabilize wallrun corner handoff and gap detach"
 - Modify: `src/ecs/systems/MovementSystem.cpp`
 - Modify: `tests/physics_trimesh_tests.cpp`
 
-- [ ] **Step 1: Write failing tests**
+- [x] **Step 1: Write failing tests**
 
 Add tests for:
 - brief stick on wall contact without forward input;
@@ -139,7 +139,7 @@ Add tests for:
 - non-upward climb timer expiry;
 - same-wall reattach blocked until the player drops below the previous attach height, but allowed on a sufficiently different wall normal.
 
-- [ ] **Step 2: Implement minimal state**
+- [x] **Step 2: Implement minimal state**
 
 Add climb attach tracking:
 
@@ -150,7 +150,7 @@ float climbNonUpTimer{0.0f};
 bool climbHadUpwardMotion{false};
 ```
 
-- [ ] **Step 3: Implement phases**
+- [x] **Step 3: Implement phases**
 
 Use Apex-inspired rules:
 - attach requires airborne wall contact and wall-facing/movement-toward-wall intent;
@@ -159,7 +159,7 @@ Use Apex-inspired rules:
 - neutral or away-from-wall input slips/down-climbs instead of forcing upward climb;
 - jump/crouch/back detach cleanly and preserve outgoing velocity.
 
-- [ ] **Step 4: Verify**
+- [x] **Step 4: Verify**
 
 Run:
 

--- a/docs/superpowers/plans/2026-05-17-traversal-polish.md
+++ b/docs/superpowers/plans/2026-05-17-traversal-polish.md
@@ -170,7 +170,7 @@ cmake --build build/debug --target physics_trimesh_tests group2 server -j 4
 
 Expected: all traversal tests pass with no warnings.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/ecs/components/PlayerSimState.hpp src/ecs/physics/TitanfallConstants.hpp src/ecs/systems/MovementSystem.cpp tests/physics_trimesh_tests.cpp
@@ -179,12 +179,12 @@ git commit -m "Add Apex-style climb phase foundation"
 
 ### Final Verification
 
-- [ ] Run `./build/debug/physics_trimesh_tests`.
-- [ ] Run `cmake --build build/debug --target group2 server -j 4`.
-- [ ] Run the CI format gate:
+- [x] Run `./build/debug/physics_trimesh_tests`.
+- [x] Run `cmake --build build/debug --target group2 server -j 4`.
+- [x] Run the CI format gate:
 
 ```bash
 PATH="/tmp/group2-clang-format-18:$PATH" git ls-files '*.cpp' '*.hpp' '*.h' '*.cc' '*.cxx' '*.c' '*.hh' '*.ipp' | PATH="/tmp/group2-clang-format-18:$PATH" xargs clang-format-18 --dry-run --Werror
 ```
 
-- [ ] Commit any final fixes.
+- [x] Commit any final fixes.

--- a/docs/superpowers/plans/2026-05-17-traversal-polish.md
+++ b/docs/superpowers/plans/2026-05-17-traversal-polish.md
@@ -1,0 +1,190 @@
+# Traversal Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make climb/ledge behavior gravity-invariant and make wallrunning continue only through forward-compatible outside corners while dropping cleanly at gaps, doors, and dead ends.
+
+**Architecture:** Keep `MovementSystem` as the owner of traversal state and velocity shaping, and keep `WallDetection`/`TriMeshCollision` as the owner of mesh queries. Add regression coverage in `tests/physics_trimesh_tests.cpp` before production edits. The implementation should stay deterministic and avoid animation/camera-only smoothing as a substitute for solver state.
+
+**Tech Stack:** C++20, EnTT ECS, GLM, custom static-trimesh collision/KCC, `physics_trimesh_tests`.
+
+---
+
+### Task 1: Gravity-Invariant Climb And Ledge
+
+**Files:**
+- Modify: `tests/physics_trimesh_tests.cpp`
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests that set `PlayerVisState::gravityFlipped = true` during `MoveMode::Climbing` and `MoveMode::LedgeGrabbing`.
+
+Expected red behavior before the fix:
+- Climbing sets positive `vel.y`, which is wrong when local up is `-Y`.
+- Ledge auto-mantle sets positive `vel.y`, which is wrong when local up is `-Y`.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+```
+
+Expected: FAIL with messages about flipped climb moving along local up and flipped ledge mantle pushing along local up.
+
+- [ ] **Step 3: Implement local-up movement**
+
+Change climb and ledge velocity shaping to use:
+
+```cpp
+const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+vel.y = climbOrMantleSpeed * gravDir;
+```
+
+Clamp climb entry velocity with the same local-up convention:
+
+```cpp
+const float upVel = vel.y * gravDir;
+if (upVel < 0.0f)
+    vel.y = 0.0f;
+```
+
+- [ ] **Step 4: Verify green**
+
+Run the same test command. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/physics_trimesh_tests.cpp src/ecs/systems/MovementSystem.cpp
+git commit -m "Fix inverted gravity climb and ledge movement"
+```
+
+### Task 2: Wallrun Forward-Compatible Handoff
+
+**Files:**
+- Modify: `tests/physics_trimesh_tests.cpp`
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify if query scoring needs a lower-level fix: `src/ecs/physics/TriMeshCollision.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add a simulation test for a wallrun approaching an authored outside 90-degree corner. The player starts on the first wall with `wallNormal = {-1,0,0}` and `wallForward = {0,0,1}`. The test expects the next movement tick to stay in `MoveMode::WallRunning`, rotate to the continuation wall normal `{0,0,-1}`, and keep forward speed non-negative against the redirected wall forward.
+
+Add a simulation test for a wallrun approaching a door/gap/dead-end with no forward-compatible continuation. The test expects the next movement tick to leave wallrunning and preserve non-reversed horizontal velocity.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+```
+
+Expected: at least one new wallrun handoff/drop test fails before the production edit.
+
+- [ ] **Step 3: Implement candidate compatibility**
+
+In `handleWallRunning`, accept a refreshed attachment only when the new surface can produce a forward-compatible tangent:
+
+```cpp
+const glm::vec3 redirected = redirectWallForward(oldForward, oldNormal, candidateNormal);
+const bool forwardCompatible = glm::dot(redirected, oldForward) > 0.05f;
+const bool notReversedVelocity = glm::dot(horizVel(vel), redirected) > -1.0f;
+```
+
+If no compatible candidate exists, call `exitWallrun()` and return. Do not flip `wallForward` 180 degrees to keep the player attached.
+
+- [ ] **Step 4: Prefer outside-corner candidates over stale wall candidates**
+
+When a lookahead attachment is available, prefer a candidate whose normal turns by up to 90 degrees and whose redirected tangent remains forward-compatible. Reject candidates with a turn greater than `k_wallrunMaxFaceRedirect` or with a tangent opposite the stored travel direction.
+
+- [ ] **Step 5: Verify green**
+
+Run:
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests -j 4
+./build/debug/physics_trimesh_tests
+cmake --build build/debug --target group2 server -j 4
+```
+
+Expected: all pass with no compiler warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/physics_trimesh_tests.cpp src/ecs/systems/MovementSystem.cpp src/ecs/physics/TriMeshCollision.cpp
+git commit -m "Stabilize wallrun corner handoff and gap detach"
+```
+
+### Task 3: Apex-Style Climb Foundation
+
+**Files:**
+- Modify: `src/ecs/components/PlayerSimState.hpp`
+- Modify: `src/ecs/physics/TitanfallConstants.hpp`
+- Modify: `src/ecs/systems/MovementSystem.cpp`
+- Modify: `tests/physics_trimesh_tests.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for:
+- brief stick on wall contact without forward input;
+- upward climb while movement points into the wall;
+- downward/slip behavior when movement points away or input is neutral;
+- non-upward climb timer expiry;
+- same-wall reattach blocked until the player drops below the previous attach height, but allowed on a sufficiently different wall normal.
+
+- [ ] **Step 2: Implement minimal state**
+
+Add climb attach tracking:
+
+```cpp
+glm::vec3 climbAttachPoint{0.0f};
+float climbAttachHeight{0.0f};
+float climbNonUpTimer{0.0f};
+bool climbHadUpwardMotion{false};
+```
+
+- [ ] **Step 3: Implement phases**
+
+Use Apex-inspired rules:
+- attach requires airborne wall contact and wall-facing/movement-toward-wall intent;
+- upward climb is timerless while local-up velocity is above threshold;
+- non-upward climb detaches after a short timer;
+- neutral or away-from-wall input slips/down-climbs instead of forcing upward climb;
+- jump/crouch/back detach cleanly and preserve outgoing velocity.
+
+- [ ] **Step 4: Verify**
+
+Run:
+
+```bash
+cmake --build build/debug --target physics_trimesh_tests group2 server -j 4
+./build/debug/physics_trimesh_tests
+```
+
+Expected: all traversal tests pass with no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ecs/components/PlayerSimState.hpp src/ecs/physics/TitanfallConstants.hpp src/ecs/systems/MovementSystem.cpp tests/physics_trimesh_tests.cpp
+git commit -m "Add Apex-style climb phase foundation"
+```
+
+### Final Verification
+
+- [ ] Run `./build/debug/physics_trimesh_tests`.
+- [ ] Run `cmake --build build/debug --target group2 server -j 4`.
+- [ ] Run the CI format gate:
+
+```bash
+PATH="/tmp/group2-clang-format-18:$PATH" git ls-files '*.cpp' '*.hpp' '*.h' '*.cc' '*.cxx' '*.c' '*.hh' '*.ipp' | PATH="/tmp/group2-clang-format-18:$PATH" xargs clang-format-18 --dry-run --Werror
+```
+
+- [ ] Commit any final fixes.

--- a/src/ecs/components/PlayerSimState.hpp
+++ b/src/ecs/components/PlayerSimState.hpp
@@ -75,8 +75,12 @@ struct PlayerSimState
     bool wallBlacklistActive{false};
 
     // ── Climbing ───────────────────────────────────────────────────────────
-    glm::vec3 climbWallNormal{0.0f}; ///< Normal of the wall being climbed.
-    float climbTimer{0.0f};          ///< Time on current climb (s).
+    glm::vec3 climbWallNormal{0.0f};  ///< Normal of the wall being climbed.
+    glm::vec3 climbAttachPoint{0.0f}; ///< Surface point where the current climb attached.
+    float climbAttachHeight{0.0f};    ///< World Y at climb attach; used for same-wall regrab gating.
+    float climbNonUpTimer{0.0f};      ///< Time spent attached without upward climb intent/motion (s).
+    float climbTimer{0.0f};           ///< Time on current climb (s).
+    bool climbHadUpwardMotion{false}; ///< True once this climb produces local-up velocity.
     float exitClimbTimer{0.0f};
     bool wasClimbing{false};
 

--- a/src/ecs/components/PlayerSimState.hpp
+++ b/src/ecs/components/PlayerSimState.hpp
@@ -66,8 +66,10 @@ struct PlayerSimState
     uint32_t wallMeshIndex{UINT32_MAX}; ///< Current static collision mesh under the wall attachment, if any.
     uint32_t wallTriId{UINT32_MAX};     ///< Current mesh triangle under the wall attachment, if any.
     physics::TriRegion wallRegion{physics::TriRegion::Face}; ///< Closest feature on `wallMeshIndex` / `wallTriId`.
-    bool wallAttachmentValid{false}; ///< True while the wallrun has a collision-backed attachment.
-    bool wasWallRunning{false};      ///< Set briefly after leaving wallrun (coyote wall jump).
+    bool wallAttachmentValid{false};             ///< True while the wallrun has a collision-backed attachment.
+    glm::vec3 wallRecentHandoffFromNormal{0.0f}; ///< Previous wall normal briefly blocked to avoid corner ping-pong.
+    float wallRecentHandoffTimer{0.0f};          ///< Remaining time to suppress immediate handoff backtracks (s).
+    bool wasWallRunning{false};                  ///< Set briefly after leaving wallrun (coyote wall jump).
 
     // Wall blacklist: stores the last wall's normal + height to prevent regrab.
     glm::vec3 wallBlacklistNormal{0.0f};

--- a/src/ecs/components/PlayerSimState.hpp
+++ b/src/ecs/components/PlayerSimState.hpp
@@ -66,10 +66,20 @@ struct PlayerSimState
     uint32_t wallMeshIndex{UINT32_MAX}; ///< Current static collision mesh under the wall attachment, if any.
     uint32_t wallTriId{UINT32_MAX};     ///< Current mesh triangle under the wall attachment, if any.
     physics::TriRegion wallRegion{physics::TriRegion::Face}; ///< Closest feature on `wallMeshIndex` / `wallTriId`.
-    bool wallAttachmentValid{false};             ///< True while the wallrun has a collision-backed attachment.
-    glm::vec3 wallRecentHandoffFromNormal{0.0f}; ///< Previous wall normal briefly blocked to avoid corner ping-pong.
-    float wallRecentHandoffTimer{0.0f};          ///< Remaining time to suppress immediate handoff backtracks (s).
-    bool wasWallRunning{false};                  ///< Set briefly after leaving wallrun (coyote wall jump).
+    bool wallAttachmentValid{false};          ///< True while the wallrun has a collision-backed attachment.
+    bool wallCornerTransitionActive{false};   ///< True while carrying a pending external-corner handoff.
+    glm::vec3 wallCornerAnchor{0.0f};         ///< Corner/seam point used as the transition clearance origin.
+    glm::vec3 wallCornerFromNormal{0.0f};     ///< Wall normal held until the capsule clears the old wall edge.
+    glm::vec3 wallCornerFromForward{0.0f};    ///< Old wall tangent held during the corner approach.
+    glm::vec3 wallCornerToNormal{0.0f};       ///< Pending wall normal to attach after clearance.
+    glm::vec3 wallCornerToForward{0.0f};      ///< Pending wall tangent to use after clearance.
+    uint32_t wallCornerMeshIndex{UINT32_MAX}; ///< Pending wall mesh after corner clearance.
+    uint32_t wallCornerTriId{UINT32_MAX};     ///< Pending wall triangle after corner clearance.
+    physics::TriRegion wallCornerRegion{physics::TriRegion::Face}; ///< Pending wall feature after clearance.
+    float wallCornerTimer{0.0f};                                   ///< Time spent in the active corner transition (s).
+    glm::vec3 wallCornerIgnoreNormal{0.0f}; ///< Source wall briefly ignored after a corner commit.
+    float wallCornerIgnoreTimer{0.0f};      ///< Remaining time to suppress source-wall backtracking.
+    bool wasWallRunning{false};             ///< Set briefly after leaving wallrun (coyote wall jump).
 
     // Wall blacklist: stores the last wall's normal + height to prevent regrab.
     glm::vec3 wallBlacklistNormal{0.0f};

--- a/src/ecs/physics/TitanfallConstants.hpp
+++ b/src/ecs/physics/TitanfallConstants.hpp
@@ -105,18 +105,22 @@ constexpr float k_wallrunMaxFaceRedirect = 1.57079632679f; ///< Max face-normal 
 
 // Climbing
 
-constexpr float k_climbCheckDist = 35.0f;          ///< Forward sphere-cast distance (u).
-constexpr float k_climbSphereRadius = 12.0f;       ///< Sphere-cast radius for climb detection (u).
-constexpr float k_climbMaxSpeed = 280.0f;          ///< Max upward climbing speed (u/s).
-constexpr float k_climbMinSpeed = 180.0f;          ///< Min climbing speed (after decay) (u/s).
-constexpr float k_climbKickoffDuration = 2.0f;     ///< Max climb time on same wall (s).
-constexpr float k_climbMaxWallLookAngle = 30.0f;   ///< Max angle (degrees) between look dir and wall normal.
-constexpr float k_climbSidewaysMultiplier = 0.1f;  ///< Sideways movement reduction while climbing.
-constexpr float k_climbJumpUpForce = 320.0f;       ///< Upward velocity on climb jump (u/s).
-constexpr float k_climbJumpBackForce = 350.0f;     ///< Backward velocity on climb jump (u/s).
-constexpr float k_climbMinGroundDist = 40.0f;      ///< Min height above ground to start climbing (u).
-constexpr float k_climbExitTime = 0.5f;            ///< Duration of "exiting climb" flag (s).
-constexpr float k_climbRegrabLowerHeight = 400.0f; ///< Must be this much lower to regrab same wall (u).
+constexpr float k_climbCheckDist = 35.0f;           ///< Forward sphere-cast distance (u).
+constexpr float k_climbSphereRadius = 12.0f;        ///< Sphere-cast radius for climb detection (u).
+constexpr float k_climbMaxSpeed = 280.0f;           ///< Max upward climbing speed (u/s).
+constexpr float k_climbMinSpeed = 180.0f;           ///< Min climbing speed (after decay) (u/s).
+constexpr float k_climbKickoffDuration = 2.0f;      ///< Max climb time on same wall (s).
+constexpr float k_climbMaxWallLookAngle = 30.0f;    ///< Max angle (degrees) between look dir and wall normal.
+constexpr float k_climbSidewaysMultiplier = 0.1f;   ///< Sideways movement reduction while climbing.
+constexpr float k_climbIntentThreshold = 0.1f;      ///< Min dot(wishDir, -wallNormal) for active upward climb.
+constexpr float k_climbSlipSpeed = 90.0f;           ///< Local-down slip speed while attached without up intent (u/s).
+constexpr float k_climbNonUpDetachTime = 0.25f;     ///< Grace time before slipping/no-up climb detaches (s).
+constexpr float k_climbUpVelocityThreshold = 25.0f; ///< Local-up velocity that counts as committed climb motion (u/s).
+constexpr float k_climbJumpUpForce = 320.0f;        ///< Upward velocity on climb jump (u/s).
+constexpr float k_climbJumpBackForce = 350.0f;      ///< Backward velocity on climb jump (u/s).
+constexpr float k_climbMinGroundDist = 40.0f;       ///< Min height above ground to start climbing (u).
+constexpr float k_climbExitTime = 0.5f;             ///< Duration of "exiting climb" flag (s).
+constexpr float k_climbRegrabLowerHeight = 400.0f;  ///< Must be this much lower to regrab same wall (u).
 
 // Ledge grabbing
 

--- a/src/ecs/physics/WallDetection.cpp
+++ b/src/ecs/physics/WallDetection.cpp
@@ -201,26 +201,28 @@ WallAttachmentResult findWallRunAttachment(CapsuleShape capsule,
         if (!prevCp.found)
             return;
 
-        TriRegion seamRegion = prevCp.region;
-        if (edgeIndexForRegion(seamRegion) < 0 && incidentEdgeForVertex(seamRegion, 0) < 0)
-            seamRegion = previousRegion;
+        auto considerSeamRegion = [&](TriRegion seamRegion) {
+            const int edge = edgeIndexForRegion(seamRegion);
+            if (edge >= 0) {
+                const size_t neighborIndex = static_cast<size_t>(previousTriId) * 3u + static_cast<size_t>(edge);
+                if (neighborIndex < mesh.edgeNeighbor.size())
+                    considerNeighbor(meshIndex, mesh, mesh.edgeNeighbor[neighborIndex]);
+                return;
+            }
 
-        const int edge = edgeIndexForRegion(seamRegion);
-        if (edge >= 0) {
-            const size_t neighborIndex = static_cast<size_t>(previousTriId) * 3u + static_cast<size_t>(edge);
-            if (neighborIndex < mesh.edgeNeighbor.size())
-                considerNeighbor(meshIndex, mesh, mesh.edgeNeighbor[neighborIndex]);
-            return;
-        }
+            for (int slot = 0; slot < 2; ++slot) {
+                const int vertexEdge = incidentEdgeForVertex(seamRegion, slot);
+                if (vertexEdge < 0)
+                    continue;
+                const size_t neighborIndex = static_cast<size_t>(previousTriId) * 3u + static_cast<size_t>(vertexEdge);
+                if (neighborIndex < mesh.edgeNeighbor.size())
+                    considerNeighbor(meshIndex, mesh, mesh.edgeNeighbor[neighborIndex]);
+            }
+        };
 
-        for (int slot = 0; slot < 2; ++slot) {
-            const int vertexEdge = incidentEdgeForVertex(seamRegion, slot);
-            if (vertexEdge < 0)
-                continue;
-            const size_t neighborIndex = static_cast<size_t>(previousTriId) * 3u + static_cast<size_t>(vertexEdge);
-            if (neighborIndex < mesh.edgeNeighbor.size())
-                considerNeighbor(meshIndex, mesh, mesh.edgeNeighbor[neighborIndex]);
-        }
+        considerSeamRegion(prevCp.region);
+        if (previousRegion != prevCp.region)
+            considerSeamRegion(previousRegion);
     };
 
     auto considerMesh = [&](uint32_t meshIndex, const WorldTriMesh& mesh) {

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -1084,7 +1084,9 @@ void tryEnterClimb(glm::vec3& vel,
     // Reduce horizontal velocity immediately.
     vel.x *= tms::k_climbSidewaysMultiplier;
     vel.z *= tms::k_climbSidewaysMultiplier;
-    vel.y = std::max(vel.y, 0.0f);
+    const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+    if (vel.y * gravDir < 0.0f)
+        vel.y = 0.0f;
 }
 
 /// @brief Exit climb mode and start cooldown timers.
@@ -1128,7 +1130,8 @@ void handleClimbing(glm::vec3& vel,
     const float k_decayAlpha = std::clamp(state.sim.climbTimer / tms::k_climbKickoffDuration, 0.0f, 1.0f);
     const float k_climbSpeed = std::lerp(tms::k_climbMaxSpeed, tms::k_climbMinSpeed, k_decayAlpha);
 
-    vel.y = k_climbSpeed;
+    const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+    vel.y = k_climbSpeed * gravDir;
 
     // Minimal sideways movement.
     vel.x *= tms::k_climbSidewaysMultiplier;
@@ -1187,7 +1190,8 @@ void handleLedgeGrab(glm::vec3& vel, PlayerStateRef state, const InputSnapshot& 
 
     // Auto-mantle: if holding movement keys past min hold time.
     if (state.sim.ledgeHoldTimer >= tms::k_ledgeMinHoldTime && anyMoveInput(input)) {
-        vel.y = tms::k_ledgeJumpUpForce;
+        const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+        vel.y = tms::k_ledgeJumpUpForce * gravDir;
         const glm::vec3 ledgeNormal = normalizedOrZero(state.sim.ledgeNormal);
         if (glm::dot(ledgeNormal, ledgeNormal) > 0.0f)
             vel += ledgeNormal * tms::k_ledgeJumpBackForce;

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -641,7 +641,10 @@ namespace
 {
 
 constexpr float k_wallrunAttachPushback = 0.03125f;
-constexpr float k_wallrunReturnHandoffCooldown = 0.14f;
+constexpr float k_wallrunCornerClearancePadding = 1.0f;
+constexpr float k_wallrunCornerMaxTransitionTime = 0.22f;
+constexpr float k_wallrunCornerIntoOldWallDot = -0.25f;
+constexpr float k_wallrunCornerSourceIgnoreTime = 0.16f;
 
 /// @brief Check if a wall normal matches the blacklist (same wall).
 /// @param normal    Wall normal to test.
@@ -683,6 +686,26 @@ struct WallAttachmentProbe
     uint32_t triId{UINT32_MAX};
     physics::TriRegion region{physics::TriRegion::Face};
 };
+
+void clearWallCornerTransition(PlayerStateRef state)
+{
+    state.sim.wallCornerTransitionActive = false;
+    state.sim.wallCornerAnchor = glm::vec3{0.0f};
+    state.sim.wallCornerFromNormal = glm::vec3{0.0f};
+    state.sim.wallCornerFromForward = glm::vec3{0.0f};
+    state.sim.wallCornerToNormal = glm::vec3{0.0f};
+    state.sim.wallCornerToForward = glm::vec3{0.0f};
+    state.sim.wallCornerMeshIndex = UINT32_MAX;
+    state.sim.wallCornerTriId = UINT32_MAX;
+    state.sim.wallCornerRegion = physics::TriRegion::Face;
+    state.sim.wallCornerTimer = 0.0f;
+}
+
+void clearWallCornerIgnore(PlayerStateRef state)
+{
+    state.sim.wallCornerIgnoreNormal = glm::vec3{0.0f};
+    state.sim.wallCornerIgnoreTimer = 0.0f;
+}
 
 WallAttachmentProbe findWallAttachment(glm::vec3 pos,
                                        const CollisionShape& shape,
@@ -805,6 +828,45 @@ glm::vec3 redirectWallForwardTowardAnchor(
     return redirectWallForward(oldForward, oldNormal, newNormal);
 }
 
+void finishWallrunFrame(glm::vec3& vel, PlayerStateRef state, const InputSnapshot& input, float dt)
+{
+    const glm::vec3 k_hv = horizVel(vel);
+    const float k_hvLen = glm::length(k_hv);
+
+    glm::vec3 wallFwd;
+    if (k_hvLen > 1.0f) {
+        wallFwd = k_hv - state.sim.wallNormal * glm::dot(k_hv, state.sim.wallNormal);
+        const float k_projLen = glm::length(wallFwd);
+        if (k_projLen > 0.001f)
+            wallFwd /= k_projLen;
+        else
+            wallFwd = state.sim.wallForward;
+    } else {
+        wallFwd = state.sim.wallForward;
+    }
+
+    if (glm::dot(state.sim.wallForward, wallFwd) < 0.0f)
+        wallFwd = -wallFwd;
+    state.sim.wallForward = wallFwd;
+
+    const float k_currentFwdSpeed = glm::dot(k_hv, state.sim.wallForward);
+    if (k_currentFwdSpeed < tms::k_wallrunMaxSpeed) {
+        const float k_addSpeed = std::min(tms::k_wallrunAccel * dt, tms::k_wallrunMaxSpeed - k_currentFwdSpeed);
+        vel += state.sim.wallForward * k_addSpeed;
+    }
+
+    if (state.sim.wallRunSpeedTimer > tms::k_wallrunSpeedLossDelay)
+        clampHorizSpeed(vel, tms::k_wallrunMaxSpeed);
+
+    vel.y *= std::exp(-dt / tms::k_wallrunVerticalDecayTau);
+    vel -= state.sim.wallNormal * glm::dot(vel, state.sim.wallNormal);
+
+    const float sideDot = glm::dot(state.sim.wallNormal, glm::vec3{std::cos(input.yaw), 0.0f, -std::sin(input.yaw)});
+    state.vis.wallRunSide = (sideDot < 0.0f) ? WallSide::Right : WallSide::Left;
+    state.vis.targetCameraTilt =
+        std::clamp(-sideDot * tms::k_wallrunCameraTilt, -tms::k_wallrunCameraTilt, tms::k_wallrunCameraTilt);
+}
+
 /// @brief Attempt to enter wallrun mode when airborne near a wall.
 /// @param vel    Velocity (modified in place).
 /// @param state  Player state (modified in place).
@@ -875,8 +937,8 @@ void tryEnterWallrun(glm::vec3& vel,
         state.sim.wallForward = wallFwd;
         state.sim.wallRunTimer = 0.0f;
         state.sim.wallRunSpeedTimer = 0.0f;
-        state.sim.wallRecentHandoffTimer = 0.0f;
-        state.sim.wallRecentHandoffFromNormal = glm::vec3{0.0f};
+        clearWallCornerTransition(state);
+        clearWallCornerIgnore(state);
         seedWallAttachmentFromProbe(state, wallPoint, wallNorm, meshIndex, triId, region);
 
         const WallAttachmentProbe attachment = findWallAttachment(pos, shape, world, wallNorm);
@@ -941,8 +1003,124 @@ void exitWallrun(PlayerStateRef state, float posY)
     state.sim.wallAttachmentValid = false;
     state.sim.wallMeshIndex = UINT32_MAX;
     state.sim.wallTriId = UINT32_MAX;
-    state.sim.wallRecentHandoffTimer = 0.0f;
-    state.sim.wallRecentHandoffFromNormal = glm::vec3{0.0f};
+    clearWallCornerTransition(state);
+    clearWallCornerIgnore(state);
+}
+
+float desiredWallrunStandoff(const CollisionShape& shape, glm::vec3 normal)
+{
+    return (shape.type == CollisionShapeType::Capsule)
+               ? capsuleQueryForWallrun(shape).minkowskiExtent(normal) + k_wallrunAttachPushback
+               : shape.minkowskiExtent(normal) + k_wallrunAttachPushback;
+}
+
+void startWallCornerTransition(PlayerStateRef state,
+                               const WallAttachmentProbe& attachment,
+                               glm::vec3 fromNormal,
+                               glm::vec3 fromForward,
+                               glm::vec3 toForward)
+{
+    state.sim.wallCornerTransitionActive = true;
+    state.sim.wallCornerAnchor = attachment.anchor;
+    state.sim.wallCornerFromNormal = fromNormal;
+    state.sim.wallCornerFromForward = fromForward;
+    state.sim.wallCornerToNormal = attachment.normal;
+    state.sim.wallCornerToForward = toForward;
+    state.sim.wallCornerMeshIndex = attachment.meshIndex;
+    state.sim.wallCornerTriId = attachment.triId;
+    state.sim.wallCornerRegion = attachment.region;
+    state.sim.wallCornerTimer = 0.0f;
+}
+
+bool handleWallCornerTransition(glm::vec3& pos,
+                                glm::vec3& vel,
+                                PlayerStateRef state,
+                                const InputSnapshot& input,
+                                const CollisionShape& shape,
+                                const physics::WorldGeometry& world,
+                                float posY,
+                                float dt,
+                                float preAttachHorizSpeed)
+{
+    if (!state.sim.wallCornerTransitionActive)
+        return false;
+
+    state.sim.wallCornerTimer += dt;
+
+    const glm::vec3 fromNormal = state.sim.wallCornerFromNormal;
+    const glm::vec3 fromForward = state.sim.wallCornerFromForward;
+    const glm::vec3 cornerAnchor = state.sim.wallCornerAnchor;
+    const float clearance = shape.radius + k_wallrunCornerClearancePadding;
+    const float progress = glm::dot(pos - cornerAnchor, fromForward);
+    const bool clearOfOldWall = progress >= clearance;
+
+    if (!clearOfOldWall) {
+        if (state.sim.wallCornerTimer > k_wallrunCornerMaxTransitionTime) {
+            exitWallrun(state, posY);
+            return true;
+        }
+
+        WallAttachmentProbe oldAttachment = findWallAttachment(pos,
+                                                               shape,
+                                                               world,
+                                                               fromNormal,
+                                                               glm::vec3{0.0f},
+                                                               0.0f,
+                                                               state.sim.wallMeshIndex,
+                                                               state.sim.wallTriId,
+                                                               state.sim.wallRegion);
+        state.sim.wallNormal = fromNormal;
+        state.sim.wallForward = fromForward;
+        if (oldAttachment.found && glm::dot(oldAttachment.normal, fromNormal) > 0.95f) {
+            state.sim.wallAnchor = oldAttachment.anchor;
+            state.sim.wallMeshIndex = oldAttachment.meshIndex;
+            state.sim.wallTriId = oldAttachment.triId;
+            state.sim.wallRegion = oldAttachment.region;
+
+            const float desiredStandoff = desiredWallrunStandoff(shape, state.sim.wallNormal);
+            const float currentStandoff = glm::dot(pos - state.sim.wallAnchor, state.sim.wallNormal);
+            pos += state.sim.wallNormal * (desiredStandoff - currentStandoff);
+        }
+
+        const float verticalVel = vel.y;
+        vel = fromForward * preAttachHorizSpeed;
+        vel.y = verticalVel;
+        finishWallrunFrame(vel, state, input, dt);
+        return true;
+    }
+
+    glm::vec3 toNormal = state.sim.wallCornerToNormal;
+    const glm::vec3 toAnchor = state.sim.wallCornerAnchor;
+    if (glm::dot(pos - toAnchor, toNormal) < 0.0f)
+        toNormal = -toNormal;
+
+    const glm::vec3 toForward = redirectWallForwardTowardAnchor(fromForward, fromNormal, toNormal, pos, toAnchor);
+    const glm::vec3 wishDir = physics::computeWishDir(input.yaw, input.forward, input.back, input.left, input.right);
+    if (glm::length(wishDir) > 0.5f && glm::dot(wishDir, toForward) < -0.05f) {
+        exitWallrun(state, posY);
+        return true;
+    }
+
+    state.sim.wallAnchor = toAnchor;
+    state.sim.wallNormal = toNormal;
+    state.sim.wallForward = toForward;
+    state.sim.wallMeshIndex = state.sim.wallCornerMeshIndex;
+    state.sim.wallTriId = state.sim.wallCornerTriId;
+    state.sim.wallRegion = state.sim.wallCornerRegion;
+    state.sim.wallAttachmentValid = true;
+    clearWallCornerTransition(state);
+    state.sim.wallCornerIgnoreNormal = fromNormal;
+    state.sim.wallCornerIgnoreTimer = k_wallrunCornerSourceIgnoreTime;
+
+    const float desiredStandoff = desiredWallrunStandoff(shape, state.sim.wallNormal);
+    const float currentStandoff = glm::dot(pos - state.sim.wallAnchor, state.sim.wallNormal);
+    pos += state.sim.wallNormal * (desiredStandoff - currentStandoff);
+
+    const float verticalVel = vel.y;
+    vel = state.sim.wallForward * preAttachHorizSpeed;
+    vel.y = verticalVel;
+    finishWallrunFrame(vel, state, input, dt);
+    return true;
 }
 
 /// @brief Process wallrunning movement, exit conditions, and camera tilt.
@@ -967,7 +1145,7 @@ void handleWallRunning(glm::vec3& pos,
 {
     state.sim.wallRunTimer += dt;
     state.sim.wallRunSpeedTimer += dt;
-    state.sim.wallRecentHandoffTimer = std::max(0.0f, state.sim.wallRecentHandoffTimer - dt);
+    state.sim.wallCornerIgnoreTimer = std::max(0.0f, state.sim.wallCornerIgnoreTimer - dt);
 
     // Lucio-style detach: jump released → fire the full wall-jump impulse
     // away from the wall, then exit. Holding jump is what kept the player
@@ -990,6 +1168,9 @@ void handleWallRunning(glm::vec3& pos,
     const glm::vec3 oldForward = state.sim.wallForward;
     const float preAttachHorizSpeed = glm::length(horizVel(vel));
     const float handoffLookahead = std::clamp(preAttachHorizSpeed * dt + 4.0f, 4.0f, shape.radius);
+
+    if (handleWallCornerTransition(pos, vel, state, input, shape, world, posY, dt, preAttachHorizSpeed))
+        return;
 
     WallAttachmentProbe attachment = findWallAttachment(pos,
                                                         shape,
@@ -1018,28 +1199,27 @@ void handleWallRunning(glm::vec3& pos,
         }
     }
 
-    float normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
-    if (normalTurn > 0.05f && state.sim.wallRecentHandoffTimer > 0.0f &&
-        glm::dot(attachment.normal, state.sim.wallRecentHandoffFromNormal) > 0.95f)
+    if (attachment.found && state.sim.wallCornerIgnoreTimer > 0.0f &&
+        glm::dot(attachment.normal, state.sim.wallCornerIgnoreNormal) > 0.95f)
     {
-        const WallAttachmentProbe stickyAttachment = findWallAttachment(pos,
-                                                                        shape,
-                                                                        world,
-                                                                        oldNormal,
-                                                                        glm::vec3{0.0f},
-                                                                        0.0f,
-                                                                        state.sim.wallMeshIndex,
-                                                                        state.sim.wallTriId,
-                                                                        state.sim.wallRegion);
-        if (stickyAttachment.found && glm::dot(stickyAttachment.normal, oldNormal) > 0.95f) {
-            attachment = stickyAttachment;
-            normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
+        const WallAttachmentProbe currentWallAttachment = findWallAttachment(pos,
+                                                                             shape,
+                                                                             world,
+                                                                             oldNormal,
+                                                                             glm::vec3{0.0f},
+                                                                             0.0f,
+                                                                             state.sim.wallMeshIndex,
+                                                                             state.sim.wallTriId,
+                                                                             state.sim.wallRegion);
+        if (currentWallAttachment.found && glm::dot(currentWallAttachment.normal, oldNormal) > 0.95f) {
+            attachment = currentWallAttachment;
         } else {
             exitWallrun(state, posY);
             return;
         }
     }
 
+    float normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
     if (normalTurn > tms::k_wallrunMaxFaceRedirect + 1e-4f) {
         exitWallrun(state, posY);
         return;
@@ -1053,6 +1233,19 @@ void handleWallRunning(glm::vec3& pos,
         return;
     }
 
+    if (normalTurn > 0.05f) {
+        const glm::vec3 redirectedForward =
+            redirectWallForwardTowardAnchor(oldForward, oldNormal, attachment.normal, pos, attachment.anchor);
+        if (glm::dot(redirectedForward, oldNormal) < k_wallrunCornerIntoOldWallDot) {
+            startWallCornerTransition(state, attachment, oldNormal, oldForward, redirectedForward);
+            const float verticalVel = vel.y;
+            vel = oldForward * preAttachHorizSpeed;
+            vel.y = verticalVel;
+            finishWallrunFrame(vel, state, input, dt);
+            return;
+        }
+    }
+
     state.sim.wallAnchor = attachment.anchor;
     state.sim.wallNormal = attachment.normal;
     state.sim.wallMeshIndex = attachment.meshIndex;
@@ -1060,10 +1253,7 @@ void handleWallRunning(glm::vec3& pos,
     state.sim.wallRegion = attachment.region;
     state.sim.wallAttachmentValid = true;
 
-    const float desiredStandoff =
-        (shape.type == CollisionShapeType::Capsule)
-            ? capsuleQueryForWallrun(shape).minkowskiExtent(state.sim.wallNormal) + k_wallrunAttachPushback
-            : shape.minkowskiExtent(state.sim.wallNormal) + k_wallrunAttachPushback;
+    const float desiredStandoff = desiredWallrunStandoff(shape, state.sim.wallNormal);
     const glm::vec3 preStandoffPos = pos;
     const float currentStandoff = glm::dot(pos - state.sim.wallAnchor, state.sim.wallNormal);
     pos += state.sim.wallNormal * (desiredStandoff - currentStandoff);
@@ -1082,57 +1272,12 @@ void handleWallRunning(glm::vec3& pos,
         }
 
         state.sim.wallForward = redirectedForward;
-        state.sim.wallRecentHandoffFromNormal = oldNormal;
-        state.sim.wallRecentHandoffTimer = k_wallrunReturnHandoffCooldown;
         const float verticalVel = vel.y;
         vel = state.sim.wallForward * preAttachHorizSpeed;
         vel.y = verticalVel;
     }
 
-    // --- Compute wall-tangent acceleration direction ---
-    // Accelerate along the current velocity direction projected onto the wall
-    // plane.  This makes the controls intuitive: as long as wishDir has a
-    // component into the wall, the player is accelerated forward regardless
-    // of strafe keys.
-    const glm::vec3 k_hv = horizVel(vel);
-    const float k_hvLen = glm::length(k_hv);
-
-    glm::vec3 wallFwd;
-    if (k_hvLen > 1.0f) {
-        // Project current velocity onto the wall plane (remove normal component).
-        wallFwd = k_hv - state.sim.wallNormal * glm::dot(k_hv, state.sim.wallNormal);
-        const float k_projLen = glm::length(wallFwd);
-        if (k_projLen > 0.001f)
-            wallFwd /= k_projLen;
-        else
-            wallFwd = state.sim.wallForward;
-    } else {
-        wallFwd = state.sim.wallForward;
-    }
-
-    // Ensure consistency with stored direction (don't flip 180°).
-    if (glm::dot(state.sim.wallForward, wallFwd) < 0.0f)
-        wallFwd = -wallFwd;
-    state.sim.wallForward = wallFwd;
-
-    // Accelerate along the wall.
-    const float k_currentFwdSpeed = glm::dot(k_hv, state.sim.wallForward);
-    if (k_currentFwdSpeed < tms::k_wallrunMaxSpeed) {
-        const float k_addSpeed = std::min(tms::k_wallrunAccel * dt, tms::k_wallrunMaxSpeed - k_currentFwdSpeed);
-        vel += state.sim.wallForward * k_addSpeed;
-    }
-
-    // Speed clamping (after initial delay to allow wallkick tech).
-    if (state.sim.wallRunSpeedTimer > tms::k_wallrunSpeedLossDelay)
-        clampHorizSpeed(vel, tms::k_wallrunMaxSpeed);
-
-    vel.y *= std::exp(-dt / tms::k_wallrunVerticalDecayTau);
-    vel -= state.sim.wallNormal * glm::dot(vel, state.sim.wallNormal);
-
-    const float sideDot = glm::dot(state.sim.wallNormal, glm::vec3{std::cos(input.yaw), 0.0f, -std::sin(input.yaw)});
-    state.vis.wallRunSide = (sideDot < 0.0f) ? WallSide::Right : WallSide::Left;
-    state.vis.targetCameraTilt =
-        std::clamp(-sideDot * tms::k_wallrunCameraTilt, -tms::k_wallrunCameraTilt, tms::k_wallrunCameraTilt);
+    finishWallrunFrame(vel, state, input, dt);
 }
 
 } // namespace

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -738,6 +738,41 @@ glm::vec3 redirectWallForward(glm::vec3 oldForward, glm::vec3 oldNormal, glm::ve
     return (len > 0.001f) ? redirected / len : oldForward;
 }
 
+bool isBoundaryFeature(physics::TriRegion region)
+{
+    return region != physics::TriRegion::Face;
+}
+
+bool isTrailingSameWallBoundary(const WallAttachmentProbe& attachment,
+                                glm::vec3 pos,
+                                glm::vec3 oldForward,
+                                glm::vec3 oldNormal,
+                                float normalTurn,
+                                float radius)
+{
+    if (!isBoundaryFeature(attachment.region) || normalTurn >= 0.05f)
+        return false;
+    if (glm::dot(attachment.normal, oldNormal) < 0.98f)
+        return false;
+
+    const float alongTravel = glm::dot(attachment.anchor - pos, oldForward);
+    return alongTravel < -std::max(radius * 0.25f, 1.0f);
+}
+
+bool isForwardCompatibleWallHandoff(glm::vec3 oldForward, glm::vec3 oldNormal, glm::vec3 newNormal, glm::vec3 velocity)
+{
+    const glm::vec3 redirected = redirectWallForward(oldForward, oldNormal, newNormal);
+    if (glm::dot(redirected, oldForward) < -0.05f)
+        return false;
+
+    const glm::vec3 horizontalVelocity = horizVel(velocity);
+    const float horizontalSpeed = glm::length(horizontalVelocity);
+    if (horizontalSpeed > 1.0f && glm::dot(horizontalVelocity / horizontalSpeed, redirected) < -0.05f)
+        return false;
+
+    return true;
+}
+
 /// @brief Attempt to enter wallrun mode when airborne near a wall.
 /// @param vel    Velocity (modified in place).
 /// @param state  Player state (modified in place).
@@ -948,6 +983,14 @@ void handleWallRunning(glm::vec3& pos,
 
     const float normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
     if (normalTurn > tms::k_wallrunMaxFaceRedirect + 1e-4f) {
+        exitWallrun(state, posY);
+        return;
+    }
+    if (isTrailingSameWallBoundary(attachment, pos, oldForward, oldNormal, normalTurn, shape.radius)) {
+        exitWallrun(state, posY);
+        return;
+    }
+    if (normalTurn > 0.05f && !isForwardCompatibleWallHandoff(oldForward, oldNormal, attachment.normal, vel)) {
         exitWallrun(state, posY);
         return;
     }

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -641,6 +641,7 @@ namespace
 {
 
 constexpr float k_wallrunAttachPushback = 0.03125f;
+constexpr float k_wallrunReturnHandoffCooldown = 0.14f;
 
 /// @brief Check if a wall normal matches the blacklist (same wall).
 /// @param normal    Wall normal to test.
@@ -874,6 +875,8 @@ void tryEnterWallrun(glm::vec3& vel,
         state.sim.wallForward = wallFwd;
         state.sim.wallRunTimer = 0.0f;
         state.sim.wallRunSpeedTimer = 0.0f;
+        state.sim.wallRecentHandoffTimer = 0.0f;
+        state.sim.wallRecentHandoffFromNormal = glm::vec3{0.0f};
         seedWallAttachmentFromProbe(state, wallPoint, wallNorm, meshIndex, triId, region);
 
         const WallAttachmentProbe attachment = findWallAttachment(pos, shape, world, wallNorm);
@@ -938,6 +941,8 @@ void exitWallrun(PlayerStateRef state, float posY)
     state.sim.wallAttachmentValid = false;
     state.sim.wallMeshIndex = UINT32_MAX;
     state.sim.wallTriId = UINT32_MAX;
+    state.sim.wallRecentHandoffTimer = 0.0f;
+    state.sim.wallRecentHandoffFromNormal = glm::vec3{0.0f};
 }
 
 /// @brief Process wallrunning movement, exit conditions, and camera tilt.
@@ -962,6 +967,7 @@ void handleWallRunning(glm::vec3& pos,
 {
     state.sim.wallRunTimer += dt;
     state.sim.wallRunSpeedTimer += dt;
+    state.sim.wallRecentHandoffTimer = std::max(0.0f, state.sim.wallRecentHandoffTimer - dt);
 
     // Lucio-style detach: jump released → fire the full wall-jump impulse
     // away from the wall, then exit. Holding jump is what kept the player
@@ -1012,7 +1018,28 @@ void handleWallRunning(glm::vec3& pos,
         }
     }
 
-    const float normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
+    float normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
+    if (normalTurn > 0.05f && state.sim.wallRecentHandoffTimer > 0.0f &&
+        glm::dot(attachment.normal, state.sim.wallRecentHandoffFromNormal) > 0.95f)
+    {
+        const WallAttachmentProbe stickyAttachment = findWallAttachment(pos,
+                                                                        shape,
+                                                                        world,
+                                                                        oldNormal,
+                                                                        glm::vec3{0.0f},
+                                                                        0.0f,
+                                                                        state.sim.wallMeshIndex,
+                                                                        state.sim.wallTriId,
+                                                                        state.sim.wallRegion);
+        if (stickyAttachment.found && glm::dot(stickyAttachment.normal, oldNormal) > 0.95f) {
+            attachment = stickyAttachment;
+            normalTurn = std::acos(std::clamp(glm::dot(oldNormal, attachment.normal), -1.0f, 1.0f));
+        } else {
+            exitWallrun(state, posY);
+            return;
+        }
+    }
+
     if (normalTurn > tms::k_wallrunMaxFaceRedirect + 1e-4f) {
         exitWallrun(state, posY);
         return;
@@ -1055,6 +1082,8 @@ void handleWallRunning(glm::vec3& pos,
         }
 
         state.sim.wallForward = redirectedForward;
+        state.sim.wallRecentHandoffFromNormal = oldNormal;
+        state.sim.wallRecentHandoffTimer = k_wallrunReturnHandoffCooldown;
         const float verticalVel = vel.y;
         vel = state.sim.wallForward * preAttachHorizSpeed;
         vel.y = verticalVel;

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -739,9 +739,11 @@ glm::vec3 redirectWallForward(glm::vec3 oldForward, glm::vec3 oldNormal, glm::ve
 {
     glm::vec3 redirected = oldForward + oldNormal;
     redirected -= newNormal * glm::dot(redirected, newNormal);
+    redirected.y = 0.0f;
 
     if (glm::length(redirected) < 0.001f) {
         redirected = glm::cross(glm::vec3{0.0f, 1.0f, 0.0f}, newNormal);
+        redirected.y = 0.0f;
         if (glm::dot(redirected, oldNormal) < 0.0f)
             redirected = -redirected;
     }
@@ -790,6 +792,7 @@ glm::vec3 redirectWallForwardTowardAnchor(
 {
     glm::vec3 anchorTangent = anchor - pos;
     anchorTangent -= newNormal * glm::dot(anchorTangent, newNormal);
+    anchorTangent.y = 0.0f;
 
     const float anchorLen = glm::length(anchorTangent);
     if (anchorLen > 0.25f) {
@@ -1034,6 +1037,7 @@ void handleWallRunning(glm::vec3& pos,
         (shape.type == CollisionShapeType::Capsule)
             ? capsuleQueryForWallrun(shape).minkowskiExtent(state.sim.wallNormal) + k_wallrunAttachPushback
             : shape.minkowskiExtent(state.sim.wallNormal) + k_wallrunAttachPushback;
+    const glm::vec3 preStandoffPos = pos;
     const float currentStandoff = glm::dot(pos - state.sim.wallAnchor, state.sim.wallNormal);
     pos += state.sim.wallNormal * (desiredStandoff - currentStandoff);
 
@@ -1041,8 +1045,16 @@ void handleWallRunning(glm::vec3& pos,
     vel -= state.sim.wallNormal * normalVel;
 
     if (normalTurn > 0.05f) {
-        state.sim.wallForward =
-            redirectWallForwardTowardAnchor(oldForward, oldNormal, state.sim.wallNormal, pos, state.sim.wallAnchor);
+        const glm::vec3 redirectedForward = redirectWallForwardTowardAnchor(
+            oldForward, oldNormal, state.sim.wallNormal, preStandoffPos, state.sim.wallAnchor);
+        const glm::vec3 wishDir =
+            physics::computeWishDir(input.yaw, input.forward, input.back, input.left, input.right);
+        if (glm::length(wishDir) > 0.5f && glm::dot(wishDir, redirectedForward) < -0.05f) {
+            exitWallrun(state, posY);
+            return;
+        }
+
+        state.sim.wallForward = redirectedForward;
         const float verticalVel = vel.y;
         vel = state.sim.wallForward * preAttachHorizSpeed;
         vel.y = verticalVel;

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -305,8 +305,10 @@ namespace
 /// @param input   Current input snapshot.
 /// @param state   Player state (modified in place).
 /// @param dt      Fixed physics delta time in seconds (unused).
+/// @param posY    Current world Y for traversal blacklist heights.
 /// @param gravDir +1.0 for normal gravity, -1.0 for flipped (inverts all vertical impulses).
-void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state, float /*dt*/, float gravDir = 1.0f)
+void handleJump(
+    glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state, float /*dt*/, float posY, float gravDir = 1.0f)
 {
     if (!input.jump)
         return;
@@ -349,6 +351,7 @@ void handleJump(glm::vec3& vel, const InputSnapshot& input, PlayerStateRef state
 
         state.sim.climbBlacklistActive = true;
         state.sim.climbBlacklistNormal = state.sim.climbWallNormal;
+        state.sim.climbBlacklistHeight = posY;
         return;
     }
 
@@ -654,6 +657,15 @@ bool isBlacklisted(const glm::vec3& normal, float height, const glm::vec3& blNor
     if (glm::dot(normal, blNormal) > 0.9f && height >= blHeight)
         return true;
     return false;
+}
+
+bool isClimbBlacklisted(const glm::vec3& normal, float height, const glm::vec3& blNormal, float blHeight, bool active)
+{
+    if (!active)
+        return false;
+    if (glm::dot(normal, blNormal) <= 0.9f)
+        return false;
+    return height > blHeight - tms::k_climbRegrabLowerHeight;
 }
 
 physics::CapsuleShape capsuleQueryForWallrun(const CollisionShape& shape)
@@ -1090,8 +1102,6 @@ void tryEnterClimb(glm::vec3& vel,
         return;
     if (state.vis.grounded || state.vis.exitingClimb)
         return;
-    if (!input.forward)
-        return;
     if (walls.groundDistance < tms::k_climbMinGroundDist)
         return;
     if (!walls.wallFront)
@@ -1109,18 +1119,26 @@ void tryEnterClimb(glm::vec3& vel,
     if (k_lookAngle > k_maxAngleRad)
         return;
 
+    const glm::vec3 wishDir = physics::computeWishDir(input.yaw, input.forward, input.back, input.left, input.right);
+    if (glm::dot(wishDir, -wallNormal) < tms::k_climbIntentThreshold)
+        return;
+
     // Blacklist check.
-    if (isBlacklisted(wallNormal,
-                      posY,
-                      state.sim.climbBlacklistNormal,
-                      state.sim.climbBlacklistHeight,
-                      state.sim.climbBlacklistActive))
+    if (isClimbBlacklisted(wallNormal,
+                           posY,
+                           state.sim.climbBlacklistNormal,
+                           state.sim.climbBlacklistHeight,
+                           state.sim.climbBlacklistActive))
         return;
 
     // Enter climbing.
     state.vis.moveMode = MoveMode::Climbing;
     state.sim.climbWallNormal = wallNormal;
+    state.sim.climbAttachPoint = walls.frontPoint;
+    state.sim.climbAttachHeight = posY;
     state.sim.climbTimer = 0.0f;
+    state.sim.climbNonUpTimer = 0.0f;
+    state.sim.climbHadUpwardMotion = false;
     // DJ no longer refreshes from entering climb — only from ground time.
     state.vis.jumpCount = 0;
 
@@ -1164,26 +1182,51 @@ void handleClimbing(glm::vec3& vel,
     state.sim.climbTimer += dt;
 
     // Exit conditions
-    if (state.sim.climbTimer >= tms::k_climbKickoffDuration || !walls.wallFront || !input.forward) {
+    if (!walls.wallFront || input.crouch || input.back) {
         exitClimb(state, posY);
         return;
     }
+
+    const glm::vec3 climbNormal = normalizedOrZero(state.sim.climbWallNormal);
+    if (glm::dot(climbNormal, climbNormal) <= 0.0f) {
+        exitClimb(state, posY);
+        return;
+    }
+
+    const glm::vec3 wishDir = physics::computeWishDir(input.yaw, input.forward, input.back, input.left, input.right);
+    const bool hasUpIntent = glm::dot(wishDir, -climbNormal) >= tms::k_climbIntentThreshold;
+    const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
+
+    if (!hasUpIntent) {
+        state.sim.climbNonUpTimer += dt;
+        if (state.sim.climbNonUpTimer >= tms::k_climbNonUpDetachTime) {
+            exitClimb(state, posY);
+            return;
+        }
+
+        vel.y = -tms::k_climbSlipSpeed * gravDir;
+        vel.x *= tms::k_climbSidewaysMultiplier;
+        vel.z *= tms::k_climbSidewaysMultiplier;
+        vel -= climbNormal * tms::k_wallrunPushForce * dt;
+        state.vis.targetCameraTilt = 0.0f;
+        return;
+    }
+
+    state.sim.climbNonUpTimer = 0.0f;
 
     // Climbing movement (upward with speed decay)
     const float k_decayAlpha = std::clamp(state.sim.climbTimer / tms::k_climbKickoffDuration, 0.0f, 1.0f);
     const float k_climbSpeed = std::lerp(tms::k_climbMaxSpeed, tms::k_climbMinSpeed, k_decayAlpha);
 
-    const float gravDir = state.vis.gravityFlipped ? -1.0f : 1.0f;
     vel.y = k_climbSpeed * gravDir;
+    state.sim.climbHadUpwardMotion = (vel.y * gravDir) >= tms::k_climbUpVelocityThreshold;
 
     // Minimal sideways movement.
     vel.x *= tms::k_climbSidewaysMultiplier;
     vel.z *= tms::k_climbSidewaysMultiplier;
 
     // Push toward wall.
-    const glm::vec3 climbNormal = normalizedOrZero(state.sim.climbWallNormal);
-    if (glm::dot(climbNormal, climbNormal) > 0.0f)
-        vel -= climbNormal * tms::k_wallrunPushForce * dt;
+    vel -= climbNormal * tms::k_wallrunPushForce * dt;
 
     state.vis.targetCameraTilt = 0.0f;
 }
@@ -1620,7 +1663,7 @@ void runMovement(Registry& registry, float dt, const physics::WorldGeometry& wor
             //     grapple-rising-edge + jump same-tick is a rare edge case and
             //     handleGrapple's velocity override wins anyway.
             if (!state.vis.grappleActive)
-                handleJump(vel.value, input, state, dt, gravDir);
+                handleJump(vel.value, input, state, dt, pos.value.y, gravDir);
 
             // 5. Mode-specific movement
             switch (state.vis.moveMode) {

--- a/src/ecs/systems/MovementSystem.cpp
+++ b/src/ecs/systems/MovementSystem.cpp
@@ -785,6 +785,22 @@ bool isForwardCompatibleWallHandoff(glm::vec3 oldForward, glm::vec3 oldNormal, g
     return true;
 }
 
+glm::vec3 redirectWallForwardTowardAnchor(
+    glm::vec3 oldForward, glm::vec3 oldNormal, glm::vec3 newNormal, glm::vec3 pos, glm::vec3 anchor)
+{
+    glm::vec3 anchorTangent = anchor - pos;
+    anchorTangent -= newNormal * glm::dot(anchorTangent, newNormal);
+
+    const float anchorLen = glm::length(anchorTangent);
+    if (anchorLen > 0.25f) {
+        anchorTangent /= anchorLen;
+        if (glm::dot(anchorTangent, oldForward) >= -0.05f)
+            return anchorTangent;
+    }
+
+    return redirectWallForward(oldForward, oldNormal, newNormal);
+}
+
 /// @brief Attempt to enter wallrun mode when airborne near a wall.
 /// @param vel    Velocity (modified in place).
 /// @param state  Player state (modified in place).
@@ -1025,7 +1041,8 @@ void handleWallRunning(glm::vec3& pos,
     vel -= state.sim.wallNormal * normalVel;
 
     if (normalTurn > 0.05f) {
-        state.sim.wallForward = redirectWallForward(oldForward, oldNormal, state.sim.wallNormal);
+        state.sim.wallForward =
+            redirectWallForwardTowardAnchor(oldForward, oldNormal, state.sim.wallNormal, pos, state.sim.wallAnchor);
         const float verticalVel = vel.y;
         vel = state.sim.wallForward * preAttachHorizSpeed;
         vel.y = verticalVel;
@@ -1073,10 +1090,8 @@ void handleWallRunning(glm::vec3& pos,
 
     const float sideDot = glm::dot(state.sim.wallNormal, glm::vec3{std::cos(input.yaw), 0.0f, -std::sin(input.yaw)});
     state.vis.wallRunSide = (sideDot < 0.0f) ? WallSide::Right : WallSide::Left;
-
-    // Camera tilt.
     state.vis.targetCameraTilt =
-        (state.vis.wallRunSide == WallSide::Right) ? tms::k_wallrunCameraTilt : -tms::k_wallrunCameraTilt;
+        std::clamp(-sideDot * tms::k_wallrunCameraTilt, -tms::k_wallrunCameraTilt, tms::k_wallrunCameraTilt);
 }
 
 } // namespace

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -1185,6 +1185,104 @@ bool wallrunMapCorridorTurnsIntoCorridor()
                  "map corridor outside corner should keep wallrunning onto the corridor wall");
     ok &= expect(outSim.wallNormal.z < -0.7f, "map corridor handoff should attach to the upper corridor wall");
     ok &= expect(outVel.value.x > 0.0f, "map corridor handoff should turn into the corridor instead of away from it");
+    ok &= expect(glm::length(glm::vec3{outVel.value.x, 0.0f, outVel.value.z}) > 300.0f,
+                 "map corridor handoff should preserve moving wallrun speed instead of stopping in place");
+    return ok;
+}
+
+bool wallrunInternalCornerKeepsMoving()
+{
+    WorldTriMesh corner = makeCookedMesh(
+        {
+            {0.0f, 0.0f, -80.0f},
+            {0.0f, 40.0f, -80.0f},
+            {0.0f, 40.0f, 20.0f},
+            {0.0f, 0.0f, 20.0f},
+            {80.0f, 0.0f, 20.0f},
+            {80.0f, 40.0f, 20.0f},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+            3,
+            2,
+            5,
+            3,
+            5,
+            4,
+        });
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&corner, 1),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{-10.0f, 20.0f, 12.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {0.0f, 20.0f, 12.0f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 1u;
+    sim.wallRegion = physics::TriRegion::Edge1;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    const CapsuleShape capsule{.radius = 10.0f, .halfHeight = 20.0f, .up = {0.0f, 1.0f, 0.0f}};
+    const physics::WallAttachmentResult attachment = physics::findWallRunAttachment(capsule,
+                                                                                    {-10.0f, 20.0f, 12.0f},
+                                                                                    world,
+                                                                                    {-1.0f, 0.0f, 0.0f},
+                                                                                    {0.0f, 0.0f, 1.0f},
+                                                                                    10.0f,
+                                                                                    35.0f,
+                                                                                    0u,
+                                                                                    1u,
+                                                                                    physics::TriRegion::Edge1);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(attachment.found, "internal corner attachment query should find a candidate");
+    ok &= expect(attachment.normal.z < -0.7f, "internal corner attachment query should prefer the turned wall");
+    ok &= expect(outVis.moveMode == MoveMode::WallRunning, "internal corner should stay wallrunning");
+    ok &= expect(outSim.wallNormal.z < -0.7f, "internal corner should transition to the turned wall normal");
+    ok &= expect(glm::length(glm::vec3{outVel.value.x, 0.0f, outVel.value.z}) > 300.0f,
+                 "internal corner wallrun should keep moving instead of becoming static");
     return ok;
 }
 
@@ -1947,6 +2045,7 @@ int main()
     ok &= wallrunOuterCornerKeepsForwardVelocity();
     ok &= wallrunGapDropsWithoutReversingVelocity();
     ok &= wallrunMapCorridorTurnsIntoCorridor();
+    ok &= wallrunInternalCornerKeepsMoving();
     ok &= wallrunRollScalesWithViewAngle();
     ok &= wallrunMapCorridorEndDoesNotAttachToAirSide();
     ok &= climbMantleToTopFloorKeepsFiniteState();

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -190,6 +190,66 @@ WorldTriMesh makeSingleMeshOutsideWallCorner()
         });
 }
 
+std::array<WorldTriMesh, 3> makeAuthoredMapWallrunCorridorSegment()
+{
+    constexpr float xWall = 687.566f;
+    constexpr float zLowerWall = 386.311f;
+    constexpr float zUpperWall = 593.671f;
+    constexpr float yMin = 12.853f;
+    constexpr float yMax = 252.853f;
+    constexpr float corridorEndX = 964.046f;
+
+    WorldTriMesh mainWall = makeCookedMesh(
+        {
+            {xWall, yMin, zUpperWall},
+            {xWall, yMin, 2131.591f},
+            {xWall, yMax, 2131.591f},
+            {xWall, yMax, zUpperWall},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+
+    WorldTriMesh upperCorridorWall = makeCookedMesh(
+        {
+            {xWall, yMin, zUpperWall},
+            {corridorEndX, yMin, zUpperWall},
+            {corridorEndX, yMax, zUpperWall},
+            {xWall, yMax, zUpperWall},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+
+    WorldTriMesh lowerCorridorWall = makeCookedMesh(
+        {
+            {corridorEndX, yMin, zLowerWall},
+            {xWall, yMin, zLowerWall},
+            {xWall, yMax, zLowerWall},
+            {corridorEndX, yMax, zLowerWall},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+
+    return {mainWall, upperCorridorWall, lowerCorridorWall};
+}
+
 WorldTriMesh makeTwoTriangleFloor()
 {
     return makeCookedMesh(
@@ -1068,6 +1128,190 @@ bool wallrunGapDropsWithoutReversingVelocity()
     return ok;
 }
 
+bool wallrunMapCorridorTurnsIntoCorridor()
+{
+    std::array<WorldTriMesh, 3> meshes = makeAuthoredMapWallrunCorridorSegment();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(meshes),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{671.530f, 80.0f, 577.639f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {687.566f, 80.0f, 577.639f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 0u;
+    sim.wallRegion = physics::TriRegion::Face;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(outVis.moveMode == MoveMode::WallRunning,
+                 "map corridor outside corner should keep wallrunning onto the corridor wall");
+    ok &= expect(outSim.wallNormal.z < -0.7f, "map corridor handoff should attach to the upper corridor wall");
+    ok &= expect(outVel.value.x > 0.0f, "map corridor handoff should turn into the corridor instead of away from it");
+    return ok;
+}
+
+bool wallrunRollScalesWithViewAngle()
+{
+    std::array<WorldTriMesh, 3> meshes = makeAuthoredMapWallrunCorridorSegment();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(meshes),
+    };
+
+    auto runAtYaw = [&](float yaw) {
+        Registry registry;
+        const entt::entity player = registry.create();
+        registry.emplace<Position>(player, glm::vec3{671.530f, 80.0f, 1200.0f});
+        registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+        CollisionShape shape;
+        shape.type = CollisionShapeType::Capsule;
+        shape.radius = 10.0f;
+        shape.halfHeight = 20.0f;
+        shape.halfExtents = {10.0f, 30.0f, 10.0f};
+        registry.emplace<CollisionShape>(player, shape);
+
+        PlayerVisState vis;
+        vis.moveMode = MoveMode::WallRunning;
+        vis.wallRunSide = WallSide::Right;
+        vis.grounded = false;
+        registry.emplace<PlayerVisState>(player, vis);
+
+        PlayerSimState sim;
+        sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+        sim.wallForward = {0.0f, 0.0f, 1.0f};
+        sim.wallAnchor = {687.566f, 80.0f, 1200.0f};
+        sim.wallMeshIndex = 0u;
+        sim.wallTriId = 0u;
+        sim.wallRegion = physics::TriRegion::Face;
+        sim.wallAttachmentValid = true;
+        registry.emplace<PlayerSimState>(player, sim);
+
+        InputSnapshot input;
+        input.jump = true;
+        input.forward = true;
+        input.yaw = yaw;
+        registry.emplace<InputSnapshot>(player, input);
+
+        systems::runMovement(registry, 1.0f / 128.0f, world);
+        return registry.get<PlayerVisState>(player).targetCameraTilt;
+    };
+
+    const float parallelRoll = runAtYaw(0.0f);
+    const float wallFacingRoll = runAtYaw(1.57079632679f);
+
+    bool ok = true;
+    ok &= expect(parallelRoll > tms::k_wallrunCameraTilt * 0.9f,
+                 "wallrun roll should be strongest when looking along the wall");
+    ok &= expect(std::abs(wallFacingRoll) < std::abs(parallelRoll) * 0.5f,
+                 "wallrun roll should soften when looking toward or away from the wall normal");
+    return ok;
+}
+
+bool wallrunMapCorridorEndDoesNotAttachToAirSide()
+{
+    std::array<WorldTriMesh, 3> meshes = makeAuthoredMapWallrunCorridorSegment();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(meshes),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{703.597f, 80.0f, 577.639f});
+    registry.emplace<Velocity>(player, glm::vec3{-500.0f, 0.0f, 0.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {0.0f, 0.0f, -1.0f};
+    sim.wallForward = {-1.0f, 0.0f, 0.0f};
+    sim.wallAnchor = {703.597f, 80.0f, 593.671f};
+    sim.wallMeshIndex = 1u;
+    sim.wallTriId = 0u;
+    sim.wallRegion = physics::TriRegion::Face;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = -1.57079632679f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    for (int i = 0; i < 12; ++i)
+        systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    if (outVis.moveMode == MoveMode::WallRunning) {
+        ok &= expect(outSim.wallNormal.x < 0.7f,
+                     "corridor end should not attach to the east/air side of the main-room wall");
+        ok &= expect(outVel.value.x <= 0.0f, "corridor end should not reverse back into the corridor");
+    }
+    return ok;
+}
+
 bool climbMantleToTopFloorKeepsFiniteState()
 {
     const WorldTriMesh climbMesh = makeClimbWallWithTopFloor();
@@ -1702,6 +1946,9 @@ int main()
     ok &= wallAttachmentWalksSingleMeshAdjacencyAtCorner();
     ok &= wallrunOuterCornerKeepsForwardVelocity();
     ok &= wallrunGapDropsWithoutReversingVelocity();
+    ok &= wallrunMapCorridorTurnsIntoCorridor();
+    ok &= wallrunRollScalesWithViewAngle();
+    ok &= wallrunMapCorridorEndDoesNotAttachToAirSide();
     ok &= climbMantleToTopFloorKeepsFiniteState();
     ok &= ledgeMantleRejectsInvalidStoredNormal();
     ok &= flippedGravityClimbMovesAlongLocalUp();

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -175,7 +175,7 @@ WorldTriMesh makeSingleMeshOutsideWallCorner()
             {0.0f, 40.0f, -20.0f},
             {0.0f, 40.0f, 20.0f},
             {0.0f, 0.0f, 20.0f},
-            {-40.0f, 0.0f, 20.0f},
+            {-120.0f, 0.0f, 20.0f},
         },
         {
             0,
@@ -1067,6 +1067,168 @@ bool wallrunOuterCornerKeepsForwardVelocity()
     ok &= expect(outSim.wallNormal.z < -0.7f, "outer corner should hand off to the forward continuation wall");
     ok &= expect(glm::dot(glm::vec3{outVel.value.x, 0.0f, outVel.value.z}, outSim.wallForward) >= 0.0f,
                  "outer corner handoff should not reverse horizontal velocity");
+    return ok;
+}
+
+bool wallrunSingleMeshExternalLCornerContinuesAroundCorner()
+{
+    const WorldTriMesh mesh = makeSingleMeshOutsideWallCorner();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&mesh, 1),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{-10.0f, 20.0f, 16.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {0.0f, 20.0f, 16.0f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 1u;
+    sim.wallRegion = physics::TriRegion::Edge1;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    bool wallrunningEveryFrame = true;
+    float minHorizSpeed = 1e30f;
+    for (int frame = 0; frame < 16; ++frame) {
+        systems::runMovement(registry, 1.0f / 128.0f, world);
+        systems::runKinematicCharacterController(registry.get<Position>(player).value,
+                                                 registry.get<Velocity>(player).value,
+                                                 registry.get<CollisionShape>(player),
+                                                 registry.get<PlayerVisState>(player),
+                                                 1.0f / 128.0f,
+                                                 world,
+                                                 player,
+                                                 registry.get<PlayerSimState>(player).jumpedThisTick);
+
+        const auto& stepVis = registry.get<PlayerVisState>(player);
+        const auto& stepVel = registry.get<Velocity>(player);
+        wallrunningEveryFrame &= stepVis.moveMode == MoveMode::WallRunning;
+        minHorizSpeed = std::min(minHorizSpeed, glm::length(glm::vec3{stepVel.value.x, 0.0f, stepVel.value.z}));
+    }
+
+    const auto& outPos = registry.get<Position>(player);
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(wallrunningEveryFrame, "external L corner should not drop wallrun during the handoff");
+    ok &= expect(outVis.moveMode == MoveMode::WallRunning, "external L corner should still be wallrunning");
+    ok &= expect(outSim.wallNormal.z < -0.7f, "external L corner should attach to the perpendicular wall");
+    ok &= expect(outSim.wallForward.x < -0.7f, "external L corner should continue around the outside corner");
+    ok &= expect(outPos.value.x < -20.0f, "external L corner should move along the new wall");
+    ok &= expect(minHorizSpeed > 300.0f, "external L corner should not stall during transition");
+    ok &= expect(outVel.value.x < -300.0f, "external L corner should preserve speed into the new wall direction");
+    return ok;
+}
+
+bool wallrunMapExternalLCornerContinuesWithKcc()
+{
+    std::array<WorldTriMesh, 3> meshes = makeAuthoredMapWallrunCorridorSegment();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(meshes),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{671.530f, 80.0f, 577.639f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {687.566f, 80.0f, 577.639f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 0u;
+    sim.wallRegion = physics::TriRegion::Face;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    bool wallrunningEveryFrame = true;
+    float minHorizSpeed = 1e30f;
+    for (int frame = 0; frame < 24; ++frame) {
+        systems::runMovement(registry, 1.0f / 128.0f, world);
+        systems::runKinematicCharacterController(registry.get<Position>(player).value,
+                                                 registry.get<Velocity>(player).value,
+                                                 registry.get<CollisionShape>(player),
+                                                 registry.get<PlayerVisState>(player),
+                                                 1.0f / 128.0f,
+                                                 world,
+                                                 player,
+                                                 registry.get<PlayerSimState>(player).jumpedThisTick);
+
+        const auto& stepVis = registry.get<PlayerVisState>(player);
+        const auto& stepVel = registry.get<Velocity>(player);
+        wallrunningEveryFrame &= stepVis.moveMode == MoveMode::WallRunning;
+        minHorizSpeed = std::min(minHorizSpeed, glm::length(glm::vec3{stepVel.value.x, 0.0f, stepVel.value.z}));
+    }
+
+    const auto& outPos = registry.get<Position>(player);
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(wallrunningEveryFrame, "map external L corner should not drop during KCC simulation");
+    ok &= expect(outVis.moveMode == MoveMode::WallRunning, "map external L corner should stay in wallrun");
+    ok &= expect(outSim.wallNormal.z < -0.7f, "map external L corner should attach to the corridor wall");
+    ok &= expect(outSim.wallForward.x > 0.7f, "map external L corner should redirect into the corridor");
+    ok &= expect(outPos.value.x > 760.0f, "map external L corner should make progress along the corridor wall");
+    ok &= expect(minHorizSpeed > 300.0f, "map external L corner should not stall during transition");
+    ok &= expect(outVel.value.x > 300.0f, "map external L corner should preserve speed into the corridor direction");
     return ok;
 }
 
@@ -2043,8 +2205,10 @@ int main()
     ok &= wallAttachmentLookaheadFindsOuterCornerContinuation();
     ok &= wallAttachmentWalksSingleMeshAdjacencyAtCorner();
     ok &= wallrunOuterCornerKeepsForwardVelocity();
+    ok &= wallrunSingleMeshExternalLCornerContinuesAroundCorner();
     ok &= wallrunGapDropsWithoutReversingVelocity();
     ok &= wallrunMapCorridorTurnsIntoCorridor();
+    ok &= wallrunMapExternalLCornerContinuesWithKcc();
     ok &= wallrunInternalCornerKeepsMoving();
     ok &= wallrunRollScalesWithViewAngle();
     ok &= wallrunMapCorridorEndDoesNotAttachToAirSide();

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -126,6 +126,25 @@ WorldTriMesh makeThinDepthWall()
         });
 }
 
+WorldTriMesh makeTallFrontWall(float y0 = -500.0f, float y1 = 500.0f)
+{
+    return makeCookedMesh(
+        {
+            {-80.0f, y0, 0.0f},
+            {80.0f, y0, 0.0f},
+            {80.0f, y1, 0.0f},
+            {-80.0f, y1, 0.0f},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+}
+
 WorldTriMesh makeThinDepthWallAt(float z)
 {
     return makeCookedMesh(
@@ -1261,6 +1280,167 @@ bool flippedGravityLedgeMantleMovesAlongLocalUp()
     return ok;
 }
 
+bool climbNeutralInputSlipsBeforeDetach()
+{
+    const WorldTriMesh wall = makeTallFrontWall();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&wall, 1),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{0.0f, 80.0f, -24.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::Climbing;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.climbWallNormal = {0.0f, 0.0f, -1.0f};
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(outVis.moveMode == MoveMode::Climbing, "neutral climb input should briefly stay attached");
+    ok &= expect(outVel.value.y < 0.0f, "neutral climb input should slip downward instead of forcing upward climb");
+    return ok;
+}
+
+bool climbNeutralInputDetachesAfterGrace()
+{
+    const WorldTriMesh wall = makeTallFrontWall();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&wall, 1),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{0.0f, 80.0f, -24.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::Climbing;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.climbWallNormal = {0.0f, 0.0f, -1.0f};
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    bool stayedInitially = false;
+    for (int frame = 0; frame < 40; ++frame) {
+        systems::runMovement(registry, 1.0f / 128.0f, world);
+        if (frame == 0)
+            stayedInitially = registry.get<PlayerVisState>(player).moveMode == MoveMode::Climbing;
+    }
+
+    bool ok = true;
+    ok &= expect(stayedInitially, "neutral climb should not detach on the first non-upward frame");
+    ok &= expect(registry.get<PlayerVisState>(player).moveMode == MoveMode::OnFoot,
+                 "neutral climb should detach after the non-upward grace window");
+    return ok;
+}
+
+bool climbSameWallReattachRequiresMeaningfulDrop()
+{
+    const WorldTriMesh wall = makeTallFrontWall();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&wall, 1),
+    };
+
+    auto makePlayer = [](float y, glm::vec3 blacklistNormal) {
+        Registry registry;
+        const entt::entity player = registry.create();
+        registry.emplace<Position>(player, glm::vec3{0.0f, y, -24.0f});
+        registry.emplace<Velocity>(player, glm::vec3{0.0f});
+
+        CollisionShape shape;
+        shape.type = CollisionShapeType::Capsule;
+        shape.radius = 10.0f;
+        shape.halfHeight = 20.0f;
+        shape.halfExtents = {10.0f, 30.0f, 10.0f};
+        registry.emplace<CollisionShape>(player, shape);
+
+        PlayerVisState vis;
+        vis.grounded = false;
+        registry.emplace<PlayerVisState>(player, vis);
+
+        PlayerSimState sim;
+        sim.climbBlacklistActive = true;
+        sim.climbBlacklistNormal = blacklistNormal;
+        sim.climbBlacklistHeight = 100.0f;
+        registry.emplace<PlayerSimState>(player, sim);
+
+        InputSnapshot input;
+        input.forward = true;
+        input.yaw = 0.0f;
+        registry.emplace<InputSnapshot>(player, input);
+
+        return std::pair<Registry, entt::entity>{std::move(registry), player};
+    };
+
+    auto [nearRegistry, nearPlayer] = makePlayer(80.0f, {0.0f, 0.0f, -1.0f});
+    systems::runMovement(nearRegistry, 1.0f / 128.0f, world);
+
+    auto [lowRegistry, lowPlayer] = makePlayer(-350.0f, {0.0f, 0.0f, -1.0f});
+    systems::runMovement(lowRegistry, 1.0f / 128.0f, world);
+
+    auto [differentRegistry, differentPlayer] = makePlayer(80.0f, {1.0f, 0.0f, 0.0f});
+    systems::runMovement(differentRegistry, 1.0f / 128.0f, world);
+
+    bool ok = true;
+    ok &= expect(nearRegistry.get<PlayerVisState>(nearPlayer).moveMode == MoveMode::OnFoot,
+                 "same climb wall should stay blacklisted until the player drops meaningfully below it");
+    ok &= expect(lowRegistry.get<PlayerVisState>(lowPlayer).moveMode == MoveMode::Climbing,
+                 "same climb wall should be regrabbable after a meaningful drop");
+    ok &= expect(differentRegistry.get<PlayerVisState>(differentPlayer).moveMode == MoveMode::Climbing,
+                 "different climb wall normals should not inherit the same-wall regrab blacklist");
+    return ok;
+}
+
 bool triMeshValidationReportsCookerIssues()
 {
     WorldTriMesh mesh;
@@ -1526,6 +1706,9 @@ int main()
     ok &= ledgeMantleRejectsInvalidStoredNormal();
     ok &= flippedGravityClimbMovesAlongLocalUp();
     ok &= flippedGravityLedgeMantleMovesAlongLocalUp();
+    ok &= climbNeutralInputSlipsBeforeDetach();
+    ok &= climbNeutralInputDetachesAfterGrace();
+    ok &= climbSameWallReattachRequiresMeaningfulDrop();
     ok &= triMeshValidationReportsCookerIssues();
     ok &= triMeshValidationTotalsAggregateAuthoredSet();
     ok &= triMeshCookStatsReportWeldAndBvhQuality();

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -250,6 +250,49 @@ std::array<WorldTriMesh, 3> makeAuthoredMapWallrunCorridorSegment()
     return {mainWall, upperCorridorWall, lowerCorridorWall};
 }
 
+std::array<WorldTriMesh, 2> makeAuthoredMapExternalLCornerSegment()
+{
+    constexpr float xWall = 687.566f;
+    constexpr float zCorner = 593.671f;
+    constexpr float yMin = 12.853f;
+    constexpr float yMax = 252.853f;
+    constexpr float corridorEndX = 964.046f;
+
+    WorldTriMesh approachWall = makeCookedMesh(
+        {
+            {xWall, yMin, 213.671f},
+            {xWall, yMin, zCorner},
+            {xWall, yMax, zCorner},
+            {xWall, yMax, 213.671f},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+
+    WorldTriMesh continuationWall = makeCookedMesh(
+        {
+            {xWall, yMin, zCorner},
+            {corridorEndX, yMin, zCorner},
+            {corridorEndX, yMax, zCorner},
+            {xWall, yMax, zCorner},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+
+    return {approachWall, continuationWall};
+}
+
 WorldTriMesh makeTwoTriangleFloor()
 {
     return makeCookedMesh(
@@ -1153,7 +1196,7 @@ bool wallrunSingleMeshExternalLCornerContinuesAroundCorner()
 
 bool wallrunMapExternalLCornerContinuesWithKcc()
 {
-    std::array<WorldTriMesh, 3> meshes = makeAuthoredMapWallrunCorridorSegment();
+    std::array<WorldTriMesh, 2> meshes = makeAuthoredMapExternalLCornerSegment();
     const physics::WorldGeometry world{
         .planes = {},
         .boxes = {},
@@ -1224,11 +1267,72 @@ bool wallrunMapExternalLCornerContinuesWithKcc()
     bool ok = true;
     ok &= expect(wallrunningEveryFrame, "map external L corner should not drop during KCC simulation");
     ok &= expect(outVis.moveMode == MoveMode::WallRunning, "map external L corner should stay in wallrun");
-    ok &= expect(outSim.wallNormal.z < -0.7f, "map external L corner should attach to the corridor wall");
+    ok &= expect(outSim.wallNormal.z > 0.7f, "map external L corner should attach to the outside of the corridor wall");
     ok &= expect(outSim.wallForward.x > 0.7f, "map external L corner should redirect into the corridor");
-    ok &= expect(outPos.value.x > 760.0f, "map external L corner should make progress along the corridor wall");
+    ok &= expect(outPos.value.x > 740.0f, "map external L corner should make progress along the corridor wall");
     ok &= expect(minHorizSpeed > 300.0f, "map external L corner should not stall during transition");
     ok &= expect(outVel.value.x > 300.0f, "map external L corner should preserve speed into the corridor direction");
+    return ok;
+}
+
+bool wallrunExternalCornerDefersRedirectUntilOldWallClear()
+{
+    std::array<WorldTriMesh, 2> meshes = makeAuthoredMapExternalLCornerSegment();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(meshes),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{671.530f, 80.0f, 577.639f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {687.566f, 80.0f, 577.639f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 0u;
+    sim.wallRegion = physics::TriRegion::Face;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(outSim.wallNormal.x < -0.7f,
+                 "external corner should keep the old wall before the capsule clears the terminal edge");
+    ok &= expect(outSim.wallCornerTransitionActive, "external corner should keep the next wall as a pending handoff");
+    ok &= expect(outVel.value.z > 300.0f, "external corner should keep moving along the old wall before clearance");
+    ok &= expect(std::abs(outVel.value.x) < 50.0f,
+                 "external corner should not redirect into the old wall before clearance");
     return ok;
 }
 
@@ -1292,7 +1396,7 @@ bool wallrunGapDropsWithoutReversingVelocity()
 
 bool wallrunMapCorridorTurnsIntoCorridor()
 {
-    std::array<WorldTriMesh, 3> meshes = makeAuthoredMapWallrunCorridorSegment();
+    std::array<WorldTriMesh, 2> meshes = makeAuthoredMapExternalLCornerSegment();
     const physics::WorldGeometry world{
         .planes = {},
         .boxes = {},
@@ -1344,9 +1448,13 @@ bool wallrunMapCorridorTurnsIntoCorridor()
 
     bool ok = true;
     ok &= expect(outVis.moveMode == MoveMode::WallRunning,
-                 "map corridor outside corner should keep wallrunning onto the corridor wall");
-    ok &= expect(outSim.wallNormal.z < -0.7f, "map corridor handoff should attach to the upper corridor wall");
-    ok &= expect(outVel.value.x > 0.0f, "map corridor handoff should turn into the corridor instead of away from it");
+                 "map corridor outside corner should keep wallrunning while preparing the turn");
+    ok &= expect(outSim.wallNormal.x < -0.7f,
+                 "map corridor handoff should keep the approach wall until the capsule clears the edge");
+    ok &= expect(outSim.wallCornerTransitionActive,
+                 "map corridor handoff should store a pending external-corner transition");
+    ok &= expect(outVel.value.z > 300.0f,
+                 "map corridor handoff should keep moving along the approach wall before clearance");
     ok &= expect(glm::length(glm::vec3{outVel.value.x, 0.0f, outVel.value.z}) > 300.0f,
                  "map corridor handoff should preserve moving wallrun speed instead of stopping in place");
     return ok;
@@ -1442,7 +1550,8 @@ bool wallrunInternalCornerKeepsMoving()
     ok &= expect(attachment.found, "internal corner attachment query should find a candidate");
     ok &= expect(attachment.normal.z < -0.7f, "internal corner attachment query should prefer the turned wall");
     ok &= expect(outVis.moveMode == MoveMode::WallRunning, "internal corner should stay wallrunning");
-    ok &= expect(outSim.wallNormal.z < -0.7f, "internal corner should transition to the turned wall normal");
+    ok &= expect(outSim.wallNormal.z < -0.7f || outSim.wallCornerTransitionActive,
+                 "internal corner should either transition immediately or queue a clearance-safe turn");
     ok &= expect(glm::length(glm::vec3{outVel.value.x, 0.0f, outVel.value.z}) > 300.0f,
                  "internal corner wallrun should keep moving instead of becoming static");
     return ok;
@@ -2208,6 +2317,7 @@ int main()
     ok &= wallrunSingleMeshExternalLCornerContinuesAroundCorner();
     ok &= wallrunGapDropsWithoutReversingVelocity();
     ok &= wallrunMapCorridorTurnsIntoCorridor();
+    ok &= wallrunExternalCornerDefersRedirectUntilOldWallClear();
     ok &= wallrunMapExternalLCornerContinuesWithKcc();
     ok &= wallrunInternalCornerKeepsMoving();
     ok &= wallrunRollScalesWithViewAngle();

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -1030,6 +1030,100 @@ bool ledgeMantleRejectsInvalidStoredNormal()
     return ok;
 }
 
+bool flippedGravityClimbMovesAlongLocalUp()
+{
+    const WorldTriMesh climbMesh = makeClimbWallWithTopFloor();
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&climbMesh, 1),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{0.0f, 80.0f, -24.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::Climbing;
+    vis.grounded = false;
+    vis.gravityFlipped = true;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.climbWallNormal = {0.0f, 0.0f, -1.0f};
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& vel = registry.get<Velocity>(player);
+    bool ok = true;
+    ok &= expect(finiteVec3(vel.value), "flipped climb velocity should remain finite");
+    ok &= expect(vel.value.y < 0.0f, "flipped climb should move along local up (-Y), not world +Y");
+    return ok;
+}
+
+bool flippedGravityLedgeMantleMovesAlongLocalUp()
+{
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{0.0f, -160.0f, 0.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::LedgeGrabbing;
+    vis.gravityFlipped = true;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.ledgeHoldTimer = tms::k_ledgeMinHoldTime;
+    sim.ledgeNormal = {0.0f, 0.0f, -1.0f};
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.forward = true;
+    registry.emplace<InputSnapshot>(player, input);
+
+    const physics::WorldGeometry emptyWorld{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = {},
+    };
+
+    systems::runMovement(registry, 1.0f / 128.0f, emptyWorld);
+
+    const auto& vel = registry.get<Velocity>(player);
+    bool ok = true;
+    ok &= expect(finiteVec3(vel.value), "flipped ledge mantle velocity should remain finite");
+    ok &= expect(vel.value.y < 0.0f, "flipped ledge mantle should move along local up (-Y), not world +Y");
+    return ok;
+}
+
 bool triMeshValidationReportsCookerIssues()
 {
     WorldTriMesh mesh;
@@ -1291,6 +1385,8 @@ int main()
     ok &= wallAttachmentWalksSingleMeshAdjacencyAtCorner();
     ok &= climbMantleToTopFloorKeepsFiniteState();
     ok &= ledgeMantleRejectsInvalidStoredNormal();
+    ok &= flippedGravityClimbMovesAlongLocalUp();
+    ok &= flippedGravityLedgeMantleMovesAlongLocalUp();
     ok &= triMeshValidationReportsCookerIssues();
     ok &= triMeshValidationTotalsAggregateAuthoredSet();
     ok &= triMeshCookStatsReportWeldAndBvhQuality();

--- a/tests/physics_trimesh_tests.cpp
+++ b/tests/physics_trimesh_tests.cpp
@@ -88,6 +88,25 @@ WorldTriMesh makeThinWall()
         });
 }
 
+WorldTriMesh makeThinWallSegment(float z0, float z1)
+{
+    return makeCookedMesh(
+        {
+            {0.0f, 0.0f, z0},
+            {0.0f, 40.0f, z0},
+            {0.0f, 40.0f, z1},
+            {0.0f, 0.0f, z1},
+        },
+        {
+            0,
+            1,
+            2,
+            0,
+            2,
+            3,
+        });
+}
+
 WorldTriMesh makeThinDepthWall()
 {
     return makeCookedMesh(
@@ -912,6 +931,124 @@ bool wallAttachmentWalksSingleMeshAdjacencyAtCorner()
     return ok;
 }
 
+bool wallrunOuterCornerKeepsForwardVelocity()
+{
+    std::array<WorldTriMesh, 2> meshes{makeThinWall(), makeThinDepthWallAt(20.0f)};
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(meshes),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{-10.0f, 20.0f, 16.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {0.0f, 20.0f, 16.0f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 1u;
+    sim.wallRegion = physics::TriRegion::Edge1;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outSim = registry.get<PlayerSimState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(outVis.moveMode == MoveMode::WallRunning, "outer corner should continue wallrun");
+    ok &= expect(outSim.wallNormal.z < -0.7f, "outer corner should hand off to the forward continuation wall");
+    ok &= expect(glm::dot(glm::vec3{outVel.value.x, 0.0f, outVel.value.z}, outSim.wallForward) >= 0.0f,
+                 "outer corner handoff should not reverse horizontal velocity");
+    return ok;
+}
+
+bool wallrunGapDropsWithoutReversingVelocity()
+{
+    const WorldTriMesh wall = makeThinWallSegment(-60.0f, 0.0f);
+    const physics::WorldGeometry world{
+        .planes = {},
+        .boxes = {},
+        .brushes = {},
+        .cylinders = {},
+        .spheres = {},
+        .triMeshes = std::span<const WorldTriMesh>(&wall, 1),
+    };
+
+    Registry registry;
+    const entt::entity player = registry.create();
+    registry.emplace<Position>(player, glm::vec3{-10.0f, 20.0f, 8.0f});
+    registry.emplace<Velocity>(player, glm::vec3{0.0f, 0.0f, 500.0f});
+
+    CollisionShape shape;
+    shape.type = CollisionShapeType::Capsule;
+    shape.radius = 10.0f;
+    shape.halfHeight = 20.0f;
+    shape.halfExtents = {10.0f, 30.0f, 10.0f};
+    registry.emplace<CollisionShape>(player, shape);
+
+    PlayerVisState vis;
+    vis.moveMode = MoveMode::WallRunning;
+    vis.wallRunSide = WallSide::Right;
+    vis.grounded = false;
+    registry.emplace<PlayerVisState>(player, vis);
+
+    PlayerSimState sim;
+    sim.wallNormal = {-1.0f, 0.0f, 0.0f};
+    sim.wallForward = {0.0f, 0.0f, 1.0f};
+    sim.wallAnchor = {0.0f, 20.0f, 0.0f};
+    sim.wallMeshIndex = 0u;
+    sim.wallTriId = 1u;
+    sim.wallRegion = physics::TriRegion::Edge1;
+    sim.wallAttachmentValid = true;
+    registry.emplace<PlayerSimState>(player, sim);
+
+    InputSnapshot input;
+    input.jump = true;
+    input.forward = true;
+    input.yaw = 0.0f;
+    registry.emplace<InputSnapshot>(player, input);
+
+    systems::runMovement(registry, 1.0f / 128.0f, world);
+
+    const auto& outVis = registry.get<PlayerVisState>(player);
+    const auto& outVel = registry.get<Velocity>(player);
+
+    bool ok = true;
+    ok &= expect(outVis.moveMode == MoveMode::OnFoot,
+                 "wallrun should drop when a wall segment ends without continuation");
+    ok &= expect(outVel.value.z > 0.0f, "wallrun drop should preserve forward velocity instead of reversing");
+    return ok;
+}
+
 bool climbMantleToTopFloorKeepsFiniteState()
 {
     const WorldTriMesh climbMesh = makeClimbWallWithTopFloor();
@@ -1383,6 +1520,8 @@ int main()
     ok &= wallDetectionGroundDistanceUsesFlippedGravityDirection();
     ok &= wallAttachmentLookaheadFindsOuterCornerContinuation();
     ok &= wallAttachmentWalksSingleMeshAdjacencyAtCorner();
+    ok &= wallrunOuterCornerKeepsForwardVelocity();
+    ok &= wallrunGapDropsWithoutReversingVelocity();
     ok &= climbMantleToTopFloorKeepsFiniteState();
     ok &= ledgeMantleRejectsInvalidStoredNormal();
     ok &= flippedGravityClimbMovesAlongLocalUp();


### PR DESCRIPTION
This pull request introduces comprehensive planning and design documentation for implementing an Apex Legends–style climbing system, along with a small CMake improvement for dependency management. The changes lay out the target feature set, architectural approach, and a detailed, test-driven implementation plan for integrating advanced climb mechanics into the game.

**Documentation and Planning:**

* Added `docs/apex-climb-wanted-feature-set.md` to define the desired climbing mechanics, including attach/detach rules, climb zones, sub-modes (upward, slip, downward, sideways), penalties, end boost, reattach logic, and wallrun interplay. This document serves as the design reference for the new system.
* Added `docs/superpowers/plans/2026-05-16-apex-climb-implementation.md`, a step-by-step implementation plan using test-driven development. It specifies required code changes, new state and constants, test cases, and commit checkpoints for each major feature (climb space, attachment, sub-modes, zones, reattach, and wallrun transitions).

**Build System Improvement:**

* Updated `CMakeLists.txt` to ensure that the EnTT dependency's include directories are treated as system includes, which can help suppress warnings from external headers during compilation.

These changes provide a clear roadmap and technical foundation for replacing the current climbing system with a robust, Apex-inspired traversal mechanic.