### PR TITLE
add reload delay/animation

### DIFF
--- a/src/client/game/Game.cpp
+++ b/src/client/game/Game.cpp
@@ -51,8 +51,8 @@
 #include "ecs/systems/AbilitySystem.hpp"
 #include "ecs/systems/HitboxSystem.hpp"
 #include "ecs/systems/PickupGeometry.hpp"
-#include "hud/debug/HudDebugPanel.hpp"
 #include "hud/VoidfallStyle.hpp"
+#include "hud/debug/HudDebugPanel.hpp"
 #include "network/EntityInterpolation.hpp"
 #include "network/ShotEvent.hpp"
 #include "particles/ParticleEvents.hpp"
@@ -2161,7 +2161,7 @@ SDL_AppResult Game::iterate()
             bool hasAmmo = false;
             registry.view<LocalPlayer, WeaponState>().each([&](const WeaponState& ws) {
                 const GunInstance& gun = getEquippedGun(ws);
-                hasAmmo = gun.currentMagAmmo > 0 || gun.totalAmmo > 0;
+                hasAmmo = gun.currentMagAmmo > 0 && !gun.isReloading;
             });
 
             if (wpnCfg.isCharge) {
@@ -3487,6 +3487,34 @@ SDL_AppResult Game::iterate()
                     recoilRoll_ = 0.0f;
             }
 
+            // --- Reload animation ---
+            {
+                auto smooth = [](float e0, float e1, float x) {
+                    float t = std::clamp((x - e0) / (e1 - e0), 0.0f, 1.0f);
+                    return t * t * (3.0f - 2.0f * t);
+                };
+
+                float reloadOffset = 0.0f;
+                registry.view<LocalPlayer, WeaponState>().each([&](const WeaponState& ws) {
+                    const GunInstance& gun = getEquippedGun(ws);
+                    const WeaponConfig& cfg = getWeaponConfig(gun.type);
+                    if (gun.isReloading && cfg.reloadTime > 0.0f) {
+                        float t = 1.0f - (gun.reloadTime / cfg.reloadTime);
+                        constexpr float kReloadMaxDrop = 70.0f;
+                        constexpr float kReloadMovePercent = 0.15f;
+                        if (t < kReloadMovePercent) {
+                            reloadOffset = kReloadMaxDrop * smooth(0.0f, kReloadMovePercent, t);
+                        } else if (t < 1.0f - kReloadMovePercent) {
+                            reloadOffset = kReloadMaxDrop;
+                        } else {
+                            reloadOffset = kReloadMaxDrop * (1.0f - smooth(1.0f - kReloadMovePercent, 1.0f, t));
+                        }
+                    }
+                });
+
+                reloadDownwardOffset_ = reloadOffset;
+            }
+
             // --- Velocity-direction-dependent bobbing ---
             float bobPhase = 0.0f;
             float bobAmpFwd = 0.0f;
@@ -3530,6 +3558,8 @@ SDL_AppResult Game::iterate()
             weaponPos += right * bobX + up * bobY;
             // Apply recoil pushback
             weaponPos -= forward * recoilPushBack_;
+            // Apply reload downward offset
+            weaponPos -= up * reloadDownwardOffset_;
 
             // Build world transform: translate -> local-rotate -> camera-orient -> scale.
             //
@@ -4062,6 +4092,11 @@ SDL_AppResult Game::iterate()
             // so the "47/30" rifle bug (HUD hardcoded /30 vs. real /50) is
             // gone — the HUD reads exactly what gameplay says.
             hudState.magCapacity = getWeaponConfig(gun.type).magazineSize;
+            hudState.isReloading = gun.isReloading;
+            const WeaponConfig& config = getWeaponConfig(gun.type);
+            if (gun.isReloading && config.reloadTime > 0.f) {
+                hudState.reloadProgress = 1.0f - (gun.reloadTime / config.reloadTime);
+            }
         });
 
         // ── Round timer / buy phase ──

--- a/src/client/game/Game.hpp
+++ b/src/client/game/Game.hpp
@@ -453,6 +453,9 @@ private:
     float recoilPushBack_ = 0.0f; ///< Current recoil backward offset (Quake units).
     float recoilRoll_ = 0.0f;     ///< Current recoil roll offset (degrees).
 
+    // Visual reload state
+    float reloadDownwardOffset_ = 0.0f; ///< Downward offset for the reload animation
+
     // Local weapon fire cooldown (mirrors server's per-weapon cooldown for VFX)
     float localFireCooldown_ = 0.0f; ///< Countdown timer; fire VFX only when <= 0.
 

--- a/src/client/hud/HudTypes.hpp
+++ b/src/client/hud/HudTypes.hpp
@@ -77,11 +77,14 @@ struct HudVertex
 /// @brief Crosshair appearance parameters.
 struct CrosshairStyle
 {
-    float gap = 3.f;                      ///< Gap from center to start of each line (pixels).
-    float length = 6.f;                   ///< Length of each crosshair arm (pixels).
-    float thickness = 2.f;                ///< Line thickness (pixels).
-    HudColor color{0.168627f, 0.694118f, 0.741176f, 0.85f}; ///< Default primary palette color.
-    bool dot = true;                      ///< Draw center dot.
+    float gap = 3.f;                                              ///< Gap from center to start of each line (pixels).
+    float length = 6.f;                                           ///< Length of each crosshair arm (pixels).
+    float thickness = 2.f;                                        ///< Line thickness (pixels).
+    HudColor color{0.168627f, 0.694118f, 0.741176f, 0.85f};       ///< Default primary palette color.
+    bool dot = true;                                              ///< Draw center dot.
+    float reloadRadius = 20.f;                                    ///< Radius of circular reload indicator (pixels).
+    float reloadThickness = 2.f;                                  ///< Thickness of reload indicator (pixels).
+    HudColor reloadColor{0.168627f, 0.694118f, 0.741176f, 0.85f}; ///< Color of reload indicator
 };
 
 // ── Game State Contract ─────────────────────────────────────────────────────
@@ -124,7 +127,7 @@ struct HudDamageNumber
 /// @brief Current damage accumulator state for the local player.
 struct HudDamageAccum
 {
-    int total = 0;                      ///< Accumulated damage to current target.
+    int total = 0;                                        ///< Accumulated damage to current target.
     HudColor color{0.168627f, 0.694118f, 0.741176f, 1.f}; ///< Color matching the latest hit type.
 };
 
@@ -266,6 +269,8 @@ struct HudGameState
     float roundTimeRemaining = 0.f;
     bool isAlive = true;
     bool isBuyPhase = false;
+    bool isReloading = false;
+    float reloadProgress = 0.0f; ///< 0-1
 
     // Events (valid for this frame only).
     std::span<const HudKillFeedEntry> killFeedEvents;

--- a/src/client/hud/widgets/CrosshairWidget.cpp
+++ b/src/client/hud/widgets/CrosshairWidget.cpp
@@ -6,6 +6,8 @@
 #include "hud/HudContext.hpp"
 #include "hud/VoidfallStyle.hpp"
 
+#include <numbers>
+
 CrosshairWidget::CrosshairWidget()
 {
     anchor = HudAnchor::Center;
@@ -20,11 +22,17 @@ CrosshairWidget::CrosshairWidget()
     style.thickness = 2.0f;
     style.color = voidfall::k_primary;
     style.dot = true;
+    style.reloadRadius = 20.f;
+    style.reloadThickness = 2.f;
+    style.reloadColor = voidfall::k_secondary;
 }
 
 void CrosshairWidget::update(float /*dt*/, const HudGameState& state, HudTweenPool& /*tweens*/)
 {
     visible = state.isAlive;
+
+    isReloading = state.isReloading;
+    reloadProgress = state.reloadProgress;
 }
 
 void CrosshairWidget::draw(HudContext& ctx, float cx, float cy)
@@ -46,5 +54,26 @@ void CrosshairWidget::draw(HudContext& ctx, float cx, float cy)
     if (style.dot) {
         const float dotSize = 1.5f * s;
         ctx.rect(cx - dotSize * 0.5f, cy - dotSize * 0.5f, dotSize, dotSize, style.color);
+    }
+
+    // Reload visualiser
+    if (isReloading) {
+        constexpr int kMaxSegments = 64;
+
+        const float r = style.reloadRadius * s;
+        const float t = style.reloadThickness * s;
+        const float progress = std::clamp(reloadProgress, 0.0f, 1.0f);
+
+        if (progress > 0.0f) {
+            const int segments = std::max(2, static_cast<int>(kMaxSegments * progress));
+            float points[(kMaxSegments + 1) * 2];
+            for (int i = 0; i <= segments; ++i) {
+                const float frac = (static_cast<float>(i) / static_cast<float>(segments)) * progress;
+                const float angle = -0.5f * std::numbers::pi_v<float> + frac * 2.0f * std::numbers::pi_v<float>;
+                points[i * 2] = cx + r * std::cos(angle);
+                points[i * 2 + 1] = cy + r * std::sin(angle);
+            }
+            ctx.polyline(points, segments + 1, t, style.reloadColor);
+        }
     }
 }

--- a/src/client/hud/widgets/CrosshairWidget.hpp
+++ b/src/client/hud/widgets/CrosshairWidget.hpp
@@ -12,4 +12,7 @@ struct CrosshairWidget : HudWidget
     CrosshairWidget();
     void update(float dt, const HudGameState& state, HudTweenPool& tweens) override;
     void draw(HudContext& ctx, float drawX, float drawY) override;
+
+    bool isReloading = false;
+    float reloadProgress = 0.f;
 };

--- a/src/ecs/components/WeaponConfig.hpp
+++ b/src/ecs/components/WeaponConfig.hpp
@@ -25,6 +25,7 @@ struct WeaponConfig
     float ammoPerSecond = 0.0f; ///< Ammo drain rate (beam weapons only).
     float chargeDamage = 0.0f;  ///< Damage dealt on release (charge weapons only).
     float maxChargeTime = 0.0f; ///< in seconds
+    float reloadTime = 0.0f;    ///< Time to complete a reload, in seconds.
 };
 
 struct ProjectileConfig
@@ -63,6 +64,7 @@ inline const WeaponConfig& getWeaponConfig(WeaponType type)
             .hitscan = true,
             .initialProjectileSpeed = 0.0f,
             .explosive = false,
+            .reloadTime = 1.25f,
         }, // Rifle
         WeaponConfig{
             .fireCooldown = 1.0f,
@@ -72,6 +74,7 @@ inline const WeaponConfig& getWeaponConfig(WeaponType type)
             .hitscan = false,
             .initialProjectileSpeed = 3000.0f,
             .explosive = true,
+            .reloadTime = 2.5f,
         }, // Rocket
         WeaponConfig{
             .fireCooldown = 0.5f,
@@ -84,6 +87,7 @@ inline const WeaponConfig& getWeaponConfig(WeaponType type)
             .isCharge = true,
             .chargeDamage = 80.0f,
             .maxChargeTime = 1.0f,
+            .reloadTime = 2.0f,
         }, // RailGun
         WeaponConfig{
             .fireCooldown = 0.0f,
@@ -96,6 +100,7 @@ inline const WeaponConfig& getWeaponConfig(WeaponType type)
             .isBeam = true,
             .dps = 80.0f,
             .ammoPerSecond = 20.0f,
+            .reloadTime = 0.0f,
         }, // EnergyGun
         WeaponConfig{
             .fireCooldown = 0.4f,

--- a/src/ecs/components/WeaponState.hpp
+++ b/src/ecs/components/WeaponState.hpp
@@ -38,7 +38,9 @@ struct GunInstance
     int totalAmmo = 0;
     int currentMagAmmo = 0;
     float fireCooldown = 0.f;
-    float chargeTime = 0.f; ///< Accumulated charge time (charge weapons only).
+    float chargeTime = 0.f;   ///< Accumulated charge time (charge weapons only).
+    bool isReloading = false; ///< True while reload is in progress
+    float reloadTime = 0.f;   ///< Time remaining to complete a reload
 };
 
 /// @brief Component attached to armed entities (players).

--- a/src/ecs/systems/DroppedWeaponSystem.cpp
+++ b/src/ecs/systems/DroppedWeaponSystem.cpp
@@ -43,13 +43,11 @@ inline bool tryPickup(Registry& registry, Position dropPos, CollisionShape dropS
             GunInstance& secondary = getSlot(weapon, WeaponSlot::SECONDARY);
             if (primary.type == dw.type) {
                 primary.totalAmmo = dw.totalAmmo;
-                primary.currentMagAmmo = dw.currentMagAmmo;
                 consumed = true;
                 return;
             }
             if (secondary.type == dw.type) {
                 secondary.totalAmmo = dw.totalAmmo;
-                secondary.currentMagAmmo = dw.currentMagAmmo;
                 consumed = true;
                 return;
             }

--- a/src/ecs/systems/WeaponSpawnerSystem.cpp
+++ b/src/ecs/systems/WeaponSpawnerSystem.cpp
@@ -40,12 +40,10 @@ checkForPlayers(Registry& registry, Position spawnerPos, CollisionShape spawnerS
             GunInstance& secondary = getSlot(weapon, WeaponSlot::SECONDARY);
             if (primary.type == spawner.type) {
                 primary.totalAmmo = config.defaultAmmoCapacity;
-                primary.currentMagAmmo = config.magazineSize;
                 spawner.hasWeapon = false;
                 spawner.spawnCooldown = weaponCooldownTime;
             } else if (secondary.type == spawner.type) {
                 secondary.totalAmmo = config.defaultAmmoCapacity;
-                secondary.currentMagAmmo = config.magazineSize;
                 spawner.hasWeapon = false;
                 spawner.spawnCooldown = weaponCooldownTime;
             }

--- a/src/ecs/systems/WeaponSystem.cpp
+++ b/src/ecs/systems/WeaponSystem.cpp
@@ -67,9 +67,15 @@ inline bool combatLogEnabled()
 /// @param weapon  Weapon state (modified in place).
 void handleSwitch(const InputSnapshot& input, WeaponState& weapon)
 {
-    if (input.switchToPrimary) {
+    if (input.switchToPrimary && weapon.current != WeaponSlot::PRIMARY) {
+        auto& gun = getEquippedGun(weapon);
+        gun.isReloading = false;
+        gun.reloadTime = 0.0f;
         weapon.current = WeaponSlot::PRIMARY;
-    } else if (input.switchToSecondary) {
+    } else if (input.switchToSecondary && weapon.current != WeaponSlot::SECONDARY) {
+        auto& gun = getEquippedGun(weapon);
+        gun.isReloading = false;
+        gun.reloadTime = 0.0f;
         weapon.current = WeaponSlot::SECONDARY;
     }
 }
@@ -79,10 +85,25 @@ void handleSwitch(const InputSnapshot& input, WeaponState& weapon)
 /// @param dt      Fixed physics delta time in seconds.
 inline void handleCooldown(WeaponState& weapon, float dt)
 {
-    auto reduce = [dt](GunInstance& gun) { gun.fireCooldown = std::max(0.0f, gun.fireCooldown - dt); };
-
     for (auto& gun : weapon.slots) {
-        reduce(gun);
+        gun.fireCooldown = std::max(0.0f, gun.fireCooldown - dt);
+
+        if (gun.isReloading) {
+            gun.reloadTime -= dt;
+            if (gun.reloadTime <= 0.0f) {
+                const WeaponConfig& config = getWeaponConfig(gun.type);
+                int reloadAmount = config.magazineSize - gun.currentMagAmmo;
+                if (gun.totalAmmo >= reloadAmount) {
+                    gun.currentMagAmmo += reloadAmount;
+                    gun.totalAmmo -= reloadAmount;
+                } else {
+                    gun.currentMagAmmo += gun.totalAmmo;
+                    gun.totalAmmo = 0;
+                }
+                gun.isReloading = false;
+                gun.reloadTime = 0.0f;
+            }
+        }
     }
 }
 
@@ -96,15 +117,9 @@ inline void handleGrenadeCooldown(GrenadeState& grenades, float dt)
 inline void handleReload(GunInstance& gun)
 {
     const WeaponConfig& config = getWeaponConfig(gun.type);
-    if (gun.totalAmmo > 0 && gun.currentMagAmmo < config.magazineSize) {
-        int reloadAmount = config.magazineSize - gun.currentMagAmmo;
-        if ((gun.totalAmmo - reloadAmount) >= 0) {
-            gun.currentMagAmmo += reloadAmount;
-            gun.totalAmmo -= reloadAmount;
-        } else {
-            gun.currentMagAmmo += gun.totalAmmo;
-            gun.totalAmmo = 0;
-        }
+    if (!gun.isReloading && gun.totalAmmo > 0 && gun.currentMagAmmo < config.magazineSize) {
+        gun.isReloading = true;
+        gun.reloadTime = config.reloadTime;
     }
 }
 
@@ -114,7 +129,6 @@ inline void handleReload(GunInstance& gun)
 inline bool handleAmmo(GunInstance& gun)
 {
     if (gun.currentMagAmmo <= 0) {
-        // TODO: Need to implement reload state so it is not instant.
         handleReload(gun);
         return false;
     }
@@ -487,6 +501,11 @@ handleScope(Registry& registry, entt::entity shooter, const InputSnapshot& input
         return;
     }
 
+    if (gun.isReloading) {
+        gun.chargeTime = 0; // lose change if you reload
+        return;
+    }
+
     if (input.scoped) {
         gun.chargeTime = std::min((gun.chargeTime + dt), config.maxChargeTime);
     } else {
@@ -534,6 +553,13 @@ inline void handleFire(Registry& registry,
 {
     GunInstance& gun = getEquippedGun(weapon);
     const WeaponConfig& config = getWeaponConfig(gun.type);
+
+    if (gun.isReloading) {
+        if (auto* beam = registry.try_get<BeamState>(shooter)) {
+            beam->active = false; // turn off beam visuals during reload
+        }
+        return;
+    }
 
     // ── Beam weapon path ──
     if (config.isBeam) {


### PR DESCRIPTION
- configurable reload time in weapon config
- reload gets canceled if you swap weapons
- animate the weapon model down while reloading, reload done exactly when it reaches original position
- block server and client side actions while gun.isReloading
- HUD element around crosshair to indicate reload time
