### PR TITLE
Fix CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .deps/${{ matrix.preset }}
-          key: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-${{ hashFiles('CMakeLists.txt') }}
+          key: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-${{ hashFiles('cmake/dependencies.json') }}
 
       # Cache the project build tree for incremental CMake reconfigure.
       # CMakeCache.txt + CMakeFiles hold cached probe results; Ninja tracks
@@ -357,7 +357,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .deps/${{ matrix.preset }}
-          key: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-${{ hashFiles('CMakeLists.txt') }}
+          key: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-${{ hashFiles('cmake/dependencies.json') }}
 
       # Cache the project build tree for incremental CMake reconfigure.
       # CMakeCache.txt + CMakeFiles hold cached probe results; Ninja tracks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,12 @@ jobs:
       # try_compile results, compiler probes, feature detection).
       # Keeping build dirs lets cmake skip ~68 compile probes on re-runs.
       - name: Cache FetchContent deps
+        id: deps-cache
         uses: actions/cache@v4
         with:
           path: .deps/${{ matrix.preset }}
           key: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-${{ hashFiles('cmake/dependencies.json') }}
+          restore-keys: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-
 
       # Cache the project build tree for incremental CMake reconfigure.
       # CMakeCache.txt + CMakeFiles hold cached probe results; Ninja tracks
@@ -182,7 +184,7 @@ jobs:
           cmake --preset ${{ matrix.preset }} \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-            -DFETCHCONTENT_UPDATES_DISCONNECTED=ON \
+            -DFETCHCONTENT_UPDATES_DISCONNECTED=${{ steps.deps-cache.outputs.cache-hit == 'true' && 'ON' || 'OFF' }} \
             ${{ matrix.extra_cmake || '' }}
 
       - name: Build
@@ -354,10 +356,12 @@ jobs:
       # Cache dep sources AND their build dirs (CMakeCache.txt holds
       # try_compile results, compiler probes, feature detection).
       - name: Cache FetchContent deps
+        id: deps-cache
         uses: actions/cache@v4
         with:
           path: .deps/${{ matrix.preset }}
           key: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-${{ hashFiles('cmake/dependencies.json') }}
+          restore-keys: deps-v4-${{ runner.os }}-${{ matrix.preset }}-${{ matrix.cc }}-
 
       # Cache the project build tree for incremental CMake reconfigure.
       # CMakeCache.txt + CMakeFiles hold cached probe results; Ninja tracks
@@ -427,7 +431,7 @@ jobs:
           cmake --preset ${{ matrix.preset }} \
             -DCMAKE_C_COMPILER_LAUNCHER=sccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-            -DFETCHCONTENT_UPDATES_DISCONNECTED=ON \
+            -DFETCHCONTENT_UPDATES_DISCONNECTED=${{ steps.deps-cache.outputs.cache-hit == 'true' && 'ON' || 'OFF' }} \
             ${{ matrix.extra_cmake || '' }}
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,48 @@ endif()
 
 # ---- Dependencies ----
 
+set(GROUP2_DEPENDENCIES_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.json")
+file(READ "${GROUP2_DEPENDENCIES_FILE}" GROUP2_DEPENDENCIES_JSON)
+
+function(group2_dependency_git name out_repository out_tag)
+    string(JSON _repository ERROR_VARIABLE _repository_error
+           GET "${GROUP2_DEPENDENCIES_JSON}" "${name}" repository)
+    if(_repository_error)
+        message(FATAL_ERROR
+            "Missing repository for dependency '${name}' in ${GROUP2_DEPENDENCIES_FILE}: "
+            "${_repository_error}")
+    endif()
+
+    string(JSON _tag ERROR_VARIABLE _tag_error
+           GET "${GROUP2_DEPENDENCIES_JSON}" "${name}" tag)
+    if(_tag_error)
+        message(FATAL_ERROR
+            "Missing tag for dependency '${name}' in ${GROUP2_DEPENDENCIES_FILE}: "
+            "${_tag_error}")
+    endif()
+
+    set(${out_repository} "${_repository}" PARENT_SCOPE)
+    set(${out_tag} "${_tag}" PARENT_SCOPE)
+endfunction()
+
+function(group2_dependency_url name out_url)
+    string(JSON _url ERROR_VARIABLE _url_error
+           GET "${GROUP2_DEPENDENCIES_JSON}" "${name}" url)
+    if(_url_error)
+        message(FATAL_ERROR
+            "Missing URL for dependency '${name}' in ${GROUP2_DEPENDENCIES_FILE}: "
+            "${_url_error}")
+    endif()
+
+    set(${out_url} "${_url}" PARENT_SCOPE)
+endfunction()
+
 # SDL3 — window, input, GPU pipeline (Vulkan/Metal/DX12) + OpenGL context
+group2_dependency_git(SDL3 SDL3_REPOSITORY SDL3_TAG)
 FetchContent_Declare(
     SDL3
-    GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-    GIT_TAG        release-3.4.4
+    GIT_REPOSITORY "${SDL3_REPOSITORY}"
+    GIT_TAG        "${SDL3_TAG}"
     GIT_SHALLOW    TRUE
 )
 # Build SDL3 as a static library so no DLL shipping is needed at runtime.
@@ -102,11 +139,11 @@ FetchContent_MakeAvailable(SDL3)
 # SDL3_net — networking library for SDL3
 block()
     set(BUILD_SHARED_LIBS OFF)
+    group2_dependency_git(SDL3_net SDL3_NET_REPOSITORY SDL3_NET_TAG)
     FetchContent_Declare(
         SDL3_net
-        GIT_REPOSITORY https://github.com/cedricdvd/SDL_net.git
-        GIT_TAG        55c01afab84f3d30823e8868844f071b26d0c6ad
-        GIT_SHALLOW    TRUE
+        GIT_REPOSITORY "${SDL3_NET_REPOSITORY}"
+        GIT_TAG        "${SDL3_NET_TAG}"
     )
     FetchContent_MakeAvailable(SDL3_net)
 endblock()
@@ -144,10 +181,11 @@ if(SHADERCROSS_PLATFORM_NEEDS_TRANSPILE)
         set(SPIRV_CROSS_ENABLE_CPP          OFF CACHE BOOL "" FORCE)
         set(SPIRV_CROSS_ENABLE_UTIL         ON  CACHE BOOL "" FORCE)
         set(SPIRV_CROSS_SKIP_INSTALL        ON  CACHE BOOL "" FORCE)
+        group2_dependency_git(SPIRV-Cross SPIRV_CROSS_REPOSITORY SPIRV_CROSS_TAG)
         FetchContent_Declare(
             SPIRV-Cross
-            GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Cross.git
-            GIT_TAG        vulkan-sdk-1.4.309.0
+            GIT_REPOSITORY "${SPIRV_CROSS_REPOSITORY}"
+            GIT_TAG        "${SPIRV_CROSS_TAG}"
             GIT_SHALLOW    TRUE
         )
         FetchContent_MakeAvailable(SPIRV-Cross)
@@ -184,9 +222,10 @@ if(SHADERCROSS_PLATFORM_NEEDS_TRANSPILE)
     # can find dxcompiler.dll/.lib/dxcapi.h without building LLVM ourselves.
     # On other platforms we disable DXC entirely (we only need MSL on macOS).
     if(WIN32)
+        group2_dependency_url(dxc_binaries DXC_BINARIES_URL)
         FetchContent_Declare(
             dxc_binaries
-            URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip
+            URL "${DXC_BINARIES_URL}"
             DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         )
         FetchContent_MakeAvailable(dxc_binaries)
@@ -215,10 +254,11 @@ if(SHADERCROSS_PLATFORM_NEEDS_TRANSPILE)
         set(SDLSHADERCROSS_INSTALL          OFF CACHE BOOL "" FORCE)
         set(SDLSHADERCROSS_TESTS            OFF CACHE BOOL "" FORCE)
         set(SDLSHADERCROSS_WERROR           OFF CACHE BOOL "" FORCE)
+        group2_dependency_git(SDL_shadercross SDL_SHADERCROSS_REPOSITORY SDL_SHADERCROSS_TAG)
         FetchContent_Declare(
             SDL_shadercross
-            GIT_REPOSITORY https://github.com/libsdl-org/SDL_shadercross.git
-            GIT_TAG        main
+            GIT_REPOSITORY "${SDL_SHADERCROSS_REPOSITORY}"
+            GIT_TAG        "${SDL_SHADERCROSS_TAG}"
             GIT_SHALLOW    TRUE
         )
         FetchContent_MakeAvailable(SDL_shadercross)
@@ -244,29 +284,32 @@ block()
     set(ENABLE_SPVREMAPPER        OFF CACHE BOOL "" FORCE)
     set(ENABLE_CTEST              OFF CACHE BOOL "" FORCE)
     set(SKIP_GLSLANG_INSTALL      ON  CACHE BOOL "" FORCE)
+    group2_dependency_git(glslang GLSLANG_REPOSITORY GLSLANG_TAG)
     FetchContent_Declare(
         glslang
-        GIT_REPOSITORY https://github.com/KhronosGroup/glslang.git
-        GIT_TAG        vulkan-sdk-1.4.309.0
+        GIT_REPOSITORY "${GLSLANG_REPOSITORY}"
+        GIT_TAG        "${GLSLANG_TAG}"
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(glslang)
 endblock()
 
 # GLM — header-only math library (vectors, matrices, quaternions)
+group2_dependency_git(glm GLM_REPOSITORY GLM_TAG)
 FetchContent_Declare(
     glm
-    GIT_REPOSITORY https://github.com/g-truc/glm.git
-    GIT_TAG        1.0.1
+    GIT_REPOSITORY "${GLM_REPOSITORY}"
+    GIT_TAG        "${GLM_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(glm)
 
 # EnTT — fast header-only ECS library
+group2_dependency_git(EnTT ENTT_REPOSITORY ENTT_TAG)
 FetchContent_Declare(
     EnTT
-    GIT_REPOSITORY https://github.com/skypjack/entt.git
-    GIT_TAG        v3.14.0
+    GIT_REPOSITORY "${ENTT_REPOSITORY}"
+    GIT_TAG        "${ENTT_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(EnTT)
@@ -280,10 +323,11 @@ if(TARGET EnTT)
 endif()
 
 # toml++ - TOML parsing library
+group2_dependency_git(tomlplusplus TOMLPLUSPLUS_REPOSITORY TOMLPLUSPLUS_TAG)
 FetchContent_Declare(
     tomlplusplus
-    GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
-    GIT_TAG        v3.4.0
+    GIT_REPOSITORY "${TOMLPLUSPLUS_REPOSITORY}"
+    GIT_TAG        "${TOMLPLUSPLUS_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(tomlplusplus)
@@ -308,10 +352,11 @@ set(ASSIMP_BUILD_MINIZIP                 ON  CACHE BOOL "" FORCE)
 set(ASSIMP_WARNINGS_AS_ERRORS            OFF CACHE BOOL "" FORCE)
 block()
     set(BUILD_SHARED_LIBS OFF)
+    group2_dependency_git(assimp ASSIMP_REPOSITORY ASSIMP_TAG)
     FetchContent_Declare(
         assimp
-        GIT_REPOSITORY https://github.com/assimp/assimp.git
-        GIT_TAG        v5.4.3
+        GIT_REPOSITORY "${ASSIMP_REPOSITORY}"
+        GIT_TAG        "${ASSIMP_TAG}"
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(assimp)
@@ -321,10 +366,11 @@ endblock()
 # PNG/JPEG textures embedded in GLB files).  stb ships no CMakeLists.txt, so
 # FetchContent just populates the source directory; we expose it as a simple
 # INTERFACE library so callers get -isystem suppression.
+group2_dependency_git(stb STB_REPOSITORY STB_TAG)
 FetchContent_Declare(
     stb
-    GIT_REPOSITORY https://github.com/nothings/stb.git
-    GIT_TAG        master
+    GIT_REPOSITORY "${STB_REPOSITORY}"
+    GIT_TAG        "${STB_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(stb)
@@ -333,10 +379,11 @@ target_include_directories(stb_image SYSTEM INTERFACE ${stb_SOURCE_DIR})
 
 # minimp3 — single-header MP3 decoder (used by SfxSystem to load MP3 sound assets).
 # Same FetchContent+INTERFACE pattern as stb above.
+group2_dependency_git(minimp3 MINIMP3_REPOSITORY MINIMP3_TAG)
 FetchContent_Declare(
     minimp3
-    GIT_REPOSITORY https://github.com/lieff/minimp3.git
-    GIT_TAG        master
+    GIT_REPOSITORY "${MINIMP3_REPOSITORY}"
+    GIT_TAG        "${MINIMP3_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(minimp3)
@@ -361,10 +408,11 @@ if(WIN32)
     set(OPUS_X86_PRESUME_SSE4_1 OFF CACHE BOOL "" FORCE)
     set(OPUS_X86_PRESUME_AVX2 OFF CACHE BOOL "" FORCE)
 endif()
+group2_dependency_git(opus OPUS_REPOSITORY OPUS_TAG)
 FetchContent_Declare(
     opus
-    GIT_REPOSITORY https://github.com/xiph/opus.git
-    GIT_TAG        v1.5.2
+    GIT_REPOSITORY "${OPUS_REPOSITORY}"
+    GIT_TAG        "${OPUS_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(opus)
@@ -374,10 +422,11 @@ if(GROUP2_ENABLE_VHACD)
     # V-HACD — legacy opt-in convex decomposition for prototype props.
     # Production map collision is authored as simplified triangle meshes, so
     # default builds do not fetch or compile V-HACD.
+    group2_dependency_git(vhacd_src VHACD_REPOSITORY VHACD_TAG)
     FetchContent_Declare(
         vhacd_src
-        GIT_REPOSITORY https://github.com/kmammou/v-hacd.git
-        GIT_TAG        v4.1.0
+        GIT_REPOSITORY "${VHACD_REPOSITORY}"
+        GIT_TAG        "${VHACD_TAG}"
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(vhacd_src)
@@ -397,10 +446,11 @@ set(ozz_build_data      OFF CACHE BOOL "" FORCE)
 set(ozz_build_msvc_rt_dll ON CACHE BOOL "" FORCE)
 block()
     set(BUILD_SHARED_LIBS OFF)
+    group2_dependency_git(ozz-animation OZZ_ANIMATION_REPOSITORY OZZ_ANIMATION_TAG)
     FetchContent_Declare(
         ozz-animation
-        GIT_REPOSITORY https://github.com/guillaumeblanc/ozz-animation.git
-        GIT_TAG        0.15.0
+        GIT_REPOSITORY "${OZZ_ANIMATION_REPOSITORY}"
+        GIT_TAG        "${OZZ_ANIMATION_TAG}"
         GIT_SHALLOW    TRUE
     )
     FetchContent_MakeAvailable(ozz-animation)
@@ -435,10 +485,11 @@ endforeach()
 # ImGui ships no CMakeLists.txt, so FetchContent_MakeAvailable just downloads
 # the source tree without calling add_subdirectory. We compile it ourselves
 # as imgui_lib below.
+group2_dependency_git(imgui IMGUI_REPOSITORY IMGUI_TAG)
 FetchContent_Declare(
     imgui
-    GIT_REPOSITORY https://github.com/ocornut/imgui.git
-    GIT_TAG        v1.92.0
+    GIT_REPOSITORY "${IMGUI_REPOSITORY}"
+    GIT_TAG        "${IMGUI_TAG}"
     GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(imgui)
@@ -464,11 +515,12 @@ target_compile_options(imgui_lib PRIVATE
 )
 
 # argparse -- header-only command-line argument parser used by the server.
+group2_dependency_git(argparse ARGPARSE_REPOSITORY ARGPARSE_TAG)
 FetchContent_Declare(
     argparse
-    GIT_REPOSITORY https://github.com/p-ranav/argparse.git
-    GIT_TAG v3.2
-    GIT_SHALLOW TRUE
+    GIT_REPOSITORY "${ARGPARSE_REPOSITORY}"
+    GIT_TAG        "${ARGPARSE_TAG}"
+    GIT_SHALLOW    TRUE
 )
 FetchContent_MakeAvailable(argparse)
 

--- a/cmake/dependencies.json
+++ b/cmake/dependencies.json
@@ -1,0 +1,69 @@
+{
+  "SDL3": {
+    "repository": "https://github.com/libsdl-org/SDL.git",
+    "tag": "release-3.4.4"
+  },
+  "SDL3_net": {
+    "repository": "https://github.com/cedricdvd/SDL_net.git",
+    "tag": "55c01afab84f3d30823e8868844f071b26d0c6ad"
+  },
+  "SPIRV-Cross": {
+    "repository": "https://github.com/KhronosGroup/SPIRV-Cross.git",
+    "tag": "vulkan-sdk-1.4.309.0"
+  },
+  "dxc_binaries": {
+    "url": "https://github.com/microsoft/DirectXShaderCompiler/releases/download/v1.8.2407/dxc_2024_07_31.zip"
+  },
+  "SDL_shadercross": {
+    "repository": "https://github.com/libsdl-org/SDL_shadercross.git",
+    "tag": "main"
+  },
+  "glslang": {
+    "repository": "https://github.com/KhronosGroup/glslang.git",
+    "tag": "vulkan-sdk-1.4.309.0"
+  },
+  "glm": {
+    "repository": "https://github.com/g-truc/glm.git",
+    "tag": "1.0.1"
+  },
+  "EnTT": {
+    "repository": "https://github.com/skypjack/entt.git",
+    "tag": "v3.14.0"
+  },
+  "tomlplusplus": {
+    "repository": "https://github.com/marzer/tomlplusplus.git",
+    "tag": "v3.4.0"
+  },
+  "assimp": {
+    "repository": "https://github.com/assimp/assimp.git",
+    "tag": "v5.4.3"
+  },
+  "stb": {
+    "repository": "https://github.com/nothings/stb.git",
+    "tag": "master"
+  },
+  "minimp3": {
+    "repository": "https://github.com/lieff/minimp3.git",
+    "tag": "master"
+  },
+  "opus": {
+    "repository": "https://github.com/xiph/opus.git",
+    "tag": "v1.5.2"
+  },
+  "vhacd_src": {
+    "repository": "https://github.com/kmammou/v-hacd.git",
+    "tag": "v4.1.0"
+  },
+  "ozz-animation": {
+    "repository": "https://github.com/guillaumeblanc/ozz-animation.git",
+    "tag": "0.15.0"
+  },
+  "imgui": {
+    "repository": "https://github.com/ocornut/imgui.git",
+    "tag": "v1.92.0"
+  },
+  "argparse": {
+    "repository": "https://github.com/p-ranav/argparse.git",
+    "tag": "v3.2"
+  }
+}


### PR DESCRIPTION
Narrowed the scope of caching to a dependency file. Also helps fix the issue where our fork of SDL_net may update its version, causing `.deps` to be stale.