### PR TITLE
local server discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,6 +669,8 @@ add_executable(group2
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/network/Client.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/DeveloperConfig.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/DeveloperConfig.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/client/network/DiscoveryClient.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/client/network/DiscoveryClient.hpp"
     # PR-11 (server-perf): client-side render-delay interpolation
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/network/EntityInterpolation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/client/network/EntityInterpolation.hpp"
@@ -1118,6 +1120,8 @@ add_executable(server
     "${CMAKE_CURRENT_SOURCE_DIR}/src/server/network/Server.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/DeveloperConfig.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/DeveloperConfig.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/server/network/DiscoveryServer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/server/network/DiscoveryServer.hpp"
     # PR-1 (server-perf): scoped profiler + 1 Hz aggregator.
     "${CMAKE_CURRENT_SOURCE_DIR}/src/server/perf/Profiler.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/server/perf/Profiler.cpp"

--- a/src/client/menus/home/Home.cpp
+++ b/src/client/menus/home/Home.cpp
@@ -20,6 +20,9 @@ bool Home::init(NewRenderer* rendererPtr, SDL_Window* windowPtr, const GlobalDis
     window = windowPtr;
     discoveryConfig = discoveryCfg;
     startGlobalRefresh(true);
+
+    localDiscoveryClient->start(9998);
+
     return true;
 }
 
@@ -36,6 +39,8 @@ void Home::quit()
 {
     if (browserThread.joinable())
         browserThread.join();
+
+    localDiscoveryClient->stop();
 }
 
 SDL_AppResult Home::iterate()
@@ -47,6 +52,9 @@ SDL_AppResult Home::iterate()
         startGlobalRefresh();
     }
 
+    localDiscoveryClient->poll();
+    localServers = localDiscoveryClient->getServers();
+
     ImGui_ImplSDLGPU3_NewFrame();
     ImGui_ImplSDL3_NewFrame();
     ImGui::NewFrame();
@@ -57,8 +65,12 @@ SDL_AppResult Home::iterate()
         servers = globalServers;
         globalError = browserError;
     }
-    JoinMenuResult result = home_ui::buildJoinMenu(
-        joinMenuState, joinError, servers, globalError, browserRefreshing.load(std::memory_order_relaxed));
+    JoinMenuResult result = home_ui::buildJoinMenu(joinMenuState,
+                                                   joinError,
+                                                   localServers,
+                                                   servers,
+                                                   globalError,
+                                                   browserRefreshing.load(std::memory_order_relaxed));
     if (result.refreshClicked) {
         startGlobalRefresh(true);
     }
@@ -79,7 +91,12 @@ SDL_AppResult Home::iterate()
         joinError.clear();
         pendingJoinRequest =
             JoinRequest{.serverIp = server.host, .serverPort = server.gamePort, .globalServerId = server.id};
+    } else if (result.localServerIndex >= 0 && result.localServerIndex < static_cast<int>(localServers.size())) {
+        const auto& server = localServers[static_cast<std::size_t>(result.localServerIndex)];
+        joinError.clear();
+        pendingJoinRequest = JoinRequest{.serverIp = server.hostIp, .serverPort = server.gamePort, .globalServerId = 0};
     }
+
     ImGui::Render();
     renderer->drawFrame(glm::vec3(0.0f), 0.0f, 0.0f, 0.0f);
     return SDL_APP_CONTINUE;

--- a/src/client/menus/home/Home.hpp
+++ b/src/client/menus/home/Home.hpp
@@ -3,10 +3,10 @@
 
 #include "IScreen.hpp"
 #include "menus/home/ui/HomeUI.hpp"
+#include "network/DiscoveryClient.hpp"
 #include "network/NetworkConfig.hpp"
 #include "network/discovery/GlobalDiscoveryClient.hpp"
 #include "renderer-new/NewRenderer.hpp"
-#include "network/DiscoveryClient.hpp"
 
 #include <atomic>
 #include <memory>

--- a/src/client/menus/home/Home.hpp
+++ b/src/client/menus/home/Home.hpp
@@ -6,8 +6,10 @@
 #include "network/NetworkConfig.hpp"
 #include "network/discovery/GlobalDiscoveryClient.hpp"
 #include "renderer-new/NewRenderer.hpp"
+#include "network/DiscoveryClient.hpp"
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -50,10 +52,13 @@ private:
         pendingJoinRequest;          ///< Set when the user clicks "Join", cleared on App transition to Lobby.
     std::string joinError;           ///< Error message shown on the join form; empty when no error.
 
+    std::unique_ptr<DiscoveryClient> localDiscoveryClient = std::make_unique<DiscoveryClient>();
+
     void startGlobalRefresh(bool force = false);
     void joinRefreshThreadIfFinished();
 
     std::vector<net::discovery::ServerInfo> globalServers;
+    std::vector<DiscoveryClient::DiscoveredServer> localServers;
     std::string browserError;
     std::mutex browserMutex;
     std::thread browserThread;

--- a/src/client/menus/home/ui/HomeUI.cpp
+++ b/src/client/menus/home/ui/HomeUI.cpp
@@ -10,6 +10,7 @@ namespace home_ui
 {
 JoinMenuResult buildJoinMenu(JoinMenuState& state,
                              std::string_view errorMessage,
+                             const std::vector<DiscoveryClient::DiscoveredServer>& localServers,
                              const std::vector<net::discovery::ServerInfo>& globalServers,
                              std::string_view browserError,
                              bool browserRefreshing)
@@ -29,6 +30,34 @@ JoinMenuResult buildJoinMenu(JoinMenuState& state,
             ImGui::Spacing();
             ImGui::TextColored(
                 ImVec4(1.0f, 0.25f, 0.25f, 1.0f), "%.*s", static_cast<int>(errorMessage.size()), errorMessage.data());
+        }
+
+        ImGui::SeparatorText("Local Servers");
+        if (ImGui::BeginTable("LocalServerTable", 4, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV)) {
+            ImGui::TableSetupColumn("Name");
+            ImGui::TableSetupColumn("Address");
+            ImGui::TableSetupColumn("Players");
+            ImGui::TableSetupColumn("");
+            ImGui::TableHeadersRow();
+
+            for (int i = 0; i < static_cast<int>(localServers.size()); ++i) {
+                const auto& server = localServers[static_cast<std::size_t>(i)];
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                ImGui::TextUnformatted(server.serverName.c_str());
+                ImGui::TableSetColumnIndex(1);
+                ImGui::Text("%s:%u", server.hostIp.c_str(), server.gamePort);
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("%u/%u", server.currentPlayers, server.maxPlayers);
+                ImGui::TableSetColumnIndex(3);
+                ImGui::PushID(i);
+                if (ImGui::SmallButton("Join")) {
+                    result.localServerIndex = i;
+                }
+                ImGui::PopID();
+            }
+
+            ImGui::EndTable();
         }
 
         ImGui::SeparatorText("Global Servers");

--- a/src/client/menus/home/ui/HomeUI.hpp
+++ b/src/client/menus/home/ui/HomeUI.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "network/discovery/GlobalDiscoveryProtocol.hpp"
+#include "network/DiscoveryClient.hpp"
 
 #include <string>
 #include <string_view>
@@ -21,6 +22,7 @@ struct JoinMenuResult
 {
     bool connectClicked = false; ///< True if the user pressed "Join" this frame.
     bool refreshClicked = false; ///< True if the user requested a global browser refresh.
+    int localServerIndex = -1;   ///< Index of a discovered local server to join, or -1.
     int globalServerIndex = -1;  ///< Index of a discovered server to join, or -1.
 };
 
@@ -33,6 +35,7 @@ namespace home_ui
 /// @return Actions the caller should apply (connect request).
 JoinMenuResult buildJoinMenu(JoinMenuState& state,
                              std::string_view errorMessage,
+                             const std::vector<DiscoveryClient::DiscoveredServer>& localServers,
                              const std::vector<net::discovery::ServerInfo>& globalServers,
                              std::string_view browserError,
                              bool browserRefreshing);

--- a/src/client/menus/home/ui/HomeUI.hpp
+++ b/src/client/menus/home/ui/HomeUI.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "network/discovery/GlobalDiscoveryProtocol.hpp"
 #include "network/DiscoveryClient.hpp"
+#include "network/discovery/GlobalDiscoveryProtocol.hpp"
 
 #include <string>
 #include <string_view>

--- a/src/client/network/DiscoveryClient.cpp
+++ b/src/client/network/DiscoveryClient.cpp
@@ -4,6 +4,7 @@
 #include "network/PacketType.hpp"
 
 #include <vector>
+#include <cstring>
 
 bool DiscoveryClient::start(uint16_t port)
 {

--- a/src/client/network/DiscoveryClient.cpp
+++ b/src/client/network/DiscoveryClient.cpp
@@ -3,8 +3,8 @@
 #include "SDL3_net/SDL_net.h"
 #include "network/PacketType.hpp"
 
-#include <vector>
 #include <cstring>
+#include <vector>
 
 bool DiscoveryClient::start(uint16_t port)
 {

--- a/src/client/network/DiscoveryClient.cpp
+++ b/src/client/network/DiscoveryClient.cpp
@@ -1,0 +1,84 @@
+#include "DiscoveryClient.hpp"
+
+#include "SDL3_net/SDL_net.h"
+#include "network/PacketType.hpp"
+
+#include <vector>
+
+bool DiscoveryClient::start(uint16_t discoveryPort)
+{
+    socket = NET_CreateDatagramSocket(nullptr, discoveryPort);
+    if (!socket) {
+        SDL_Log("DiscoveryClient: failed to create datagram socket: %s", SDL_GetError());
+        return false;
+    }
+    return true;
+}
+
+void DiscoveryClient::stop()
+{
+    if (socket) {
+        NET_DestroyDatagramSocket(socket);
+        socket = nullptr;
+    }
+}
+
+void DiscoveryClient::poll()
+{
+    if (!socket) {
+        return;
+    }
+
+    NET_Datagram* datagram = nullptr;
+    while (NET_ReceiveDatagram(socket, &datagram) && datagram) {
+        // min length is 1+2+1+1=5
+        if (datagram->buflen >= 5 && static_cast<PacketType>(datagram->buf[0]) == PacketType::LOCAL_SERVER_ADVERTISEMENT) {
+            const uint8_t* data = datagram->buf + 1;
+
+            uint16_t port = 0;
+            std::memcpy(&port, data, sizeof(port));
+            data += sizeof(port);
+
+            uint8_t currentPlayers = *data++;
+            uint8_t nameLength = *data++;
+
+            if (datagram->buflen >= 5 + nameLength) {
+                const char* addrRaw = NET_GetAddressString(datagram->addr);
+                std::string addr = addrRaw ? addrRaw : "unknown";
+                std::string fullAddr = addr + ":" + std::to_string(port);
+
+                auto& server = discoveredServers[fullAddr];
+                server.hostIp = addr;
+                server.gamePort = port;
+                server.currentPlayers = currentPlayers;
+                server.serverName.assign(reinterpret_cast<const char*>(data), nameLength);
+                server.lastSeenMs = SDL_GetTicks();
+            }
+        }
+
+        NET_DestroyDatagram(datagram);
+        datagram = nullptr;
+    }
+}
+
+std::vector<DiscoveryClient::DiscoveredServer> DiscoveryClient::getServers()
+{
+    // timeout servers after 10 seconds
+    constexpr uint64_t timeoutMs = 10000;
+    const uint64_t now = SDL_GetTicks();
+    for (auto it = discoveredServers.begin(); it != discoveredServers.end();) {
+        if (now - it->second.lastSeenMs > timeoutMs) {
+            it = discoveredServers.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    std::vector<DiscoveredServer> servers;
+    servers.reserve(discoveredServers.size());
+    for (const auto& [_, server] : discoveredServers) {
+        servers.push_back(server);
+    }
+
+    return servers;
+}

--- a/src/client/network/DiscoveryClient.cpp
+++ b/src/client/network/DiscoveryClient.cpp
@@ -5,13 +5,25 @@
 
 #include <vector>
 
-bool DiscoveryClient::start(uint16_t discoveryPort)
+bool DiscoveryClient::start(uint16_t port)
 {
-    socket = NET_CreateDatagramSocket(nullptr, discoveryPort);
+    discoveryPort = port;
+
+    socket = NET_CreateDatagramSocket(nullptr, 0);
     if (!socket) {
         SDL_Log("DiscoveryClient: failed to create datagram socket: %s", SDL_GetError());
         return false;
     }
+
+    broadcastAddr = NET_ResolveHostname("255.255.255.255");
+    if (NET_WaitUntilResolved(broadcastAddr, -1) == NET_FAILURE) {
+        SDL_Log("DiscoveryClient: failed to resolve broadcast address: %s", SDL_GetError());
+        NET_UnrefAddress(broadcastAddr);
+        NET_DestroyDatagramSocket(socket);
+        socket = nullptr;
+        return false;
+    }
+
     return true;
 }
 
@@ -21,6 +33,10 @@ void DiscoveryClient::stop()
         NET_DestroyDatagramSocket(socket);
         socket = nullptr;
     }
+    if (broadcastAddr) {
+        NET_UnrefAddress(broadcastAddr);
+        broadcastAddr = nullptr;
+    }
 }
 
 void DiscoveryClient::poll()
@@ -29,10 +45,20 @@ void DiscoveryClient::poll()
         return;
     }
 
+    auto now = SDL_GetTicks();
+    // broadcast every 1 second
+    if (broadcastAddr && now - lastRequestMs > 1000) {
+        uint8_t buf[1] = {static_cast<uint8_t>(PacketType::LOCAL_SERVER_DISCOVERY_REQUEST)};
+        NET_SendDatagram(socket, broadcastAddr, discoveryPort, buf, sizeof(buf));
+        lastRequestMs = now;
+    }
+
     NET_Datagram* datagram = nullptr;
     while (NET_ReceiveDatagram(socket, &datagram) && datagram) {
-        // min length is 1+2+1+1=5
-        if (datagram->buflen >= 5 && static_cast<PacketType>(datagram->buf[0]) == PacketType::LOCAL_SERVER_ADVERTISEMENT) {
+        // min length is 1+2+1+1+1=6
+        if (datagram->buflen >= 6 &&
+            static_cast<PacketType>(datagram->buf[0]) == PacketType::LOCAL_SERVER_DISCOVERY_RESPONSE)
+        {
             const uint8_t* data = datagram->buf + 1;
 
             uint16_t port = 0;
@@ -40,9 +66,10 @@ void DiscoveryClient::poll()
             data += sizeof(port);
 
             uint8_t currentPlayers = *data++;
+            uint8_t maxPlayers = *data++;
             uint8_t nameLength = *data++;
 
-            if (datagram->buflen >= 5 + nameLength) {
+            if (datagram->buflen >= 6 + nameLength) {
                 const char* addrRaw = NET_GetAddressString(datagram->addr);
                 std::string addr = addrRaw ? addrRaw : "unknown";
                 std::string fullAddr = addr + ":" + std::to_string(port);
@@ -51,6 +78,7 @@ void DiscoveryClient::poll()
                 server.hostIp = addr;
                 server.gamePort = port;
                 server.currentPlayers = currentPlayers;
+                server.maxPlayers = maxPlayers;
                 server.serverName.assign(reinterpret_cast<const char*>(data), nameLength);
                 server.lastSeenMs = SDL_GetTicks();
             }

--- a/src/client/network/DiscoveryClient.hpp
+++ b/src/client/network/DiscoveryClient.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "SDL3_net/SDL_net.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class DiscoveryClient
+{
+public:
+    struct DiscoveredServer
+    {
+        std::string serverName;
+        std::string hostIp;
+        uint16_t gamePort;
+        uint8_t currentPlayers;
+        uint64_t lastSeenMs;
+    };
+
+    bool start(uint16_t discoveryPort);
+
+    void stop();
+
+    void poll();
+
+    std::vector<DiscoveredServer> getServers();
+
+private:
+    NET_DatagramSocket* socket = nullptr;
+    std::unordered_map<std::string, DiscoveredServer> discoveredServers; // key is host IP
+};

--- a/src/client/network/DiscoveryClient.hpp
+++ b/src/client/network/DiscoveryClient.hpp
@@ -29,7 +29,7 @@ public:
 
 private:
     uint16_t discoveryPort = 0;
-    NET_Address *broadcastAddr = nullptr;
+    NET_Address* broadcastAddr = nullptr;
     uint64_t lastRequestMs = 0;
 
     NET_DatagramSocket* socket = nullptr;

--- a/src/client/network/DiscoveryClient.hpp
+++ b/src/client/network/DiscoveryClient.hpp
@@ -15,6 +15,7 @@ public:
         std::string hostIp;
         uint16_t gamePort;
         uint8_t currentPlayers;
+        uint8_t maxPlayers;
         uint64_t lastSeenMs;
     };
 
@@ -27,6 +28,11 @@ public:
     std::vector<DiscoveredServer> getServers();
 
 private:
+    uint16_t discoveryPort = 0;
+    NET_Address *broadcastAddr = nullptr;
+    uint64_t lastRequestMs = 0;
+
     NET_DatagramSocket* socket = nullptr;
+
     std::unordered_map<std::string, DiscoveredServer> discoveredServers; // key is host IP
 };

--- a/src/network/PacketType.hpp
+++ b/src/network/PacketType.hpp
@@ -71,4 +71,7 @@ enum class PacketType : uint8_t
     TEXT_CHAT,      ///< Client <-> Server: bounded UTF-8 all-chat message.
     VOICE_FRAME,    ///< Client <-> Server: Opus voice frame for proximity chat.
     VOICE_STATE,    ///< Client <-> Server: push-to-talk state hint for HUD indicators.
+
+    LOCAL_SERVER_ADVERTISEMENT, ///< Server -> clients on LAN before starting a game, lets clients discover that a server
+                          ///< exists
 };

--- a/src/network/PacketType.hpp
+++ b/src/network/PacketType.hpp
@@ -72,6 +72,6 @@ enum class PacketType : uint8_t
     VOICE_FRAME,    ///< Client <-> Server: Opus voice frame for proximity chat.
     VOICE_STATE,    ///< Client <-> Server: push-to-talk state hint for HUD indicators.
 
-    LOCAL_SERVER_ADVERTISEMENT, ///< Server -> clients on LAN before starting a game, lets clients discover that a server
-                          ///< exists
+    LOCAL_SERVER_DISCOVERY_REQUEST, ///< client broadcasts to server, which responds with response below
+    LOCAL_SERVER_DISCOVERY_RESPONSE,
 };

--- a/src/server/main/main.cpp
+++ b/src/server/main/main.cpp
@@ -3,6 +3,7 @@
 
 #include "DeveloperConfig.hpp"
 #include "game/ServerGame.hpp"
+#include "network/DiscoveryServer.hpp"
 #include "network/NetworkConfig.hpp"
 #include "network/Server.hpp"
 #include "perf/Parallel.hpp"
@@ -189,11 +190,22 @@ int main()
         return 1;
     }
 
+    // start server discovery system
+    // TODO: random port
+    DiscoveryServer discoveryServer;
+    const DiscoveryServer::ServerInfo serverInfo{
+        .serverName = "Test Server",
+        .gamePort = serverNet.port,
+        .currentPlayers = 0,
+    };
+    discoveryServer.start(9998, serverInfo);
+
     ServerGame game;
     if (!game.init(server, /*tickRateHz*/ 128, cfg.serverRep.snapshotHz, developerCfg.skipLobby)) {
         server.shutdown();
         ::group2::perf::stopAggregator();
         closeCsv();
+        discoveryServer.stop();
         NET_Quit();
         SDL_Quit();
         return 1;
@@ -205,6 +217,8 @@ int main()
 
     ::group2::perf::stopAggregator();
     closeCsv();
+
+    discoveryServer.stop();
 
     NET_Quit();
     SDL_Quit();

--- a/src/server/main/main.cpp
+++ b/src/server/main/main.cpp
@@ -191,14 +191,14 @@ int main()
     }
 
     // start server discovery system
-    // TODO: random port
     DiscoveryServer discoveryServer;
     const DiscoveryServer::ServerInfo serverInfo{
-        .serverName = "Test Server",
+        .serverName = cfg.discovery.serverName,
         .gamePort = serverNet.port,
         .currentPlayers = 0,
+        .maxPlayers = cfg.discovery.maxPlayers,
     };
-    discoveryServer.start(9998, serverInfo);
+    discoveryServer.start(9998, serverInfo, [&server]() { return server.getClientCount(); });
 
     ServerGame game;
     if (!game.init(server, /*tickRateHz*/ 128, cfg.serverRep.snapshotHz, developerCfg.skipLobby)) {

--- a/src/server/network/DiscoveryServer.cpp
+++ b/src/server/network/DiscoveryServer.cpp
@@ -4,39 +4,32 @@
 #include "network/PacketType.hpp"
 
 #include <mutex>
+#include <utility>
 
 // struct ServerInfo
 // {
 //     std::string serverName;
 //     uint16_t gamePort;
 //     uint8_t currentPlayers;
+//     uint8_t maxPlayers;
 //
 //     // other interesting things can go here
 // };
 //
 // /// starts a thread that makes a UDP socket and broadcasts
 
-bool DiscoveryServer::start(uint16_t port, const ServerInfo& serverInfo)
+bool DiscoveryServer::start(uint16_t port, const ServerInfo& serverInfo, std::function<uint8_t()> playerCountFn)
 {
-    discoveryPort = port;
+    currentPlayersFn = std::move(playerCountFn);
 
     {
         std::lock_guard<std::mutex> lock(infoMutex);
         info = serverInfo;
     }
 
-    socket = NET_CreateDatagramSocket(nullptr, 0);
+    socket = NET_CreateDatagramSocket(nullptr, port);
     if (!socket) {
         SDL_Log("DiscoveryServer: failed to create datagram socket: %s", SDL_GetError());
-        return false;
-    }
-
-    broadcastAddr = NET_ResolveHostname("255.255.255.255");
-    if (NET_WaitUntilResolved(broadcastAddr, -1) == NET_FAILURE) {
-        SDL_Log("DiscoveryServer: failed to resolve broadcast address: %s", SDL_GetError());
-        NET_UnrefAddress(broadcastAddr);
-        NET_DestroyDatagramSocket(socket);
-        socket = nullptr;
         return false;
     }
 
@@ -63,43 +56,54 @@ void DiscoveryServer::stop()
         NET_DestroyDatagramSocket(socket);
         socket = nullptr;
     }
-    if (broadcastAddr) {
-        NET_UnrefAddress(broadcastAddr);
-        broadcastAddr = nullptr;
-    }
 }
 
 void DiscoveryServer::loop()
 {
     while (!shouldStop.load()) {
+
         // serialize into packet
         std::vector<uint8_t> data;
         {
             std::lock_guard<std::mutex> lock(infoMutex);
 
+            if (currentPlayersFn) {
+                info.currentPlayers = currentPlayersFn();
+            }
+
             const uint8_t nameLen = static_cast<uint8_t>(std::min<size_t>(info.serverName.size(), 255));
 
             // packet is
-            // [packetType (1)][everything but name len (2+1 = 3)][nameLen (1)][name (nameLen)]
-            data.resize(1 + 3 + 1 + nameLen);
+            // [packetType (1)][gamePort (2)][currentPlayers (1)][maxPlayers (1)][nameLen (1)][name (nameLen)]
+            data.resize(1 + 4 + 1 + nameLen);
 
             uint8_t* ptr = data.data();
-            *ptr++ = static_cast<uint8_t>(PacketType::LOCAL_SERVER_ADVERTISEMENT);
+            *ptr++ = static_cast<uint8_t>(PacketType::LOCAL_SERVER_DISCOVERY_RESPONSE);
 
             std::memcpy(ptr, &info.gamePort, sizeof(info.gamePort));
             ptr += sizeof(info.gamePort);
 
             *ptr++ = info.currentPlayers;
+            *ptr++ = info.maxPlayers;
 
             *ptr++ = nameLen;
             std::memcpy(ptr, info.serverName.data(), nameLen);
         }
 
-        NET_SendDatagram(socket, broadcastAddr, discoveryPort, data.data(), static_cast<int>(data.size()));
+        // drain datagrams
+        NET_Datagram* datagram = nullptr;
+        while (NET_ReceiveDatagram(socket, &datagram) && datagram) {
+            // check if it is a server discovery request
+            if (datagram->buflen >= 1 &&
+                static_cast<PacketType>(datagram->buf[0]) == PacketType::LOCAL_SERVER_DISCOVERY_REQUEST)
+            {
+                // respond to the request
+                NET_SendDatagram(socket, datagram->addr, datagram->port, data.data(), static_cast<int>(data.size()));
+            }
 
-        // check should stop every 100ms, wait 2s
-        for (int i = 0; i < 20 && !shouldStop.load(); ++i) {
-            SDL_Delay(100);
+            NET_DestroyDatagram(datagram);
         }
+
+        SDL_Delay(50);
     }
 }

--- a/src/server/network/DiscoveryServer.cpp
+++ b/src/server/network/DiscoveryServer.cpp
@@ -1,0 +1,105 @@
+#include "DiscoveryServer.hpp"
+
+#include "SDL3_net/SDL_net.h"
+#include "network/PacketType.hpp"
+
+#include <mutex>
+
+// struct ServerInfo
+// {
+//     std::string serverName;
+//     uint16_t gamePort;
+//     uint8_t currentPlayers;
+//
+//     // other interesting things can go here
+// };
+//
+// /// starts a thread that makes a UDP socket and broadcasts
+
+bool DiscoveryServer::start(uint16_t port, const ServerInfo& serverInfo)
+{
+    discoveryPort = port;
+
+    {
+        std::lock_guard<std::mutex> lock(infoMutex);
+        info = serverInfo;
+    }
+
+    socket = NET_CreateDatagramSocket(nullptr, 0);
+    if (!socket) {
+        SDL_Log("DiscoveryServer: failed to create datagram socket: %s", SDL_GetError());
+        return false;
+    }
+
+    broadcastAddr = NET_ResolveHostname("255.255.255.255");
+    if (NET_WaitUntilResolved(broadcastAddr, -1) == NET_FAILURE) {
+        SDL_Log("DiscoveryServer: failed to resolve broadcast address: %s", SDL_GetError());
+        NET_UnrefAddress(broadcastAddr);
+        NET_DestroyDatagramSocket(socket);
+        socket = nullptr;
+        return false;
+    }
+
+    shouldStop.store(false);
+    broadcastThread = std::thread(&DiscoveryServer::loop, this);
+    return true;
+}
+
+void DiscoveryServer::updateInfo(const ServerInfo& serverInfo)
+{
+    std::lock_guard<std::mutex> lock(infoMutex);
+    info = serverInfo;
+}
+
+void DiscoveryServer::stop()
+{
+    shouldStop.store(true);
+
+    if (broadcastThread.joinable()) {
+        broadcastThread.join();
+    }
+
+    if (socket) {
+        NET_DestroyDatagramSocket(socket);
+        socket = nullptr;
+    }
+    if (broadcastAddr) {
+        NET_UnrefAddress(broadcastAddr);
+        broadcastAddr = nullptr;
+    }
+}
+
+void DiscoveryServer::loop()
+{
+    while (!shouldStop.load()) {
+        // serialize into packet
+        std::vector<uint8_t> data;
+        {
+            std::lock_guard<std::mutex> lock(infoMutex);
+
+            const uint8_t nameLen = static_cast<uint8_t>(std::min<size_t>(info.serverName.size(), 255));
+
+            // packet is
+            // [packetType (1)][everything but name len (2+1 = 3)][nameLen (1)][name (nameLen)]
+            data.resize(1 + 3 + 1 + nameLen);
+
+            uint8_t* ptr = data.data();
+            *ptr++ = static_cast<uint8_t>(PacketType::LOCAL_SERVER_ADVERTISEMENT);
+
+            std::memcpy(ptr, &info.gamePort, sizeof(info.gamePort));
+            ptr += sizeof(info.gamePort);
+
+            *ptr++ = info.currentPlayers;
+
+            *ptr++ = nameLen;
+            std::memcpy(ptr, info.serverName.data(), nameLen);
+        }
+
+        NET_SendDatagram(socket, broadcastAddr, discoveryPort, data.data(), static_cast<int>(data.size()));
+
+        // check should stop every 100ms, wait 2s
+        for (int i = 0; i < 20 && !shouldStop.load(); ++i) {
+            SDL_Delay(100);
+        }
+    }
+}

--- a/src/server/network/DiscoveryServer.cpp
+++ b/src/server/network/DiscoveryServer.cpp
@@ -3,6 +3,7 @@
 #include "SDL3_net/SDL_net.h"
 #include "network/PacketType.hpp"
 
+#include <cstring>
 #include <mutex>
 #include <utility>
 

--- a/src/server/network/DiscoveryServer.hpp
+++ b/src/server/network/DiscoveryServer.hpp
@@ -14,12 +14,13 @@ public:
         std::string serverName;
         uint16_t gamePort;
         uint8_t currentPlayers;
+        uint8_t maxPlayers;
 
         // other interesting things can go here
     };
 
     /// starts a thread that makes a UDP socket and broadcasts
-    bool start(uint16_t port, const ServerInfo& serverInfo);
+    bool start(uint16_t port, const ServerInfo& serverInfo, std::function<uint8_t()> playerCountFn = nullptr);
 
     void updateInfo(const ServerInfo& serverInfo);
 
@@ -29,12 +30,12 @@ private:
     void loop();
 
     NET_DatagramSocket* socket = nullptr;
-    NET_Address* broadcastAddr = nullptr;
-    uint16_t discoveryPort = 0;
 
     std::atomic<bool> shouldStop{false};
     std::thread broadcastThread;
 
     ServerInfo info;
     std::mutex infoMutex;
+
+    std::function<uint8_t()> currentPlayersFn;
 };

--- a/src/server/network/DiscoveryServer.hpp
+++ b/src/server/network/DiscoveryServer.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "SDL3_net/SDL_net.h"
+
+#include <atomic>
+#include <mutex>
+#include <thread>
+class DiscoveryServer
+{
+
+public:
+    struct ServerInfo
+    {
+        std::string serverName;
+        uint16_t gamePort;
+        uint8_t currentPlayers;
+
+        // other interesting things can go here
+    };
+
+    /// starts a thread that makes a UDP socket and broadcasts
+    bool start(uint16_t port, const ServerInfo& serverInfo);
+
+    void updateInfo(const ServerInfo& serverInfo);
+
+    void stop();
+
+private:
+    void loop();
+
+    NET_DatagramSocket* socket = nullptr;
+    NET_Address* broadcastAddr = nullptr;
+    uint16_t discoveryPort = 0;
+
+    std::atomic<bool> shouldStop{false};
+    std::thread broadcastThread;
+
+    ServerInfo info;
+    std::mutex infoMutex;
+};


### PR DESCRIPTION
- Add LAN server discovery using UDP request/response on port 9998 — clients broadcast a discovery request from an ephemeral port, server responds directly to the sender
- Integrate LAN server browser into the Home screen alongside the existing global server browser
- Server advertises name, game port, current/max players from config; player count updates live via callback to Server::getClientCount()
- Fix port conflict that prevented multiple clients on the same machine (clients no longer bind to a fixed port)
