### PR TITLE
ci: publish server Docker image to GHCR + live asset fetch on every release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,6 +399,7 @@ jobs:
     if: github.event_name == 'push'
     permissions:
       contents: write
+      packages: write
 
     steps:
       # Full history + tags needed to compute the next semantic version.
@@ -664,3 +665,45 @@ jobs:
             group2-linux-x86_64.zip \
             group2-macos.zip \
             group2-windows-x86_64.zip
+
+      # ---------------- Docker image: ghcr.io/<owner>/group2-server ----------------
+      #
+      # Reuses the Linux release artifact that release-build just produced;
+      # no recompile inside Docker. The Dockerfile (docker/Dockerfile.server)
+      # consumes server + config.toml + assets/ from the unpacked zip.
+      - name: Prepare Docker build context
+        shell: bash
+        run: |
+          mkdir -p docker-context
+          unzip -q group2-linux-x86_64.zip -d docker-context-tmp
+          # The zip's top-level dir is `group2-linux-x86_64/`; flatten it.
+          mv docker-context-tmp/group2-linux-x86_64/* docker-context/
+          cp docker/Dockerfile.server   docker-context/Dockerfile
+          cp docker/.dockerignore       docker-context/.dockerignore
+          # Sanity print so a CI log reader can confirm the layout.
+          ls -la docker-context
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/group2-server
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.tag }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: docker-context
+          platforms: linux/amd64
+          push: true
+          tags:   ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,7 @@ jobs:
       # Bundle group2 + server + shaders + shaders-new + config + assets into a single zip.
       - name: Package release
         shell: bash
+        timeout-minutes: 10
         env:
           # Drive folder containing the current game assets (maps, animations,
           # prop GLBs). Fetched fresh on every release — no cache — so releases
@@ -351,6 +352,16 @@ jobs:
           # caps at 50 files unless `--remaining-ok` is passed; the flag
           # was removed in 6.x and the limit was lifted, so the modern
           # invocation is simply `--folder` with no extra flag.
+          #
+          # Observed Drive folder layout (verified 2026-05-16):
+          #   assets/animations/  (fbx, incl. nested crouch/, male_locomotion_pack/)
+          #   assets/hud_icons/   (svg + README.md)
+          #   assets/maps/        (glb map files, e.g. map1.glb)
+          #   assets/sounds/      (wav, mp3)
+          #   assets/uploads_files_812442_FreePresets/  (atm presets)
+          #   assets/uploads_files_812442_HdriFree/     (hdr environment maps)
+          # The Dockerfile and CMake post-build copy assume `assets/maps/`,
+          # `assets/animations/`, and `assets/*.glb` exist at these paths.
           pip install --quiet 'gdown>=6.0.0'
           gdown --folder \
                 -O "$STAGE/assets" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,8 +678,15 @@ jobs:
           unzip -q group2-linux-x86_64.zip -d docker-context-tmp
           # The zip's top-level dir is `group2-linux-x86_64/`; flatten it.
           mv docker-context-tmp/group2-linux-x86_64/* docker-context/
+          rm -rf docker-context-tmp
           cp docker/Dockerfile.server   docker-context/Dockerfile
           cp docker/.dockerignore       docker-context/.dockerignore
+          # Fail loud and early if the artifact didn't actually contain
+          # the binary — otherwise the downstream `docker build` would
+          # emit a confusing `COPY server` error.
+          test -f docker-context/server      || { echo "ERROR: server binary missing from context"; exit 1; }
+          test -f docker-context/config.toml || { echo "ERROR: config.toml missing from context"; exit 1; }
+          test -d docker-context/assets      || { echo "ERROR: assets/ directory missing from context"; exit 1; }
           # Sanity print so a CI log reader can confirm the layout.
           ls -la docker-context
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,11 +344,14 @@ jobs:
           cp -r "${{ matrix.build_dir }}/shaders-new" "$STAGE/"
 
           # Live assets from Google Drive — fresh on every release.
-          # --folder       : recursive folder download (gdown >= 5.0)
-          # Note: --remaining-ok was removed in gdown 6.x; gdown >= 6.0 has
-          #       no file-count limit for folder downloads by default.
-          # -O             : output directory
-          pip install --quiet 'gdown>=5.0.0'
+          # --folder : recursive folder download.
+          # -O       : output directory.
+          #
+          # Pin to gdown >= 6.0 because gdown 5.x with `--folder` silently
+          # caps at 50 files unless `--remaining-ok` is passed; the flag
+          # was removed in 6.x and the limit was lifted, so the modern
+          # invocation is simply `--folder` with no extra flag.
+          pip install --quiet 'gdown>=6.0.0'
           gdown --folder \
                 -O "$STAGE/assets" \
                 "https://drive.google.com/drive/folders/${ASSETS_FOLDER_ID}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,6 @@ jobs:
     if: github.event_name == 'push'
     env:
       SCCACHE_GHA_ENABLED: "true"
-      # Google Drive file ID for the shared assets zip.
-      ASSETS_GDRIVE_ID: "1_Xafht6-R_E8-gVglYFDAHvjZA8msfE4"
     strategy:
       fail-fast: false
       matrix:
@@ -320,24 +318,15 @@ jobs:
         shell: bash
         run: cmake --build --preset ${{ matrix.preset }} --target group2 server clientbot --parallel
 
-      # Download the shared assets zip from Google Drive (cached across runs).
-      - name: Cache assets
-        id: assets-cache
-        uses: actions/cache@v4
-        with:
-          path: assets.zip
-          key: assets-${{ env.ASSETS_GDRIVE_ID }}
-
-      - name: Download assets
-        if: steps.assets-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          pip install --quiet gdown
-          gdown "https://drive.google.com/uc?id=${ASSETS_GDRIVE_ID}" -O assets.zip
-
       # Bundle group2 + server + shaders + shaders-new + config + assets into a single zip.
       - name: Package release
         shell: bash
+        env:
+          # Drive folder containing the current game assets (maps, animations,
+          # prop GLBs). Fetched fresh on every release — no cache — so releases
+          # always reflect the latest art the team has uploaded.
+          # Folder must remain "Anyone with the link can view".
+          ASSETS_FOLDER_ID: "1nUGE1_tfFNQcl5-UDkjys0XjE8OLxd28"
         run: |
           DIR="group2-${{ matrix.archive_suffix }}"
           STAGE="staging/$DIR"
@@ -354,8 +343,15 @@ jobs:
           cp -r "${{ matrix.build_dir }}/shaders" "$STAGE/"
           cp -r "${{ matrix.build_dir }}/shaders-new" "$STAGE/"
 
-          # Assets from Google Drive (cross-platform extraction via Python)
-          python3 -c "import zipfile; zipfile.ZipFile('assets.zip').extractall('$STAGE')"
+          # Live assets from Google Drive — fresh on every release.
+          # --folder       : recursive folder download (gdown >= 5.0)
+          # Note: --remaining-ok was removed in gdown 6.x; gdown >= 6.0 has
+          #       no file-count limit for folder downloads by default.
+          # -O             : output directory
+          pip install --quiet 'gdown>=5.0.0'
+          gdown --folder \
+                -O "$STAGE/assets" \
+                "https://drive.google.com/drive/folders/${ASSETS_FOLDER_ID}"
 
           # Create release zip.
           # Linux/macOS have zip pre-installed; Windows has 7z instead.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ docker run --rm \
 # Pin to a specific release.
 docker run --rm \
   -p 9999:9999/udp -p 9999:9999/tcp \
-  ghcr.io/ucsd-cse125-sp26/group2-server:v0.1.0
+  ghcr.io/ucsd-cse125-sp26/group2-server:vX.Y.Z   # any tag from the Packages tab
 
 # Override config.toml without rebuilding.
 docker run --rm \
@@ -204,6 +204,8 @@ docker run --rm \
   -e GROUP2_SERVER_SHOTS_CSV=/var/log/group2/shots.csv \
   ghcr.io/ucsd-cse125-sp26/group2-server:latest
 ````
+
+> **First-time setup (maintainers only).** GHCR creates new packages as private by default. After the very first CI publish, an admin needs to flip the package to public once — Repo → Packages → `group2-server` → Package settings → **Change package visibility** → Public. Until then, `docker pull` requires `docker login ghcr.io -u <user> -p <github-pat-with-read:packages>`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,40 @@ LSAN_OPTIONS=suppressions=sanitizers/lsan.supp ./build/debug/group2
 .\build\debug-win\server  # Windows
 ```
 
+### Running Server in Docker
+
+Published images live at `ghcr.io/ucsd-cse125-sp26/group2-server` (Linux / amd64). Image tags: `latest` tracks the most recent release; `vX.Y.Z` pins to a specific release.
+
+````bash
+# Pull and run on the default port (9999, UDP + TCP).
+docker pull ghcr.io/ucsd-cse125-sp26/group2-server:latest
+docker run --rm \
+  -p 9999:9999/udp -p 9999:9999/tcp \
+  ghcr.io/ucsd-cse125-sp26/group2-server:latest
+
+# Pin to a specific release.
+docker run --rm \
+  -p 9999:9999/udp -p 9999:9999/tcp \
+  ghcr.io/ucsd-cse125-sp26/group2-server:v0.1.0
+
+# Override config.toml without rebuilding.
+docker run --rm \
+  -p 9999:9999/udp -p 9999:9999/tcp \
+  -v "$PWD/config.toml":/app/config.toml \
+  ghcr.io/ucsd-cse125-sp26/group2-server:latest
+````
+
+The container runs as non-root (UID 10001). If you enable shot logging by setting `GROUP2_SERVER_SHOTS_CSV`, mount the output dir and make sure UID 10001 can write to it:
+
+````bash
+mkdir -p ./logs && chown 10001 ./logs   # or chmod 777 ./logs for quick local use
+docker run --rm \
+  -p 9999:9999/udp -p 9999:9999/tcp \
+  -v "$PWD/logs":/var/log/group2 \
+  -e GROUP2_SERVER_SHOTS_CSV=/var/log/group2/shots.csv \
+  ghcr.io/ucsd-cse125-sp26/group2-server:latest
+````
+
 ---
 
 ## CMake options

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,9 @@
+# Excludes from the docker build context (the unpacked release zip).
+# The server doesn't render — shaders are dead weight in the image.
+shaders/
+shaders-new/
+
+# group2 is the client binary — same release zip carries it, but the
+# server image has no use for it.
+group2
+group2.exe

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+#
+# Runtime image for the group2 dedicated game server.
+#
+# This Dockerfile is consumed by the CI `publish` job: the build context
+# is the unpacked group2-linux-x86_64.zip artifact, so `server`,
+# `config.toml`, and `assets/` are expected to exist at the context root.
+# It is NOT designed for `docker build .` from a clean checkout.
+#
+# Base image matches the CI build runner (ubuntu-24.04) so glibc symbol
+# versions line up exactly.
+FROM ubuntu:24.04
+
+# Runtime libraries.
+#
+# The server calls SDL_Init(0) (src/server/main/main.cpp:164) with no
+# subsystem flags, so SDL3's video/audio/input backends are never
+# initialised and we don't ship X11/Wayland/audio libs.
+#
+# libtbb12: required when the build linked TBB for std::execution::par_unseq
+#           (see CMakeLists.txt around line 1238).
+# ca-certificates: harmless, future-proofs any TLS callout we might add.
+#
+# Final cleanup removes apt lists to keep the layer small.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         libtbb12 \
+         ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --no-create-home --shell /usr/sbin/nologin group2
+
+WORKDIR /app
+
+# Copy artifacts from the unpacked release zip in the build context.
+# --chown so the non-root `group2` user can read everything.
+COPY --chown=group2:group2 server ./
+COPY --chown=group2:group2 config.toml ./
+COPY --chown=group2:group2 assets/ ./assets/
+
+USER group2:group2
+
+# SDL3_net uses both UDP (game traffic) and TCP (handshake / lobby).
+# Defaults match config.template.toml [server-network] port=9999.
+EXPOSE 9999/udp 9999/tcp
+
+ENTRYPOINT ["./server"]


### PR DESCRIPTION
## Summary
- Replaces the cached static-zip Drive download in `release-build` with a live `gdown --folder` fetch (folder ID `1nUGE1_tfFNQcl5-UDkjys0XjE8OLxd28`) so releases always reflect the team's current assets — no manual zip re-upload to Drive.
- Extends the existing `publish` job (no new job, no new workflow) to build `docker/Dockerfile.server` around the Linux release zip and push `ghcr.io/ucsd-cse125-sp26/group2-server:{vX.Y.Z,latest}` to GHCR via `GITHUB_TOKEN` + `packages: write`.
- Image is single-stage `FROM ubuntu:24.04` (matches the CI build host for glibc parity), runs as non-root (UID 10001), exposes `9999/udp` + `9999/tcp`.

## Files
- `docker/Dockerfile.server` (new) — server runtime image.
- `docker/.dockerignore` (new) — excludes shaders + client binary from build context.
- `.github/workflows/ci.yml` — asset-fetch refactor in `release-build`; four new steps + `packages: write` in `publish`.
- `README.md` — \"Running Server in Docker\" subsection.

## Test plan
- [ ] CI green on this PR (only the PR-time `build` job runs here — Docker publish is gated on push-to-main, so the new steps won't execute until after merge).
- [ ] After merge, watch the first `publish` run: confirm `ghcr.io/ucsd-cse125-sp26/group2-server:vX.Y.Z` and `:latest` appear under the repo's **Packages** tab.
- [ ] One-time: admin flips the new GHCR package to **public** — Repo → Packages → `group2-server` → Package settings → **Change package visibility** → Public. (Or via `gh api --method PATCH /orgs/ucsd-cse125-sp26/packages/container/group2-server -f visibility=public`.)
- [ ] Smoke test from a clean machine: \`docker pull ghcr.io/ucsd-cse125-sp26/group2-server:latest && docker run --rm -p 9999:9999/udp -p 9999:9999/tcp ghcr.io/.../group2-server:latest\`, then connect a client with matching \`client-network\` in \`config.toml\`.

## Notes for reviewers
- The asset-fetch change affects **all three** platform release zips, not just Linux. Trade-off: every matrix job does a cold ~10–60 s Drive download (no cache) in exchange for always-fresh assets. \`timeout-minutes: 10\` guards against a stalled gdown.
- \`gdown >= 6.0.0\` is pinned because 5.x with \`--folder\` silently caps at 50 files; the Drive folder has 77+.
- The image runs as non-root (UID 10001). Users enabling shot logging via \`GROUP2_SERVER_SHOTS_CSV\` need to \`chown 10001\` the mounted log dir — documented in the README addition.
- Container healthcheck, image signing, SBOM, and multi-arch are explicitly out of scope for v1.