### PR TITLE
Batch and instrument new renderer

### DIFF
--- a/scripts/analyze-client-perf.py
+++ b/scripts/analyze-client-perf.py
@@ -39,6 +39,20 @@ SECTION_COLUMNS = [
     "pause_menu_ms",
     "imgui_render_ms",
     "draw_frame_ms",
+    "draw_acquire_ms",
+    "draw_record_ms",
+    "draw_submit_ms",
+    "renderer_swapchain_acquire_ms",
+    "renderer_depth_ensure_ms",
+    "renderer_camera_update_ms",
+    "renderer_static_batch_rebuild_ms",
+    "renderer_skinned_upload_ms",
+    "renderer_geometry_pass_ms",
+    "renderer_weapon_pass_ms",
+    "renderer_ui_pass_ms",
+    "renderer_imgui_prepare_ms",
+    "renderer_hud_draw_ms",
+    "renderer_imgui_draw_ms",
     "frame_limiter_ms",
 ]
 
@@ -51,6 +65,13 @@ COUNTER_COLUMNS = [
     "reconcile_skipped_exact",
     "reconcile_replay_forced",
     "reconcile_missing_history",
+    "renderer_static_batch_draws",
+    "renderer_dynamic_draws",
+    "renderer_material_binds",
+    "renderer_texture_binds",
+    "renderer_static_triangles",
+    "renderer_frame_submitted",
+    "renderer_swapchain_skipped",
     "perf_movement_calls",
     "perf_movement_players",
     "perf_collision_calls",
@@ -146,6 +167,17 @@ def main() -> int:
         f"p5={fps(pct(wall, 0.95)):.1f} p1={fps(pct(wall, 0.99)):.1f} min={fps(wall[-1]):.1f}"
     )
     print(f"cpu ms:  avg={avg(cpu):.3f} p95={pct(cpu, 0.95):.3f} p99={pct(cpu, 0.99):.3f}")
+    present_modes = sorted({row.get("renderer_present_mode", "") for row in rows if row.get("renderer_present_mode", "")})
+    if present_modes:
+        counts = {mode: sum(1 for row in rows if row.get("renderer_present_mode", "") == mode) for mode in present_modes}
+        print("renderer present modes: " + ", ".join(f"{mode}={count}" for mode, count in counts.items()))
+    submitted = sum(1 for row in rows if f(row, "renderer_frame_submitted") > 0.0)
+    skipped = sum(1 for row in rows if f(row, "renderer_swapchain_skipped") > 0.0)
+    duration_ms = f(rows[-1], "timestamp_ms") - f(rows[0], "timestamp_ms")
+    submitted_rows = [row for row in rows if f(row, "renderer_frame_submitted") > 0.0]
+    if submitted > 0 or skipped > 0:
+        submitted_fps = submitted * 1000.0 / duration_ms if duration_ms > 0.0 else 0.0
+        print(f"renderer submitted frames: {submitted}/{len(rows)} ({submitted_fps:.1f}/s), swapchain skipped={skipped}")
 
     slow_cutoff = pct(wall, 0.99)
     slow_rows = [r for r in rows if f(r, "wall_frame_ms") >= slow_cutoff]
@@ -153,6 +185,12 @@ def main() -> int:
     section_avgs = [(name, avg(f(r, name) for r in slow_rows)) for name in SECTION_COLUMNS]
     for name, value in sorted(section_avgs, key=lambda item: item[1], reverse=True)[:16]:
         print(f"  {name:20s} {value:8.3f}")
+
+    if submitted_rows:
+        print("\nsubmitted-frame avg section ms:")
+        submitted_section_avgs = [(name, avg(f(r, name) for r in submitted_rows)) for name in SECTION_COLUMNS]
+        for name, value in sorted(submitted_section_avgs, key=lambda item: item[1], reverse=True)[:16]:
+            print(f"  {name:20s} {value:8.3f}")
 
     print("\nphysics tick distribution:")
     for tick_value in sorted({int(f(r, "physics_ticks")) for r in rows}):
@@ -187,6 +225,14 @@ def main() -> int:
             f"recErrV={f(row, 'reconcile_error_velocity'):.3f} "
             f"refreshP={f(row, 'refresh_players_ms'):.3f}ms cam={f(row, 'camera_resolve_ms'):.3f}ms "
             f"draw={f(row, 'draw_frame_ms'):.3f}ms acq={f(row, 'draw_acquire_ms'):.3f}ms "
+            f"record={f(row, 'draw_record_ms'):.3f}ms sub={f(row, 'draw_submit_ms'):.3f}ms "
+            f"swap={f(row, 'renderer_swapchain_acquire_ms'):.3f}ms "
+            f"geom={f(row, 'renderer_geometry_pass_ms'):.3f}ms "
+            f"weapon={f(row, 'renderer_weapon_pass_ms'):.3f}ms uiPass={f(row, 'renderer_ui_pass_ms'):.3f}ms "
+            f"imguiPrep={f(row, 'renderer_imgui_prepare_ms'):.3f}ms "
+            f"hudDraw={f(row, 'renderer_hud_draw_ms'):.3f}ms imguiDraw={f(row, 'renderer_imgui_draw_ms'):.3f}ms "
+            f"pmode={row.get('renderer_present_mode', 'n/a')} "
+            f"submitted={row.get('renderer_frame_submitted', '0')} skip={row.get('renderer_swapchain_skipped', '0')} "
             f"phys_ticks={row.get('physics_ticks', '0')} rec_ticks={row.get('reconcile_replayed_ticks', '0')} "
             f"kcc={row.get('perf_kcc_calls', '0')} sweepTri={row.get('perf_sweep_capsule_trimesh_tris', '0')} "
             f"closestTri={row.get('perf_closest_point_mesh_tris', '0')} "
@@ -196,6 +242,9 @@ def main() -> int:
             f"wallBroad={row.get('perf_wall_attachment_broadphase_fallbacks', '0')} "
             f"wallProbeTri={row.get('perf_closest_point_wall_probe_tris', '0')} "
             f"wallAttachTri={row.get('perf_closest_point_wall_attachment_tris', '0')} "
+            f"staticBatch={row.get('renderer_static_batch_draws', '0')} "
+            f"dynDraws={row.get('renderer_dynamic_draws', '0')} "
+            f"matBinds={row.get('renderer_material_binds', '0')} "
             f"draws={row.get('renderer_mesh_draws', '0')} tris={row.get('renderer_triangles', '0')}"
         )
 

--- a/scripts/perf-100bots.sh
+++ b/scripts/perf-100bots.sh
@@ -59,17 +59,17 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-# 1. Server (background) — wait until it logs "listening"
+# 1. Server (background) — wait until it logs a ready/listening line.
 # Map loading + V-HACD decomposition can take 10-30s on a cold start, so
 # we poll for up to 60s.
 "$BUILD_DIR/server" >>"$LOG" 2>&1 &
 SERVER_PID=$!
 for _ in {1..600}; do
-    if grep -q "Server: listening" "$LOG" 2>/dev/null; then break; fi
+    if grep -Eq "Server: listening|Server: UDP session listening" "$LOG" 2>/dev/null; then break; fi
     sleep 0.1
 done
-if ! grep -q "Server: listening" "$LOG"; then
-    echo "[perf] FAILED — server never logged 'listening'" >&2
+if ! grep -Eq "Server: listening|Server: UDP session listening" "$LOG"; then
+    echo "[perf] FAILED — server never logged a listening line" >&2
     exit 3
 fi
 

--- a/scripts/perf-toggles.md
+++ b/scripts/perf-toggles.md
@@ -8,7 +8,7 @@ so prefixing the script call with `KEY=VALUE …` flips a toggle for one run.
 
 | Env var | Default | Effect |
 |---|---|---|
-| `BENCH_SECONDS=N` | unset | Runs for N seconds, prints per-section profile + p1/p5/p99 fps, exits.  Forces vsync off, disables ImGui submit (see `imguiEnabled` flag). |
+| `BENCH_SECONDS=N` | unset | Runs for N seconds, prints submitted-frame profile + p1/p5/p99 fps, exits. Forces uncapped mailbox present by default and disables ImGui submit (see `imguiEnabled` flag). |
 | `GROUP2_BOT_AI=1` | off | Each bot becomes a stochastic agent (random walk, aim sweep, jump, fire).  The "in-game" workload — without it bots stand idle. |
 | `GROUP2_NO_IMGUI=1` | off | Skips ImGui prepare + render-data submission.  Bench mode flips this on automatically.  +19 % median fps in single-run direct comparison. |
 | `GROUP2_CLIENT_CORES="0,1,2,3"` | unset | `pthread_setaffinity_np` on the main render thread to those CPU cores (Linux only).  Stops the kernel migrating us onto cores busy with server / bot threads. |
@@ -68,13 +68,13 @@ GROUP2_BOT_AI=1 BENCH_PRESENT=immediate bash scripts/perf-100bots.sh 100 25
 [bench] median-band  total=Tms phys=… net=… anim=… part=… ent=… ui=… draw=…
 [bench] slowest-1%   total=Tms phys=… net=… anim=… part=… ent=… ui=… draw=…
 [bench] top-5 slowest individual frames:
-[bench]   total=Tms phys=… net=… anim=… … draw=… (acq=… rec=… sub=…)
+[bench]   total=Tms phys=… net=… anim=… … draw=… (acq=… record=… sub=…)
 ```
 
 * `median-band` = average of frames near the 50 %-ile; the typical-frame cost.
 * `slowest-1%` = average of the 1 % slowest frames; what the p1 tail is made of.
 * `acq` = `SDL_AcquireGPUSwapchainTexture` blocking time (swap-queue back-pressure).
-* `rec` = CPU time recording the GPU command buffer.
+* `record` = CPU time recording the GPU command buffer.
 * `sub` = `SDL_SubmitGPUCommandBuffer` blocking time (rare with MAILBOX).
 * If `acq` dominates the slow tail, you're GPU-saturated waiting on a swap image.
 * If `rec` dominates, you're CPU-bound recording.

--- a/src/client/debug/ClientPerfRecorder.cpp
+++ b/src/client/debug/ClientPerfRecorder.cpp
@@ -70,7 +70,10 @@ void writeHeader(std::ofstream& out)
            "refresh_dropped_weapons_ms,refresh_powerups_ms,camera_resolve_ms,camera_ms,local_vfx_ms,"
            "dispatch_ms,particles_ms,audio_ms,interpolation_ms,animation_ms,entity_cmds_ms,viewmodel_ms,"
            "recorder_fps_ms,imgui_ms,hud_ms,pause_menu_ms,imgui_render_ms,draw_frame_ms,draw_acquire_ms,"
-           "draw_record_ms,draw_submit_ms,frame_limiter_ms,"
+           "draw_record_ms,draw_submit_ms,renderer_swapchain_acquire_ms,renderer_depth_ensure_ms,"
+           "renderer_camera_update_ms,renderer_static_batch_rebuild_ms,renderer_skinned_upload_ms,"
+           "renderer_geometry_pass_ms,renderer_weapon_pass_ms,renderer_ui_pass_ms,renderer_imgui_prepare_ms,"
+           "renderer_hud_draw_ms,renderer_imgui_draw_ms,frame_limiter_ms,"
            "physics_ticks,tick_count,snapshot_apply_count,snapshot_applied,reconcile_requested_ticks,"
            "reconcile_replayed_ticks,reconcile_missing_ticks,reconcile_skipped_exact,reconcile_replay_forced,"
            "reconcile_missing_history,client_predict_tick,server_acked_client_tick,reconcile_error_position,"
@@ -84,7 +87,9 @@ void writeHeader(std::ofstream& out)
            "rtt_ms,avg_rtt_ms,recv_kbps,send_kbps,registry_update_kb,"
            "swapchain_width,swapchain_height,renderer_world_instances,renderer_entity_cmds,renderer_entity_draws,"
            "renderer_point_lights,renderer_skinned_instances,renderer_weapon_drawn,renderer_model_draws,"
-           "renderer_mesh_draws,renderer_indexed_draws,renderer_triangles,"
+           "renderer_mesh_draws,renderer_indexed_draws,renderer_triangles,renderer_static_batch_draws,"
+           "renderer_dynamic_draws,renderer_material_binds,renderer_texture_binds,renderer_static_triangles,"
+           "renderer_present_mode,renderer_frame_submitted,renderer_swapchain_skipped,"
            "imgui_draw_lists,imgui_vertices,imgui_indices,"
            "perf_movement_calls,perf_movement_players,perf_collision_calls,perf_collision_players,"
            "perf_kcc_calls,perf_kcc_bump_hits,perf_kcc_ca_iterations,perf_kcc_sweep_hits,"
@@ -112,30 +117,37 @@ void writeFrame(std::ofstream& out, const ClientPerfFrame& f)
         << ',' << f.audioMs << ',' << f.interpolationMs << ',' << f.animationMs << ',' << f.entityCmdsMs << ','
         << f.viewmodelMs << ',' << f.recorderFpsMs << ',' << f.imguiMs << ',' << f.hudMs << ',' << f.pauseMenuMs << ','
         << f.imguiRenderMs << ',' << f.drawFrameMs << ',' << f.drawAcquireMs << ',' << f.drawRecordMs << ','
-        << f.drawSubmitMs << ',' << f.frameLimiterMs << ',' << f.physicsTicks << ',' << f.tickCount << ','
-        << f.snapshotApplyCount << ',' << f.snapshotApplied << ',' << f.reconcileRequestedTicks << ','
-        << f.reconcileReplayedTicks << ',' << f.reconcileMissingTicks << ',' << f.reconcileSkippedExact << ','
-        << f.reconcileReplayForced << ',' << f.reconcileMissingHistory << ',' << f.clientPredictTick << ','
-        << f.serverAckedClientTick << ',' << f.reconcileErrorPosition << ',' << f.reconcileErrorVelocity << ','
-        << f.accumulatorMs << ',' << f.measuredPhysicsHz << ',' << f.fpsCurrent << ',' << f.fps1pLow << ','
-        << f.fps5pLow << ',' << f.playerEntities << ',' << f.localPlayers << ',' << f.renderableEntities << ','
-        << f.projectileEntities << ',' << f.fireFields << ',' << f.animatedCandidates << ',' << f.animatedSampled << ','
-        << f.animatedDrawn << ',' << f.skinnedInstances << ',' << f.boneMatrices << ',' << f.entityRenderCmds << ','
-        << f.pointLights << ',' << f.beamPointLights << ',' << f.impactParticles << ',' << f.tracerParticles << ','
-        << f.ribbonVertices << ',' << f.hitscanBeams << ',' << f.arcVertices << ',' << f.smokeParticles << ','
-        << f.decals << ',' << f.audioSourcesActive << ',' << f.voiceSourcesActive << ',' << f.audioEventsPosted << ','
+        << f.drawSubmitMs << ',' << f.rendererSwapchainAcquireMs << ',' << f.rendererDepthEnsureMs << ','
+        << f.rendererCameraUpdateMs << ',' << f.rendererStaticBatchRebuildMs << ',' << f.rendererSkinnedUploadMs << ','
+        << f.rendererGeometryPassMs << ',' << f.rendererWeaponPassMs << ',' << f.rendererUiPassMs << ','
+        << f.rendererImguiPrepareMs << ',' << f.rendererHudDrawMs << ',' << f.rendererImguiDrawMs << ','
+        << f.frameLimiterMs << ',' << f.physicsTicks << ',' << f.tickCount << ',' << f.snapshotApplyCount << ','
+        << f.snapshotApplied << ',' << f.reconcileRequestedTicks << ',' << f.reconcileReplayedTicks << ','
+        << f.reconcileMissingTicks << ',' << f.reconcileSkippedExact << ',' << f.reconcileReplayForced << ','
+        << f.reconcileMissingHistory << ',' << f.clientPredictTick << ',' << f.serverAckedClientTick << ','
+        << f.reconcileErrorPosition << ',' << f.reconcileErrorVelocity << ',' << f.accumulatorMs << ','
+        << f.measuredPhysicsHz << ',' << f.fpsCurrent << ',' << f.fps1pLow << ',' << f.fps5pLow << ','
+        << f.playerEntities << ',' << f.localPlayers << ',' << f.renderableEntities << ',' << f.projectileEntities
+        << ',' << f.fireFields << ',' << f.animatedCandidates << ',' << f.animatedSampled << ',' << f.animatedDrawn
+        << ',' << f.skinnedInstances << ',' << f.boneMatrices << ',' << f.entityRenderCmds << ',' << f.pointLights
+        << ',' << f.beamPointLights << ',' << f.impactParticles << ',' << f.tracerParticles << ',' << f.ribbonVertices
+        << ',' << f.hitscanBeams << ',' << f.arcVertices << ',' << f.smokeParticles << ',' << f.decals << ','
+        << f.audioSourcesActive << ',' << f.voiceSourcesActive << ',' << f.audioEventsPosted << ','
         << f.audioCommandsGenerated << ',' << f.audioSourcesStarted << ',' << f.audioDroppedByCooldown << ','
         << f.audioDroppedByLimit << ',' << f.audioStolenSources << ',' << f.rttMs << ',' << f.avgRttMs << ','
         << f.recvKBps << ',' << f.sendKBps << ',' << f.registryUpdateKB << ',' << f.swapchainWidth << ','
         << f.swapchainHeight << ',' << f.rendererWorldInstances << ',' << f.rendererEntityCmds << ','
         << f.rendererEntityDraws << ',' << f.rendererPointLights << ',' << f.rendererSkinnedInstances << ','
         << f.rendererWeaponDrawn << ',' << f.rendererModelDraws << ',' << f.rendererMeshDraws << ','
-        << f.rendererIndexedDraws << ',' << f.rendererTriangles << ',' << f.imguiDrawLists << ',' << f.imguiVertices
-        << ',' << f.imguiIndices << ',' << f.perfMovementCalls << ',' << f.perfMovementPlayers << ','
-        << f.perfCollisionCalls << ',' << f.perfCollisionPlayers << ',' << f.perfKccCalls << ',' << f.perfKccBumpHits
-        << ',' << f.perfKccCaIterations << ',' << f.perfKccSweepHits << ',' << f.perfWallDetectCalls << ','
-        << f.perfWallMeshProbes << ',' << f.perfWallMeshProbeMeshes << ',' << f.perfWallSphereFallbacks << ','
-        << f.perfWallAttachmentCalls << ',' << f.perfWallAttachmentMeshes << ',' << f.perfWallDetectSkippedByGate << ','
+        << f.rendererIndexedDraws << ',' << f.rendererTriangles << ',' << f.rendererStaticBatchDraws << ','
+        << f.rendererDynamicDraws << ',' << f.rendererMaterialBinds << ',' << f.rendererTextureBinds << ','
+        << f.rendererStaticTriangles << ',' << f.rendererPresentMode << ',' << f.rendererFrameSubmitted << ','
+        << f.rendererSwapchainSkipped << ',' << f.imguiDrawLists << ',' << f.imguiVertices << ',' << f.imguiIndices
+        << ',' << f.perfMovementCalls << ',' << f.perfMovementPlayers << ',' << f.perfCollisionCalls << ','
+        << f.perfCollisionPlayers << ',' << f.perfKccCalls << ',' << f.perfKccBumpHits << ',' << f.perfKccCaIterations
+        << ',' << f.perfKccSweepHits << ',' << f.perfWallDetectCalls << ',' << f.perfWallMeshProbes << ','
+        << f.perfWallMeshProbeMeshes << ',' << f.perfWallSphereFallbacks << ',' << f.perfWallAttachmentCalls << ','
+        << f.perfWallAttachmentMeshes << ',' << f.perfWallDetectSkippedByGate << ','
         << f.perfWallAttachmentPrevTriangleHits << ',' << f.perfWallAttachmentNeighborHits << ','
         << f.perfWallAttachmentBroadphaseFallbacks << ',' << f.perfStaticBroadphaseQueries << ','
         << f.perfStaticBroadphaseMeshes << ',' << f.perfSweepAabbAllCalls << ',' << f.perfSweepCapsuleAllCalls << ','
@@ -319,6 +331,9 @@ void ClientPerfRecorder::writeSummary() const
         const ClientPerfFrame& f = *slow[i];
         out << "frame=" << f.frameNumber << " wall_ms=" << f.wallFrameMs << " cpu_ms=" << f.cpuFrameMs
             << " max_section_ms=" << maxSection(f) << " draw_ms=" << f.drawFrameMs << " acquire_ms=" << f.drawAcquireMs
+            << " record_ms=" << f.drawRecordMs << " submit_ms=" << f.drawSubmitMs
+            << " swapchain_ms=" << f.rendererSwapchainAcquireMs << " geom_pass_ms=" << f.rendererGeometryPassMs
+            << " weapon_pass_ms=" << f.rendererWeaponPassMs << " ui_pass_ms=" << f.rendererUiPassMs
             << " physics_ms=" << f.physicsMs << " poll_ms=" << f.networkPollMs
             << " snapshot_apply_ms=" << f.snapshotApplyMs << " reconcile_ms=" << f.reconciliationMs
             << " reconcile_ticks=" << f.reconcileReplayedTicks << " reconcile_skip=" << f.reconcileSkippedExact
@@ -326,7 +341,10 @@ void ClientPerfRecorder::writeSummary() const
             << " refresh_players_ms=" << f.refreshPlayersMs << " animation_ms=" << f.animationMs
             << " hud_ms=" << f.hudMs << " imgui_ms=" << f.imguiMs << " limiter_ms=" << f.frameLimiterMs
             << " entity_cmds=" << f.entityRenderCmds << " skinned=" << f.skinnedInstances
-            << " triangles=" << f.rendererTriangles << " kcc=" << f.perfKccCalls
+            << " triangles=" << f.rendererTriangles << " static_batch_draws=" << f.rendererStaticBatchDraws
+            << " dynamic_draws=" << f.rendererDynamicDraws << " submitted=" << f.rendererFrameSubmitted
+            << " swapchain_skip=" << f.rendererSwapchainSkipped << " material_binds=" << f.rendererMaterialBinds
+            << " texture_binds=" << f.rendererTextureBinds << " kcc=" << f.perfKccCalls
             << " sweep_capsule_tris=" << f.perfSweepCapsuleTriMeshTris
             << " closest_point_tris=" << f.perfClosestPointMeshTris << " wall_skip=" << f.perfWallDetectSkippedByGate
             << " wall_prev=" << f.perfWallAttachmentPrevTriangleHits

--- a/src/client/debug/ClientPerfRecorder.hpp
+++ b/src/client/debug/ClientPerfRecorder.hpp
@@ -51,6 +51,17 @@ struct ClientPerfFrame
     float drawAcquireMs = 0.0f;
     float drawRecordMs = 0.0f;
     float drawSubmitMs = 0.0f;
+    float rendererSwapchainAcquireMs = 0.0f;
+    float rendererDepthEnsureMs = 0.0f;
+    float rendererCameraUpdateMs = 0.0f;
+    float rendererStaticBatchRebuildMs = 0.0f;
+    float rendererSkinnedUploadMs = 0.0f;
+    float rendererGeometryPassMs = 0.0f;
+    float rendererWeaponPassMs = 0.0f;
+    float rendererUiPassMs = 0.0f;
+    float rendererImguiPrepareMs = 0.0f;
+    float rendererHudDrawMs = 0.0f;
+    float rendererImguiDrawMs = 0.0f;
     float frameLimiterMs = 0.0f;
 
     std::uint32_t physicsTicks = 0;
@@ -122,6 +133,14 @@ struct ClientPerfFrame
     std::uint32_t rendererMeshDraws = 0;
     std::uint32_t rendererIndexedDraws = 0;
     std::uint32_t rendererTriangles = 0;
+    std::uint32_t rendererStaticBatchDraws = 0;
+    std::uint32_t rendererDynamicDraws = 0;
+    std::uint32_t rendererMaterialBinds = 0;
+    std::uint32_t rendererTextureBinds = 0;
+    std::uint32_t rendererStaticTriangles = 0;
+    std::uint32_t rendererPresentMode = 0;
+    std::uint32_t rendererFrameSubmitted = 0;
+    std::uint32_t rendererSwapchainSkipped = 0;
 
     std::uint32_t imguiDrawLists = 0;
     std::uint32_t imguiVertices = 0;

--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -88,6 +88,25 @@ namespace
 {
 constexpr float kMinFootstepIntervalSeconds = 0.14f;
 
+bool parseBenchPresentMode(const char* value, SDL_GPUPresentMode& outMode)
+{
+    if (value == nullptr || value[0] == '\0')
+        return false;
+    if (std::strcmp(value, "vsync") == 0) {
+        outMode = SDL_GPU_PRESENTMODE_VSYNC;
+        return true;
+    }
+    if (std::strcmp(value, "mailbox") == 0) {
+        outMode = SDL_GPU_PRESENTMODE_MAILBOX;
+        return true;
+    }
+    if (std::strcmp(value, "immediate") == 0) {
+        outMode = SDL_GPU_PRESENTMODE_IMMEDIATE;
+        return true;
+    }
+    return false;
+}
+
 int addAssetDefinition(AssetRegistry& assets, const AssetDefinition& def)
 {
     return assets.add(
@@ -1017,6 +1036,7 @@ bool Game::init(AppContext& ctx)
             benchSeconds_ = seconds;
             benchActive_ = true;
             benchStartTime_ = prevTime;
+            benchLastSubmittedTick_ = 0;
             // Reserve enough room for ~5000 fps × bench duration (worst case),
             // so push_back never reallocates inside the hot path.
             benchFrameTimesMs_.reserve(static_cast<size_t>(seconds * 5000.0f));
@@ -1487,6 +1507,17 @@ void Game::applyFrameRateLimit()
     if (mode && mode->refresh_rate > 0.0f)
         monitorHz = static_cast<int>(std::ceil(mode->refresh_rate));
 
+    if (const char* forcedPresent = SDL_getenv("BENCH_PRESENT"); forcedPresent != nullptr && forcedPresent[0] != '\0') {
+        SDL_GPUPresentMode presentMode = SDL_GPU_PRESENTMODE_MAILBOX;
+        if (parseBenchPresentMode(forcedPresent, presentMode)) {
+            softLimitPeriod = 0;
+            if (renderer)
+                renderer->setPresentMode(presentMode);
+            return;
+        }
+        SDL_Log("[client] ignoring invalid BENCH_PRESENT='%s' (expected vsync, mailbox, or immediate)", forcedPresent);
+    }
+
     if (limitFPSToMonitor && monitorHz >= k_physicsHz) {
         // Monitor is fast enough; rely on the renderer's default present mode.
         softLimitPeriod = 0;
@@ -1620,10 +1651,6 @@ SDL_AppResult Game::iterate()
     // print + quit when the duration is up.
     if (benchActive_) {
         const float benchElapsed = static_cast<float>(k_now - benchStartTime_) / static_cast<float>(k_perfFreq);
-        // Record this frame's wall-clock time once we're past the warmup window.
-        if (benchElapsed >= k_benchWarmupSeconds && frameTime > 0.0f && frameTime < 0.25f)
-            benchFrameTimesMs_.push_back(frameTime * 1000.0f);
-
         if (benchElapsed >= benchSeconds_) {
             const auto countSamples = benchFrameTimesMs_.size();
             if (countSamples == 0) {
@@ -1689,6 +1716,13 @@ SDL_AppResult Game::iterate()
                     medAvg.entityCmdsMs += sortedStats[i].entityCmdsMs;
                     medAvg.imguiMs += sortedStats[i].imguiMs;
                     medAvg.drawFrameMs += sortedStats[i].drawFrameMs;
+                    medAvg.drawAcquireMs += sortedStats[i].drawAcquireMs;
+                    medAvg.drawRecordMs += sortedStats[i].drawRecordMs;
+                    medAvg.drawSubmitMs += sortedStats[i].drawSubmitMs;
+                    medAvg.rendererSwapchainAcquireMs += sortedStats[i].rendererSwapchainAcquireMs;
+                    medAvg.rendererGeometryPassMs += sortedStats[i].rendererGeometryPassMs;
+                    medAvg.rendererWeaponPassMs += sortedStats[i].rendererWeaponPassMs;
+                    medAvg.rendererUiPassMs += sortedStats[i].rendererUiPassMs;
                     ++medCount;
                 }
                 for (size_t i = slowLo; i < n; ++i) {
@@ -1701,6 +1735,13 @@ SDL_AppResult Game::iterate()
                     slowAvg.entityCmdsMs += sortedStats[i].entityCmdsMs;
                     slowAvg.imguiMs += sortedStats[i].imguiMs;
                     slowAvg.drawFrameMs += sortedStats[i].drawFrameMs;
+                    slowAvg.drawAcquireMs += sortedStats[i].drawAcquireMs;
+                    slowAvg.drawRecordMs += sortedStats[i].drawRecordMs;
+                    slowAvg.drawSubmitMs += sortedStats[i].drawSubmitMs;
+                    slowAvg.rendererSwapchainAcquireMs += sortedStats[i].rendererSwapchainAcquireMs;
+                    slowAvg.rendererGeometryPassMs += sortedStats[i].rendererGeometryPassMs;
+                    slowAvg.rendererWeaponPassMs += sortedStats[i].rendererWeaponPassMs;
+                    slowAvg.rendererUiPassMs += sortedStats[i].rendererUiPassMs;
                     ++slowCount;
                 }
                 auto avgRow = [&](ClientPerfFrame& s, size_t c) {
@@ -1715,13 +1756,21 @@ SDL_AppResult Game::iterate()
                     s.entityCmdsMs /= static_cast<float>(c);
                     s.imguiMs /= static_cast<float>(c);
                     s.drawFrameMs /= static_cast<float>(c);
+                    s.drawAcquireMs /= static_cast<float>(c);
+                    s.drawRecordMs /= static_cast<float>(c);
+                    s.drawSubmitMs /= static_cast<float>(c);
+                    s.rendererSwapchainAcquireMs /= static_cast<float>(c);
+                    s.rendererGeometryPassMs /= static_cast<float>(c);
+                    s.rendererWeaponPassMs /= static_cast<float>(c);
+                    s.rendererUiPassMs /= static_cast<float>(c);
                 };
                 avgRow(medAvg, medCount);
                 avgRow(slowAvg, slowCount);
 
                 std::fprintf(stderr,
                              "[bench] median-band  total=%5.2fms phys=%4.2f net=%4.2f anim=%4.2f "
-                             "part=%4.2f ent=%4.2f ui=%4.2f draw=%5.2f\n",
+                             "part=%4.2f ent=%4.2f ui=%4.2f draw=%5.2f "
+                             "(acq=%4.2f record=%4.2f sub=%4.2f swap=%4.2f geom=%4.2f weapon=%4.2f uiPass=%4.2f)\n",
                              static_cast<double>(medAvg.cpuFrameMs),
                              static_cast<double>(medAvg.physicsMs),
                              static_cast<double>(medAvg.networkPollMs),
@@ -1729,10 +1778,18 @@ SDL_AppResult Game::iterate()
                              static_cast<double>(medAvg.particlesMs),
                              static_cast<double>(medAvg.entityCmdsMs),
                              static_cast<double>(medAvg.imguiMs),
-                             static_cast<double>(medAvg.drawFrameMs));
+                             static_cast<double>(medAvg.drawFrameMs),
+                             static_cast<double>(medAvg.drawAcquireMs),
+                             static_cast<double>(medAvg.drawRecordMs),
+                             static_cast<double>(medAvg.drawSubmitMs),
+                             static_cast<double>(medAvg.rendererSwapchainAcquireMs),
+                             static_cast<double>(medAvg.rendererGeometryPassMs),
+                             static_cast<double>(medAvg.rendererWeaponPassMs),
+                             static_cast<double>(medAvg.rendererUiPassMs));
                 std::fprintf(stderr,
                              "[bench] slowest-1%%  total=%5.2fms phys=%4.2f net=%4.2f anim=%4.2f "
-                             "part=%4.2f ent=%4.2f ui=%4.2f draw=%5.2f\n",
+                             "part=%4.2f ent=%4.2f ui=%4.2f draw=%5.2f "
+                             "(acq=%4.2f record=%4.2f sub=%4.2f swap=%4.2f geom=%4.2f weapon=%4.2f uiPass=%4.2f)\n",
                              static_cast<double>(slowAvg.cpuFrameMs),
                              static_cast<double>(slowAvg.physicsMs),
                              static_cast<double>(slowAvg.networkPollMs),
@@ -1740,7 +1797,14 @@ SDL_AppResult Game::iterate()
                              static_cast<double>(slowAvg.particlesMs),
                              static_cast<double>(slowAvg.entityCmdsMs),
                              static_cast<double>(slowAvg.imguiMs),
-                             static_cast<double>(slowAvg.drawFrameMs));
+                             static_cast<double>(slowAvg.drawFrameMs),
+                             static_cast<double>(slowAvg.drawAcquireMs),
+                             static_cast<double>(slowAvg.drawRecordMs),
+                             static_cast<double>(slowAvg.drawSubmitMs),
+                             static_cast<double>(slowAvg.rendererSwapchainAcquireMs),
+                             static_cast<double>(slowAvg.rendererGeometryPassMs),
+                             static_cast<double>(slowAvg.rendererWeaponPassMs),
+                             static_cast<double>(slowAvg.rendererUiPassMs));
 
                 // Top 5 slowest frames, full breakdown — to spot one-off
                 // stalls (e.g. a single drawFrame=120ms in an otherwise
@@ -1751,7 +1815,8 @@ SDL_AppResult Game::iterate()
                     const auto& s = sortedStats[i];
                     std::fprintf(stderr,
                                  "[bench]   total=%5.2fms phys=%4.2f net=%4.2f anim=%4.2f part=%4.2f ent=%4.2f "
-                                 "ui=%4.2f draw=%5.2f (acq=%4.2f rec=%4.2f sub=%4.2f)\n",
+                                 "ui=%4.2f draw=%5.2f "
+                                 "(acq=%4.2f record=%4.2f sub=%4.2f swap=%4.2f geom=%4.2f weapon=%4.2f uiPass=%4.2f)\n",
                                  static_cast<double>(s.cpuFrameMs),
                                  static_cast<double>(s.physicsMs),
                                  static_cast<double>(s.networkPollMs),
@@ -1762,7 +1827,11 @@ SDL_AppResult Game::iterate()
                                  static_cast<double>(s.drawFrameMs),
                                  static_cast<double>(s.drawAcquireMs),
                                  static_cast<double>(s.drawRecordMs),
-                                 static_cast<double>(s.drawSubmitMs));
+                                 static_cast<double>(s.drawSubmitMs),
+                                 static_cast<double>(s.rendererSwapchainAcquireMs),
+                                 static_cast<double>(s.rendererGeometryPassMs),
+                                 static_cast<double>(s.rendererWeaponPassMs),
+                                 static_cast<double>(s.rendererUiPassMs));
                 }
             }
 
@@ -4449,6 +4518,39 @@ SDL_AppResult Game::iterate()
         phaseStats.sendKBps = netStats.sendBytesPerSec / 1024.0f;
         phaseStats.registryUpdateKB = static_cast<float>(netStats.registryUpdateSize) / 1024.0f;
 
+        const RendererFrameStats& rendererStats = renderer->getLastFrameStats();
+        phaseStats.swapchainWidth = rendererStats.swapchainWidth;
+        phaseStats.swapchainHeight = rendererStats.swapchainHeight;
+        phaseStats.rendererWorldInstances = rendererStats.worldInstances;
+        phaseStats.rendererEntityCmds = rendererStats.entityCmds;
+        phaseStats.rendererEntityDraws = rendererStats.entityDraws;
+        phaseStats.rendererPointLights = rendererStats.pointLights;
+        phaseStats.rendererSkinnedInstances = rendererStats.skinnedInstances;
+        phaseStats.rendererWeaponDrawn = rendererStats.weaponDrawn;
+        phaseStats.rendererModelDraws = rendererStats.modelDraws;
+        phaseStats.rendererMeshDraws = rendererStats.meshDraws;
+        phaseStats.rendererIndexedDraws = rendererStats.indexedDraws;
+        phaseStats.rendererTriangles = rendererStats.triangles;
+        phaseStats.rendererStaticBatchDraws = rendererStats.staticBatchDraws;
+        phaseStats.rendererDynamicDraws = rendererStats.dynamicDraws;
+        phaseStats.rendererMaterialBinds = rendererStats.materialBinds;
+        phaseStats.rendererTextureBinds = rendererStats.textureBinds;
+        phaseStats.rendererStaticTriangles = rendererStats.staticTriangles;
+        phaseStats.rendererPresentMode = rendererStats.presentMode;
+        phaseStats.rendererFrameSubmitted = rendererStats.frameSubmitted;
+        phaseStats.rendererSwapchainSkipped = rendererStats.swapchainSkipped;
+        phaseStats.rendererSwapchainAcquireMs = rendererStats.swapchainAcquireMs;
+        phaseStats.rendererDepthEnsureMs = rendererStats.depthEnsureMs;
+        phaseStats.rendererCameraUpdateMs = rendererStats.cameraUpdateMs;
+        phaseStats.rendererStaticBatchRebuildMs = rendererStats.staticBatchRebuildMs;
+        phaseStats.rendererSkinnedUploadMs = rendererStats.skinnedUploadMs;
+        phaseStats.rendererGeometryPassMs = rendererStats.geometryPassMs;
+        phaseStats.rendererWeaponPassMs = rendererStats.weaponPassMs;
+        phaseStats.rendererUiPassMs = rendererStats.uiPassMs;
+        phaseStats.rendererImguiPrepareMs = rendererStats.imguiPrepareMs;
+        phaseStats.rendererHudDrawMs = rendererStats.hudDrawMs;
+        phaseStats.rendererImguiDrawMs = rendererStats.imguiDrawMs;
+
         const physics::perf::FrameStats physicsPerf = physics::perf::snapshot();
         phaseStats.perfMovementCalls = physicsPerf.movementCalls;
         phaseStats.perfMovementPlayers = physicsPerf.movementPlayers;
@@ -4491,16 +4593,28 @@ SDL_AppResult Game::iterate()
         phaseStats.perfClosestPointWallAttachmentTris = physicsPerf.closestPointWallAttachmentTris;
     }
 
+    Uint64 endTick = 0;
     if (collectPerf) {
-        const Uint64 endTick = SDL_GetPerformanceCounter();
+        endTick = SDL_GetPerformanceCounter();
         phaseStats.cpuFrameMs = static_cast<float>(endTick - k_now) * 1000.0f / static_cast<float>(k_perfFreq);
     }
 
     if (benchActive_) {
-        // Only retain frames that match what benchFrameTimesMs_ collects (post-warmup).
+        // Only retain submitted render frames after warmup; swapchain-skipped loop
+        // iterations still go to GROUP2_CLIENT_PERF but should not inflate bench FPS.
         const float benchElapsedNow = static_cast<float>(k_now - benchStartTime_) / static_cast<float>(k_perfFreq);
-        if (benchElapsedNow >= k_benchWarmupSeconds && phaseStats.cpuFrameMs > 0.0f && phaseStats.cpuFrameMs < 250.0f)
+        if (benchElapsedNow >= k_benchWarmupSeconds && phaseStats.rendererFrameSubmitted != 0 && endTick != 0 &&
+            phaseStats.cpuFrameMs > 0.0f && phaseStats.cpuFrameMs < 250.0f)
+        {
+            if (benchLastSubmittedTick_ != 0) {
+                const float submittedFrameMs =
+                    static_cast<float>(endTick - benchLastSubmittedTick_) * 1000.0f / static_cast<float>(k_perfFreq);
+                if (submittedFrameMs > 0.0f && submittedFrameMs < 250.0f)
+                    benchFrameTimesMs_.push_back(submittedFrameMs);
+            }
+            benchLastSubmittedTick_ = endTick;
             benchFrameStats_.push_back(phaseStats);
+        }
     }
 
     if (limitFPSToMonitor != prevLimitFPS)

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -489,6 +489,7 @@ private:
     // stderr, then quits.  Powers `scripts/perf-100bots.sh`.
     float benchSeconds_ = 0.0f;                         ///< Bench duration in seconds (0 = disabled).
     Uint64 benchStartTime_ = 0;                         ///< Perf counter at first iterate() in bench mode.
+    Uint64 benchLastSubmittedTick_ = 0;                 ///< Perf counter for the previous submitted bench frame.
     bool benchActive_ = false;                          ///< True after BENCH_SECONDS read at init.
     static constexpr float k_benchWarmupSeconds = 2.0f; ///< Skip the first N seconds (pipeline warmup).
     std::vector<float> benchFrameTimesMs_;              ///< Per-frame ms after warmup; reservation in init().

--- a/src/client/renderer-new/NewRenderer.cpp
+++ b/src/client/renderer-new/NewRenderer.cpp
@@ -17,6 +17,8 @@
 #include <cstddef>
 #include <filesystem>
 #include <glm/ext/matrix_transform.hpp>
+#include <glm/geometric.hpp>
+#include <glm/gtc/matrix_inverse.hpp>
 #include <glm/trigonometric.hpp>
 #include <imgui.h>
 #include <iostream>
@@ -31,10 +33,69 @@ float ticksToMs(Uint64 elapsed, Uint64 freq)
     return freq == 0 ? 0.0f : (static_cast<float>(elapsed) * 1000.0f) / static_cast<float>(freq);
 }
 
+class ScopedRendererTimer
+{
+public:
+    ScopedRendererTimer(float& outMs, Uint64 freq) : outMs_(outMs), freq_(freq), start_(SDL_GetPerformanceCounter()) {}
+    ~ScopedRendererTimer() { outMs_ += ticksToMs(SDL_GetPerformanceCounter() - start_, freq_); }
+
+private:
+    float& outMs_;
+    Uint64 freq_ = 0;
+    Uint64 start_ = 0;
+};
+
 /// Side-table for per-model emissive overrides set via `setModelEmissive`.
 /// TODO(graphics): consume these inside `drawModel` when building the
 /// material UBO — currently captured but unused.
 std::unordered_map<int32_t, glm::vec4> g_emissiveOverrides;
+
+struct StaticBatchKey
+{
+    MaterialIdInt materialId = 0;
+    TexIdInt textureId = 0;
+    bool useTexture = false;
+
+    bool operator==(const StaticBatchKey& other) const noexcept
+    {
+        return materialId == other.materialId && textureId == other.textureId && useTexture == other.useTexture;
+    }
+};
+
+struct StaticBatchKeyHash
+{
+    std::size_t operator()(const StaticBatchKey& key) const noexcept
+    {
+        std::size_t h = static_cast<std::size_t>(key.materialId);
+        h ^= static_cast<std::size_t>(key.textureId) + 0x9e3779b9u + (h << 6u) + (h >> 2u);
+        h ^= static_cast<std::size_t>(key.useTexture ? 1u : 0u) + 0x9e3779b9u + (h << 6u) + (h >> 2u);
+        return h;
+    }
+};
+
+struct StaticBatchBuildData
+{
+    StaticBatchKey key{};
+    SDL_GPUTexture* texture = nullptr;
+    bool useTexture = false;
+    glm::vec4 materialDiffuse{0.8f, 0.8f, 0.8f, 1.0f};
+    std::vector<Asset::Vertex> vertices;
+    std::vector<uint32_t> indices;
+};
+
+const char* presentModeName(SDL_GPUPresentMode presentMode)
+{
+    switch (presentMode) {
+    case SDL_GPU_PRESENTMODE_VSYNC:
+        return "vsync";
+    case SDL_GPU_PRESENTMODE_IMMEDIATE:
+        return "immediate";
+    case SDL_GPU_PRESENTMODE_MAILBOX:
+        return "mailbox";
+    default:
+        return "unknown";
+    }
+}
 
 float verticalFovDegreesFromHorizontal(float horizontalFovDegrees, float aspect)
 {
@@ -198,6 +259,14 @@ void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
 
     const Uint64 freq = SDL_GetPerformanceFrequency();
     const Uint64 t0 = SDL_GetPerformanceCounter();
+    lastAcquireMs_ = 0.0f;
+    lastRecordMs_ = 0.0f;
+    lastSubmitMs_ = 0.0f;
+    lastFrameStats_ = {};
+    lastFrameStats_.entityCmds = static_cast<Uint32>(entities_.size());
+    lastFrameStats_.pointLights = static_cast<Uint32>(pointLights_.size());
+    lastFrameStats_.skinnedInstances = static_cast<Uint32>(skinnedRenderer_.pendingInstanceCount());
+    lastFrameStats_.presentMode = static_cast<Uint32>(presentMode_);
 
     SDL_GPUCommandBuffer* cmd = SDL_AcquireGPUCommandBuffer(device_);
     if (!cmd) {
@@ -210,29 +279,47 @@ void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
     SDL_GPUTexture* swapchain = nullptr;
     Uint32 width = 0;
     Uint32 height = 0;
-    if (!SDL_AcquireGPUSwapchainTexture(cmd, window_, &swapchain, &width, &height)) {
-        SDL_Log("NewRenderer::drawFrame: SDL_AcquireGPUSwapchainTexture failed: %s", SDL_GetError());
-        SDL_CancelGPUCommandBuffer(cmd);
-        return;
+    {
+        ScopedRendererTimer timer(lastFrameStats_.swapchainAcquireMs, freq);
+        if (!SDL_AcquireGPUSwapchainTexture(cmd, window_, &swapchain, &width, &height)) {
+            SDL_Log("NewRenderer::drawFrame: SDL_AcquireGPUSwapchainTexture failed: %s", SDL_GetError());
+            SDL_CancelGPUCommandBuffer(cmd);
+            return;
+        }
     }
 
     if (!swapchain) {
         // Swapchain not ready (e.g. minimised) — drop the frame silently.
+        lastFrameStats_.swapchainSkipped = 1;
         SDL_CancelGPUCommandBuffer(cmd);
         return;
     }
+    lastFrameStats_.swapchainWidth = width;
+    lastFrameStats_.swapchainHeight = height;
 
-    if (!ensureDepthTextureSize(width, height)) {
-        SDL_Log("NewRenderer::drawFrame: ensureDepthTextureSize failed");
-        SDL_CancelGPUCommandBuffer(cmd);
-        return;
+    {
+        ScopedRendererTimer timer(lastFrameStats_.depthEnsureMs, freq);
+        if (!ensureDepthTextureSize(width, height)) {
+            SDL_Log("NewRenderer::drawFrame: ensureDepthTextureSize failed");
+            SDL_CancelGPUCommandBuffer(cmd);
+            return;
+        }
     }
 
-    setMainCamera(eye, yaw, pitch, roll, width, height);
+    {
+        ScopedRendererTimer timer(lastFrameStats_.cameraUpdateMs, freq);
+        setMainCamera(eye, yaw, pitch, roll, width, height);
+    }
+
+    if (staticBatchesDirty_) {
+        ScopedRendererTimer timer(lastFrameStats_.staticBatchRebuildMs, freq);
+        rebuildStaticBatches(cmd);
+    }
 
     // Per-frame uploads (skinning palette/instances, etc.) happen BEFORE
     // the first render pass so the copy is sequenced ahead of the draws.
-    {
+    if (skinnedRenderer_.pendingInstanceCount() > 0) {
+        ScopedRendererTimer timer(lastFrameStats_.skinnedUploadMs, freq);
         SDL_GPUCopyPass* copyPass = SDL_BeginGPUCopyPass(cmd);
         if (copyPass) {
             skinnedRenderer_.uploadFrame(cmd, copyPass);
@@ -240,14 +327,24 @@ void NewRenderer::drawFrame(glm::vec3 eye, float yaw, float pitch, float roll)
         }
     }
 
-    drawGeometryPass(swapchain, cmd);
-    drawWeaponPass(swapchain, cmd);
-    drawUIPass(swapchain, cmd);
+    {
+        ScopedRendererTimer timer(lastFrameStats_.geometryPassMs, freq);
+        drawGeometryPass(swapchain, cmd);
+    }
+    {
+        ScopedRendererTimer timer(lastFrameStats_.weaponPassMs, freq);
+        drawWeaponPass(swapchain, cmd);
+    }
+    {
+        ScopedRendererTimer timer(lastFrameStats_.uiPassMs, freq);
+        drawUIPass(swapchain, cmd);
+    }
 
     const Uint64 t2 = SDL_GetPerformanceCounter();
     lastRecordMs_ = ticksToMs(t2 - t1, freq);
 
     SDL_SubmitGPUCommandBuffer(cmd);
+    lastFrameStats_.frameSubmitted = 1;
 
     const Uint64 t3 = SDL_GetPerformanceCounter();
     lastSubmitMs_ = ticksToMs(t3 - t2, freq);
@@ -279,7 +376,8 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
     drawWorldModelInstances(geometryPass, cmd);
     drawEntityModels(geometryPass, cmd);
 
-    drawSkinnedModels(geometryPass, cmd);
+    if (skinnedRenderer_.pendingInstanceCount() > 0)
+        drawSkinnedModels(geometryPass, cmd);
 
     // drawWeapon(geometryPass, cmd);
 
@@ -288,6 +386,11 @@ void NewRenderer::drawGeometryPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuff
 
 void NewRenderer::drawWeaponPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd)
 {
+    if (!weapon_.visible)
+        return;
+    if (weapon_.modelIndex < 0 || static_cast<size_t>(weapon_.modelIndex) >= Asset::modelInstances_.size())
+        return;
+
     SDL_GPUColorTargetInfo colorTarget = Boilerplate::makeColorTargetLoad(swapchain);
 
     SDL_GPUDepthStencilTargetInfo depthInfo = depthTarget_; // copy
@@ -320,6 +423,7 @@ void NewRenderer::drawWeapon(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer
         return;
     }
 
+    lastFrameStats_.weaponDrawn = 1;
     drawModel(weaponModelId, weapon_.transform, renderPass, cmd);
 }
 
@@ -330,10 +434,55 @@ void NewRenderer::drawSkinnedModels(SDL_GPURenderPass* renderPass, SDL_GPUComman
 
 void NewRenderer::drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
 {
+    if (!staticBatches_.empty()) {
+        lastFrameStats_.worldInstances = staticBatchWorldInstances_;
+        drawStaticBatches(renderPass, cmd);
+        return;
+    }
+
     for (const auto& mInstance : Asset::modelInstances_) {
         if (!mInstance.drawInScenePass)
             continue;
-        drawModel(mInstance.modelId_, mInstance.transform_, renderPass, cmd);
+        ++lastFrameStats_.worldInstances;
+        drawModel(mInstance.modelId_, mInstance.transform_, renderPass, cmd, false);
+    }
+}
+
+void NewRenderer::drawStaticBatches(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd)
+{
+    const glm::mat4 identity{1.0f};
+    SDL_PushGPUVertexUniformData(cmd, 1, &identity, sizeof(glm::mat4));
+
+    for (const StaticBatch& batch : staticBatches_) {
+        if (batch.vertexBuffer == nullptr || batch.indexBuffer == nullptr || batch.indexCount == 0)
+            continue;
+
+        SDL_GPUTexture* texture = batch.texture != nullptr ? batch.texture : texture_;
+        SDL_GPUTextureSamplerBinding textureBinding = Boilerplate::makeTextureSamplerBinding(texture, sampler_);
+        SDL_BindGPUFragmentSamplers(renderPass, 0, &textureBinding, 1);
+        ++lastFrameStats_.textureBinds;
+
+        const Uint32 useTextureUniform = batch.useTexture ? 1u : 0u;
+        SDL_PushGPUFragmentUniformData(cmd, 0, &batch.materialDiffuse, sizeof(batch.materialDiffuse));
+        SDL_PushGPUFragmentUniformData(cmd, 1, &useTextureUniform, sizeof(useTextureUniform));
+        ++lastFrameStats_.materialBinds;
+
+        SDL_GPUBufferBinding vertexBufferBinding{};
+        vertexBufferBinding.buffer = batch.vertexBuffer;
+        vertexBufferBinding.offset = 0;
+        SDL_BindGPUVertexBuffers(renderPass, 0, &vertexBufferBinding, 1);
+
+        SDL_GPUBufferBinding indexBufferBinding{};
+        indexBufferBinding.buffer = batch.indexBuffer;
+        indexBufferBinding.offset = 0;
+        SDL_BindGPUIndexBuffer(renderPass, &indexBufferBinding, SDL_GPU_INDEXELEMENTSIZE_32BIT);
+
+        SDL_DrawGPUIndexedPrimitives(renderPass, batch.indexCount, 1, 0, 0, 0);
+        ++lastFrameStats_.staticBatchDraws;
+        ++lastFrameStats_.meshDraws;
+        ++lastFrameStats_.indexedDraws;
+        lastFrameStats_.triangles += batch.triangleCount;
+        lastFrameStats_.staticTriangles += batch.triangleCount;
     }
 }
 
@@ -349,6 +498,7 @@ void NewRenderer::drawEntityModels(SDL_GPURenderPass* renderPass, SDL_GPUCommand
         ModelIdInt modelId = Asset::modelInstances_.at(static_cast<size_t>(entityCmd.modelIndex)).modelId_;
         // TODO(graphics): pass entityCmd.tint into the per-mesh material UBO
         // so tinted entities (e.g. team colors, hit flashes) render correctly.
+        ++lastFrameStats_.entityDraws;
         drawModel(modelId, entityCmd.worldTransform, renderPass, cmd);
     }
 }
@@ -356,9 +506,11 @@ void NewRenderer::drawEntityModels(SDL_GPURenderPass* renderPass, SDL_GPUCommand
 void NewRenderer::drawModel(ModelIdInt modelId,
                             const glm::mat4& modelTransform,
                             SDL_GPURenderPass* renderPass,
-                            SDL_GPUCommandBuffer* cmd)
+                            SDL_GPUCommandBuffer* cmd,
+                            bool countDynamicDraws)
 {
     Asset::Model& model = Asset::models_.at(modelId);
+    ++lastFrameStats_.modelDraws;
     for (auto& element : model.modelElements_) {
         const Asset::Material* material = nullptr;
         if (Asset::materials_.contains(element.materialId_))
@@ -377,6 +529,7 @@ void NewRenderer::drawModel(ModelIdInt modelId,
 
         SDL_GPUTextureSamplerBinding textureBinding = Boilerplate::makeTextureSamplerBinding(texture, sampler_);
         SDL_BindGPUFragmentSamplers(renderPass, 0, &textureBinding, 1);
+        ++lastFrameStats_.textureBinds;
 
         glm::vec4 materialDiffuse{0.8f, 0.8f, 0.8f, 1.0f};
         if (material != nullptr)
@@ -384,16 +537,19 @@ void NewRenderer::drawModel(ModelIdInt modelId,
         Uint32 useTextureUniform = useTexture ? 1u : 0u;
         SDL_PushGPUFragmentUniformData(cmd, 0, &materialDiffuse, sizeof(materialDiffuse));
         SDL_PushGPUFragmentUniformData(cmd, 1, &useTextureUniform, sizeof(useTextureUniform));
+        ++lastFrameStats_.materialBinds;
 
         glm::mat4 modelElementMatrix = modelTransform * element.cachedTransform_;
         SDL_PushGPUVertexUniformData(cmd, 1, &modelElementMatrix, sizeof(glm::mat4));
 
         Asset::Mesh& mesh = Asset::meshes_.at(element.meshId_);
         drawMesh(renderPass, mesh);
+        if (countDynamicDraws)
+            ++lastFrameStats_.dynamicDraws;
     }
 }
 
-void NewRenderer::drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh) const
+void NewRenderer::drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh)
 {
     SDL_GPUBufferBinding vertexBufferBinding{};
     vertexBufferBinding.buffer = mesh.vBufferInfo_.gpuBuff;
@@ -407,6 +563,150 @@ void NewRenderer::drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mes
 
     const Uint32 indexCount = static_cast<Uint32>(mesh.iBufferInfo_.bufferSize / sizeof(Uint32));
     SDL_DrawGPUIndexedPrimitives(renderPass, indexCount, 1, 0, 0, 0);
+    ++lastFrameStats_.meshDraws;
+    ++lastFrameStats_.indexedDraws;
+    lastFrameStats_.triangles += indexCount / 3;
+}
+
+void NewRenderer::releaseStaticBatches()
+{
+    if (device_ == nullptr) {
+        staticBatches_.clear();
+        staticBatchWorldInstances_ = 0;
+        staticBatchTriangles_ = 0;
+        return;
+    }
+
+    for (StaticBatch& batch : staticBatches_) {
+        if (batch.vertexBuffer != nullptr)
+            SDL_ReleaseGPUBuffer(device_, batch.vertexBuffer);
+        if (batch.indexBuffer != nullptr)
+            SDL_ReleaseGPUBuffer(device_, batch.indexBuffer);
+    }
+    staticBatches_.clear();
+    staticBatchWorldInstances_ = 0;
+    staticBatchTriangles_ = 0;
+}
+
+void NewRenderer::rebuildStaticBatches(SDL_GPUCommandBuffer* cmd)
+{
+    staticBatchesDirty_ = false;
+    releaseStaticBatches();
+    if (device_ == nullptr || cmd == nullptr)
+        return;
+
+    std::vector<StaticBatchBuildData> buildBatches;
+    std::unordered_map<StaticBatchKey, std::size_t, StaticBatchKeyHash> batchByKey;
+
+    for (const Asset::ModelInstance& instance : Asset::modelInstances_) {
+        if (!instance.drawInScenePass)
+            continue;
+
+        const auto modelIt = Asset::models_.find(instance.modelId_);
+        if (modelIt == Asset::models_.end())
+            continue;
+
+        ++staticBatchWorldInstances_;
+        const Asset::Model& model = modelIt->second;
+        for (const Asset::ModelElement& element : model.modelElements_) {
+            const auto meshIt = Asset::meshes_.find(element.meshId_);
+            if (meshIt == Asset::meshes_.end())
+                continue;
+
+            const Asset::Material* material = nullptr;
+            if (const auto materialIt = Asset::materials_.find(element.materialId_);
+                materialIt != Asset::materials_.end())
+                material = &materialIt->second;
+
+            TexIdInt textureId = 0;
+            SDL_GPUTexture* texture = nullptr;
+            if (material != nullptr) {
+                const TexIdInt candidateTexId = material->texId_[0];
+                const auto textureIt = Asset::textures_.find(candidateTexId);
+                if (textureIt != Asset::textures_.end() && textureIt->second.tex != nullptr) {
+                    textureId = candidateTexId;
+                    texture = textureIt->second.tex;
+                }
+            }
+
+            const bool useTexture = texture != nullptr || material == nullptr || !material->hasPhongData_;
+            const StaticBatchKey key{
+                .materialId = element.materialId_,
+                .textureId = textureId,
+                .useTexture = useTexture,
+            };
+
+            std::size_t batchIndex = 0;
+            const auto batchIt = batchByKey.find(key);
+            if (batchIt == batchByKey.end()) {
+                StaticBatchBuildData build{};
+                build.key = key;
+                build.texture = texture;
+                build.useTexture = useTexture;
+                if (material != nullptr)
+                    build.materialDiffuse = glm::vec4(material->kDiffuse_, 1.0f);
+                batchIndex = buildBatches.size();
+                batchByKey.emplace(key, batchIndex);
+                buildBatches.push_back(std::move(build));
+            } else {
+                batchIndex = batchIt->second;
+            }
+
+            StaticBatchBuildData& batch = buildBatches[batchIndex];
+            const Asset::Mesh& mesh = meshIt->second;
+            const uint32_t baseVertex = static_cast<uint32_t>(batch.vertices.size());
+            const glm::mat4 elementTransform = instance.transform_ * element.cachedTransform_;
+            const glm::mat3 normalMatrix = glm::transpose(glm::inverse(glm::mat3(elementTransform)));
+
+            batch.vertices.reserve(batch.vertices.size() + mesh.vertexData_.size());
+            for (const Asset::Vertex& vertex : mesh.vertexData_) {
+                Asset::Vertex baked = vertex;
+                baked.position = glm::vec3(elementTransform * glm::vec4(vertex.position, 1.0f));
+                const glm::vec3 transformedNormal = normalMatrix * vertex.normal;
+                if (glm::dot(transformedNormal, transformedNormal) > 1e-10f)
+                    baked.normal = glm::normalize(transformedNormal);
+                batch.vertices.push_back(baked);
+            }
+
+            batch.indices.reserve(batch.indices.size() + mesh.indexData_.size());
+            for (uint32_t index : mesh.indexData_)
+                batch.indices.push_back(baseVertex + index);
+        }
+    }
+
+    std::vector<Boilerplate::BufferUpload> uploads;
+    staticBatches_.reserve(buildBatches.size());
+    for (const StaticBatchBuildData& build : buildBatches) {
+        if (build.vertices.empty() || build.indices.empty())
+            continue;
+
+        const size_t vertexBytes = build.vertices.size() * sizeof(Asset::Vertex);
+        const size_t indexBytes = build.indices.size() * sizeof(uint32_t);
+
+        StaticBatch batch{};
+        batch.vertexBuffer = Boilerplate::createBuffer(device_, vertexBytes, SDL_GPU_BUFFERUSAGE_VERTEX);
+        batch.indexBuffer = Boilerplate::createBuffer(device_, indexBytes, SDL_GPU_BUFFERUSAGE_INDEX);
+        if (batch.vertexBuffer == nullptr || batch.indexBuffer == nullptr) {
+            if (batch.vertexBuffer != nullptr)
+                SDL_ReleaseGPUBuffer(device_, batch.vertexBuffer);
+            if (batch.indexBuffer != nullptr)
+                SDL_ReleaseGPUBuffer(device_, batch.indexBuffer);
+            continue;
+        }
+
+        batch.texture = build.texture;
+        batch.useTexture = build.useTexture;
+        batch.materialDiffuse = build.materialDiffuse;
+        batch.indexCount = static_cast<Uint32>(build.indices.size());
+        batch.triangleCount = static_cast<Uint32>(build.indices.size() / 3u);
+        staticBatchTriangles_ += batch.triangleCount;
+
+        uploads.push_back({batch.vertexBuffer, build.vertices.data(), static_cast<Uint32>(vertexBytes)});
+        uploads.push_back({batch.indexBuffer, build.indices.data(), static_cast<Uint32>(indexBytes)});
+        staticBatches_.push_back(batch);
+    }
+
+    Boilerplate::uploadBuffers(device_, cmd, uploads);
 }
 
 bool NewRenderer::ensureDepthTextureSize(Uint32 width, Uint32 height)
@@ -431,20 +731,32 @@ bool NewRenderer::ensureDepthTextureSize(Uint32 width, Uint32 height)
 
 void NewRenderer::drawUIPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd)
 {
-    ImDrawData* drawData = ImGui::GetDrawData();
-    if (drawData)
+    ImDrawData* drawData = imguiEnabled ? ImGui::GetDrawData() : nullptr;
+    const bool drawImgui = drawData != nullptr && drawData->CmdListsCount > 0;
+    const bool drawHudTexture = hudTexture_ != nullptr;
+    if (!drawHudTexture && !drawImgui)
+        return;
+
+    const Uint64 freq = SDL_GetPerformanceFrequency();
+    if (drawImgui) {
+        ScopedRendererTimer timer(lastFrameStats_.imguiPrepareMs, freq);
         ImGui_ImplSDLGPU3_PrepareDrawData(drawData, cmd);
+    }
 
     SDL_GPUColorTargetInfo uiColorTarget = Boilerplate::makeColorTargetLoad(swapchain);
 
     SDL_GPURenderPass* uiPass = SDL_BeginGPURenderPass(cmd, &uiColorTarget, 1, nullptr);
-    SDL_BindGPUGraphicsPipeline(uiPass, hudPipeline_);
 
-    if (hudTexture_ != nullptr)
+    if (drawHudTexture) {
+        ScopedRendererTimer timer(lastFrameStats_.hudDrawMs, freq);
+        SDL_BindGPUGraphicsPipeline(uiPass, hudPipeline_);
         drawHud(uiPass);
+    }
 
-    if (drawData && imguiEnabled)
+    if (drawImgui) {
+        ScopedRendererTimer timer(lastFrameStats_.imguiDrawMs, freq);
         ImGui_ImplSDLGPU3_RenderDrawData(drawData, cmd, uiPass);
+    }
 
     SDL_EndGPURenderPass(uiPass);
 }
@@ -466,6 +778,8 @@ void NewRenderer::quit()
 {
     if (device_) {
         SDL_WaitForGPUIdle(device_);
+
+        releaseStaticBatches();
 
         if (depthTarget_.texture)
             SDL_ReleaseGPUTexture(device_, depthTarget_.texture);
@@ -584,6 +898,7 @@ int NewRenderer::loadSceneModel(
     SDL_SubmitGPUCommandBuffer(cmd);
     SDL_WaitForGPUIdle(device_);
 
+    staticBatchesDirty_ = true;
     return static_cast<int>(Asset::modelInstances_.size() - 1);
 }
 
@@ -626,6 +941,7 @@ void NewRenderer::setModelScenePass(int32_t modelIndex, bool drawInScene)
     if (modelIndex < 0 || static_cast<size_t>(modelIndex) >= Asset::modelInstances_.size())
         return;
     Asset::modelInstances_.at(static_cast<size_t>(modelIndex)).drawInScenePass = drawInScene;
+    staticBatchesDirty_ = true;
 }
 
 void NewRenderer::setParticleSystem(ParticleSystem* ps)
@@ -638,14 +954,35 @@ void NewRenderer::setParticleSystem(ParticleSystem* ps)
     particleSystem_ = ps;
 }
 
+bool NewRenderer::setPresentMode(SDL_GPUPresentMode presentMode)
+{
+    if (!device_ || !window_)
+        return false;
+
+    if (!SDL_WindowSupportsGPUPresentMode(device_, window_, presentMode)) {
+        SDL_Log("NewRenderer: requested present mode is unsupported (%d)", static_cast<int>(presentMode));
+        return false;
+    }
+
+    if (!SDL_SetGPUSwapchainParameters(device_, window_, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, presentMode)) {
+        SDL_Log("NewRenderer: SDL_SetGPUSwapchainParameters failed: %s", SDL_GetError());
+        return false;
+    }
+
+    vsyncEnabled_ = presentMode == SDL_GPU_PRESENTMODE_VSYNC;
+    presentMode_ = presentMode;
+    SDL_Log("NewRenderer: present mode = %s", presentModeName(presentMode));
+    return true;
+}
+
 bool NewRenderer::setVSync(bool enabled)
 {
-    // TODO(graphics): apply via SDL_SetGPUSwapchainParameters with
-    //   SDL_GPU_PRESENTMODE_VSYNC (or MAILBOX) when enabled, and
-    //   SDL_GPU_PRESENTMODE_IMMEDIATE when disabled.  Check the format
-    //   you currently use for the swapchain so you preserve it.
-    vsyncEnabled_ = enabled;
-    return true;
+    if (enabled)
+        return setPresentMode(SDL_GPU_PRESENTMODE_VSYNC);
+
+    if (device_ && window_ && SDL_WindowSupportsGPUPresentMode(device_, window_, SDL_GPU_PRESENTMODE_MAILBOX))
+        return setPresentMode(SDL_GPU_PRESENTMODE_MAILBOX);
+    return setPresentMode(SDL_GPU_PRESENTMODE_IMMEDIATE);
 }
 
 void NewRenderer::requestScreenshot(const std::string& path)

--- a/src/client/renderer-new/NewRenderer.hpp
+++ b/src/client/renderer-new/NewRenderer.hpp
@@ -124,6 +124,9 @@ public:
     /// @brief Most-recent `SDL_SubmitGPUCommandBuffer` cost in milliseconds.
     [[nodiscard]] float getLastSubmitMs() const { return lastSubmitMs_; }
 
+    /// @brief Most-recent renderer workload counters for perf analysis.
+    [[nodiscard]] const RendererFrameStats& getLastFrameStats() const { return lastFrameStats_; }
+
     // ─── Per-frame submit setters (data-capture stubs) ───────────────────────
     //
     // Called by Game.cpp every frame BEFORE drawFrame.  Each stores the
@@ -265,6 +268,7 @@ public:
     ///
     /// DATA SOURCE: Game.cpp toggles this when entering/leaving menus or via
     /// debug UI.
+    bool setPresentMode(SDL_GPUPresentMode presentMode);
     bool setVSync(bool enabled);
 
     /// @brief Request a screenshot to be saved to disk after the next frame.
@@ -342,15 +346,19 @@ private:
     void drawUIPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd);
     void drawWeaponPass(SDL_GPUTexture* swapchain, SDL_GPUCommandBuffer* cmd);
     void drawWorldModelInstances(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
+    void drawStaticBatches(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
     void drawWeapon(SDL_GPURenderPass* geometryPass, SDL_GPUCommandBuffer* cmd);
     void drawSkinnedModels(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
     void drawModel(ModelIdInt modelId,
                    const glm::mat4& modelTransform,
                    SDL_GPURenderPass* renderPass,
-                   SDL_GPUCommandBuffer* cmd);
+                   SDL_GPUCommandBuffer* cmd,
+                   bool countDynamicDraws = true);
     void drawEntityModels(SDL_GPURenderPass* renderPass, SDL_GPUCommandBuffer* cmd);
-    void drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh) const;
+    void drawMesh(SDL_GPURenderPass* renderPass, const Asset::Mesh& mesh);
     void drawHud(SDL_GPURenderPass* pass);
+    void rebuildStaticBatches(SDL_GPUCommandBuffer* cmd);
+    void releaseStaticBatches();
 
     // ─── Member state ────────────────────────────────────────────────────────
 
@@ -384,13 +392,31 @@ private:
 
     // Settings captured state ─────────────────────────────────────────────────
     bool vsyncEnabled_ = true;
+    SDL_GPUPresentMode presentMode_ = SDL_GPU_PRESENTMODE_VSYNC;
     std::string pendingScreenshotPath_;
 
     // Skinned-character subsystem (see SkinnedRenderer.hpp) ──────────────────
     SkinnedRenderer skinnedRenderer_;
 
+    struct StaticBatch
+    {
+        SDL_GPUBuffer* vertexBuffer = nullptr;
+        SDL_GPUBuffer* indexBuffer = nullptr;
+        SDL_GPUTexture* texture = nullptr;
+        bool useTexture = false;
+        glm::vec4 materialDiffuse{0.8f, 0.8f, 0.8f, 1.0f};
+        Uint32 indexCount = 0;
+        Uint32 triangleCount = 0;
+    };
+
+    std::vector<StaticBatch> staticBatches_;
+    bool staticBatchesDirty_ = true;
+    Uint32 staticBatchWorldInstances_ = 0;
+    Uint32 staticBatchTriangles_ = 0;
+
     // Telemetry counters (filled by drawFrame) ────────────────────────────────
     float lastAcquireMs_ = 0.0f;
     float lastRecordMs_ = 0.0f;
     float lastSubmitMs_ = 0.0f;
+    RendererFrameStats lastFrameStats_{};
 };

--- a/src/client/renderer-new/RendererTypes.hpp
+++ b/src/client/renderer-new/RendererTypes.hpp
@@ -93,6 +93,43 @@ struct WeaponViewmodel
     bool visible = false;      ///< False = skip drawing this frame (e.g. weapon hidden).
 };
 
+/// @brief Renderer workload counters captured for the client perf recorder.
+struct RendererFrameStats
+{
+    uint32_t swapchainWidth = 0;
+    uint32_t swapchainHeight = 0;
+    uint32_t worldInstances = 0;
+    uint32_t entityCmds = 0;
+    uint32_t entityDraws = 0;
+    uint32_t pointLights = 0;
+    uint32_t skinnedInstances = 0;
+    uint32_t weaponDrawn = 0;
+    uint32_t modelDraws = 0;
+    uint32_t meshDraws = 0;
+    uint32_t indexedDraws = 0;
+    uint32_t triangles = 0;
+    uint32_t staticBatchDraws = 0;
+    uint32_t dynamicDraws = 0;
+    uint32_t materialBinds = 0;
+    uint32_t textureBinds = 0;
+    uint32_t staticTriangles = 0;
+    uint32_t presentMode = 0;
+    uint32_t frameSubmitted = 0;
+    uint32_t swapchainSkipped = 0;
+
+    float swapchainAcquireMs = 0.0f;
+    float depthEnsureMs = 0.0f;
+    float cameraUpdateMs = 0.0f;
+    float staticBatchRebuildMs = 0.0f;
+    float skinnedUploadMs = 0.0f;
+    float geometryPassMs = 0.0f;
+    float weaponPassMs = 0.0f;
+    float uiPassMs = 0.0f;
+    float imguiPrepareMs = 0.0f;
+    float hudDrawMs = 0.0f;
+    float imguiDrawMs = 0.0f;
+};
+
 // ─── Skinned-character types (NEW) ───────────────────────────────────────────
 //
 // These three types form the interface between the animation system and the


### PR DESCRIPTION
## Summary\n- Adds static-world batching for the new renderer\n- Adds renderer subphase perf metrics and analyzer output\n- Prefers mailbox present for uncapped/bench rendering, with BENCH_PRESENT override for diagnostics\n- Skips empty renderer work such as hidden weapon pass, empty UI pass, and zero skinned upload/draw paths\n\n## Split\nThis is stacked on #154 so the diff shows only the renderer/new-renderer layer. Merge #154 first, then this PR after graphics review.\n\n## Verification\n- git diff --check\n- cmake --build build/relwithdebinfo --target group2 -j 8\n- cmake --build build/relwithdebinfo --target server clientbot -j 8\n- ./build/relwithdebinfo/physics_trimesh_tests\n- cmake --build build/relwithdebinfo --target ragdoll_system_tests -j 8\n- ./build/relwithdebinfo/ragdoll_system_tests